### PR TITLE
fix(linux) overlapping content

### DIFF
--- a/src/examples/linux_text_demo.zig
+++ b/src/examples/linux_text_demo.zig
@@ -86,13 +86,17 @@ fn render(cx: *Cx) void {
     const s = cx.state(AppState);
     const size = cx.windowSize();
 
-    cx.box(.{
+    cx.scroll("main_scroll", .{
         .width = size.width,
         .height = size.height,
+        .vertical = true,
+        .horizontal = false,
         .padding = .{ .all = 24 },
         .gap = 20,
-        .direction = .column,
         .background = ui.Color.rgb(0.12, 0.12, 0.14),
+        .scrollbar_size = 8,
+        .track_color = ui.Color.rgb(0.18, 0.18, 0.2),
+        .thumb_color = ui.Color.rgb(0.3, 0.3, 0.35),
     }, .{
         // Title
         ui.text("Linux Text Rendering Demo", .{


### PR DESCRIPTION
in `linux_text_example`. Wrapping it into a `scroll` container fixed it.

## Before

<img width="800" height="800" alt="run-text-issue" src="https://github.com/user-attachments/assets/e2186d7a-42bb-4cf0-af7a-267f8d570e25" />


## Fix


<img width="800" height="800" alt="run-text-fixed" src="https://github.com/user-attachments/assets/b8648633-7c8f-43d7-8631-6de26d039598" />

