### PR TITLE
fix(scrollbar) scroll direction

### DIFF
--- a/src/widgets/scroll_container.zig
+++ b/src/widgets/scroll_container.zig
@@ -11,6 +11,7 @@
 //! scrolling when content exceeds the viewport size.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const scene_mod = @import("../scene/mod.zig");
 const layout_types = @import("../layout/types.zig");
 
@@ -97,8 +98,11 @@ pub const ScrollState = struct {
 
     /// Scroll by delta (e.g., from scroll wheel)
     pub fn scrollBy(self: *Self, delta_x: f32, delta_y: f32) void {
-        self.offset_x = std.math.clamp(self.offset_x - delta_x, 0, self.maxScrollX());
-        self.offset_y = std.math.clamp(self.offset_y - delta_y, 0, self.maxScrollY());
+        // macOS uses "natural scrolling" (scroll up = content moves down)
+        // Linux/Windows use traditional scrolling (scroll up = content moves up)
+        const direction: f32 = if (builtin.os.tag == .macos) -1.0 else 1.0;
+        self.offset_x = std.math.clamp(self.offset_x + delta_x * direction, 0, self.maxScrollX());
+        self.offset_y = std.math.clamp(self.offset_y + delta_y * direction, 0, self.maxScrollY());
     }
 
     /// Scroll to absolute position


### PR DESCRIPTION
Current scroll behavior by using scroll wheel feels something wrong to me - at least as a Linux user. I would expect:
- Scroll wheel **up** → content scrolls **up** (traditional behavior)
- Scroll wheel **down** → content scrolls **down**

`macOS` users might disagree here (I know). With this PR I suggest a platform-specific scroll direction. Open for discussion of course.