### PR TITLE
fix(text_input): selection rendering was not clipped to input field

### DIFF
--- a/src/elements/text_input.zig
+++ b/src/elements/text_input.zig
@@ -793,7 +793,7 @@ pub const TextInput = struct {
             text_height,
             self.style.selection_color,
         );
-        try scene.insertQuad(selection_quad);
+        try scene.insertQuadClipped(selection_quad);
     }
 
     /// Ensure cursor is visible by adjusting scroll offset.


### PR DESCRIPTION
Fixes a bug where if the text was to long in an input field the selection rendering was visible for text that wasn't visible.