### PR TITLE
bench: gate on best-of-N min (+ shared Sampler, CI on integration)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,15 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    # Build baseline benchmark artifacts on main and on the long-lived
+    # integration branches so the PR bench-gate has a same-lineage baseline
+    # to download.
+    branches: [main, "integration/**"]
   pull_request:
-    branches: [main]
+    # Run the full pipeline (bench-gate included) for PRs targeting main or an
+    # integration branch.  Without the integration entry, PRs onto
+    # integration/* would not trigger CI at all.
+    branches: [main, "integration/**"]
   workflow_dispatch: {}
 
 # Cancel in-progress runs for the same branch (except main)

--- a/build.zig
+++ b/build.zig
@@ -53,6 +53,15 @@ pub fn build(b: *std.Build) void {
     });
     const run_compare_tests = b.addRunArtifact(compare_tests);
 
+    // Unit tests for the JSON writer + shared timing Sampler (the bench
+    // module root). Wired into each branch's `test` step below so the
+    // harness-facing schema and min/best-of-N accumulator are exercised in
+    // CI without needing a macOS-only benchmark executable to run.
+    const bench_tests = b.addTest(.{
+        .root_module = bench_mod,
+    });
+    const run_bench_tests = b.addRunArtifact(bench_tests);
+
     // Platform detection
     const is_native_macos = target.result.os.tag == .macos;
     const is_native_linux = target.result.os.tag == .linux;
@@ -192,6 +201,7 @@ pub fn build(b: *std.Build) void {
         test_step.dependOn(&run_exe_tests.step);
         test_step.dependOn(&run_charts_tests.step);
         test_step.dependOn(&run_compare_tests.step);
+        test_step.dependOn(&run_bench_tests.step);
 
         // =====================================================================
         // Layout Fuzz Targets (PR 10)
@@ -630,6 +640,7 @@ pub fn build(b: *std.Build) void {
         const test_step = b.step("test", "Run tests");
         test_step.dependOn(&run_mod_tests.step);
         test_step.dependOn(&run_compare_tests.step);
+        test_step.dependOn(&run_bench_tests.step);
 
         // =====================================================================
         // Valgrind Memory Leak Detection

--- a/src/bench/compare.zig
+++ b/src/bench/compare.zig
@@ -56,6 +56,14 @@ const DEFAULT_THRESHOLD_PERCENT: f64 = 15.0;
 /// no amount of jitter explains.
 const MIN_NS_FOR_THRESHOLD: f64 = 10.0;
 
+/// Multiple by which a sub-floor benchmark must grow before it counts as
+/// a real regression rather than `.noisy`.  Near the floor, jitter alone
+/// routinely doubles a measurement, so a fixed absolute delta produces
+/// false positives (observed 9.49 -> 19.84 ns/op = +109% on byte-identical
+/// code).  Requiring a 4x jump that also clears the floor isolates genuine
+/// order-of-magnitude blowups (e.g. 2 -> 50 ns/op) from sub-floor noise.
+const CATASTROPHIC_JUMP_MULTIPLIER: f64 = 4.0;
+
 /// p99 tail latency is only gated at or above this baseline, in ns/op.
 ///
 /// At nanosecond scale the p99 reflects OS scheduling preemptions, not
@@ -574,9 +582,16 @@ fn classifyAvgStatus(baseline_ns: f64, current_ns: f64, base_threshold: f64) Com
     std.debug.assert(base_threshold > 0.0);
 
     if (baseline_ns < MIN_NS_FOR_THRESHOLD) {
-        // Too fast to gate by percentage.  Only a large absolute jump
-        // (>= one floor's worth of ns) survives as a real regression.
-        if ((current_ns - baseline_ns) >= MIN_NS_FOR_THRESHOLD) return .regression;
+        // Too fast to gate by percentage.  Only an order-of-magnitude
+        // blowup survives as a real regression: the current value must
+        // both clear the floor AND be at least CATASTROPHIC_JUMP_MULTIPLIER
+        // times the baseline.  A fixed absolute delta is wrong here — near
+        // the floor, noise alone doubles a benchmark (9.49 -> 19.84 ns is
+        // a +10 ns jump that is pure jitter, not a regression), whereas a
+        // genuine blowup (2 -> 50 ns) clears a 4x multiple with room.
+        const catastrophic = current_ns >= MIN_NS_FOR_THRESHOLD and
+            current_ns >= baseline_ns * CATASTROPHIC_JUMP_MULTIPLIER;
+        if (catastrophic) return .regression;
         return .noisy;
     }
 
@@ -1285,6 +1300,25 @@ test "compareReports: sub-floor catastrophic absolute jump still flags" {
 
     std.debug.assert(result.count_regressions == 1);
     std.debug.assert(result.entries[0].status == .regression);
+}
+
+test "compareReports: sub-floor noise-doubling stays noisy, not regression" {
+    var baseline: ParsedReport = .{};
+    var current: ParsedReport = .{};
+
+    // 9.49 -> 19.84 ns/op = +109%, but the baseline is below the 10 ns
+    // floor and the jump is only ~2x. This is jitter near the floor
+    // (the CI false positive on nested_list_20x50), not a 4x blowup.
+    baseline.entries[0] = makeTestEntry("near_floor", 9.49);
+    current.entries[0] = makeTestEntry("near_floor", 19.84);
+
+    baseline.count = 1;
+    current.count = 1;
+
+    const result = compareReports(&baseline, &current, 15.0);
+
+    std.debug.assert(result.count_regressions == 0);
+    std.debug.assert(result.entries[0].status == .noisy);
 }
 
 test "compareReports: scaled threshold absorbs small-bench variance" {

--- a/src/bench/compare.zig
+++ b/src/bench/compare.zig
@@ -131,6 +131,12 @@ const ParsedEntry = struct {
     avg_time_ms: f64 = 0.0,
     time_per_op_ns: f64 = 0.0,
 
+    // Best-of-N estimator. `has_min` is false for baselines written before
+    // the schema carried it, which is exactly when the gate falls back to
+    // classifying on the mean (`time_per_op_ns`).
+    has_min: bool = false,
+    min_per_op_ns: f64 = 0.0,
+
     has_percentiles: bool = false,
     p50_per_op_ns: f64 = 0.0,
     p99_per_op_ns: f64 = 0.0,
@@ -219,6 +225,14 @@ const ComparisonEntry = struct {
     baseline_ns_per_op: f64 = 0.0,
     current_ns_per_op: f64 = 0.0,
     delta_percent: f64 = 0.0,
+
+    /// Whether both entries carry a min, in which case the status is
+    /// classified on the min (best-of-N) rather than the mean. The mean is
+    /// still shown in the main row for human context.
+    gated_on_min: bool = false,
+    baseline_min: f64 = 0.0,
+    current_min: f64 = 0.0,
+    delta_min_percent: f64 = 0.0,
 
     /// Whether both entries have percentile data.
     has_percentiles: bool = false,
@@ -520,6 +534,16 @@ fn extractEntry(obj: std.json.ObjectMap) ParsedEntry {
         e.time_per_op_ns = jsonAsFloat(v) orelse 0.0;
     }
 
+    // Min field: present as float or null (or absent on an older baseline).
+    // A null/absent value leaves `has_min` false so the gate falls back to
+    // the mean for this entry.
+    if (obj.get("min_per_op_ns")) |v| {
+        if (jsonAsFloat(v)) |min_per_op| {
+            e.has_min = true;
+            e.min_per_op_ns = min_per_op;
+        }
+    }
+
     // Percentile fields: present as float or null in the JSON.
     if (obj.get("p50_per_op_ns")) |v| {
         if (jsonAsFloat(v)) |p50| {
@@ -681,6 +705,17 @@ fn populateMatchedComparison(
     comp.current_ns_per_op = current_entry.time_per_op_ns;
     comp.delta_percent = deltaPercent(baseline_entry.time_per_op_ns, current_entry.time_per_op_ns);
 
+    // Min comparison when both sides recorded it. The min (best-of-N) is the
+    // estimator least perturbed by runner noise, so it — not the mean — is
+    // what the central-tendency status gates on when available.
+    const both_have_min = baseline_entry.has_min and current_entry.has_min;
+    if (both_have_min) {
+        comp.gated_on_min = true;
+        comp.baseline_min = baseline_entry.min_per_op_ns;
+        comp.current_min = current_entry.min_per_op_ns;
+        comp.delta_min_percent = deltaPercent(baseline_entry.min_per_op_ns, current_entry.min_per_op_ns);
+    }
+
     // Percentile comparison when both sides have data.
     if (baseline_entry.has_percentiles and current_entry.has_percentiles) {
         comp.has_percentiles = true;
@@ -689,12 +724,17 @@ fn populateMatchedComparison(
         comp.delta_p99_percent = deltaPercent(baseline_entry.p99_per_op_ns, current_entry.p99_per_op_ns);
     }
 
-    // Classify the average dimension first: this honours the absolute
-    // floor (sub-floor entries become `.noisy`) and the magnitude-scaled
-    // threshold for everything above it.
+    // Classify central tendency on the most stable estimator available: the
+    // min (best-of-N) when both sides recorded it, otherwise the mean. This
+    // is the one decision that changed when min landed; the same floor,
+    // magnitude-scaling, and noisy/regression rules apply either way, just to
+    // a far less jittery input. The mean fallback keeps an older baseline
+    // (no min) gating exactly as before.
+    const central_baseline = if (both_have_min) baseline_entry.min_per_op_ns else baseline_entry.time_per_op_ns;
+    const central_current = if (both_have_min) current_entry.min_per_op_ns else current_entry.time_per_op_ns;
     var status = classifyAvgStatus(
-        baseline_entry.time_per_op_ns,
-        current_entry.time_per_op_ns,
+        central_baseline,
+        central_current,
         threshold_percent,
     );
 
@@ -845,10 +885,33 @@ fn printEntryRow(entry: *const ComparisonEntry) void {
         status_str,
     });
 
+    // Sub-line for the min (best-of-N) when both sides recorded it: this is
+    // the estimator the status gates on, so show it explicitly.
+    if (entry.gated_on_min) {
+        printMinLine(entry);
+    }
+
     // Sub-line for p99 tail latency when percentile data exists.
     if (entry.has_percentiles) {
         printPercentileLine(entry);
     }
+}
+
+/// Print a sub-line showing the min (best-of-N) comparison, indented under
+/// the main row and tagged `[gated]` because the status is classified on it
+/// rather than on the mean shown in the headline row.
+fn printMinLine(entry: *const ComparisonEntry) void {
+    std.debug.assert(entry.gated_on_min);
+
+    const sign: []const u8 = if (entry.delta_min_percent >= 0) "+" else "";
+    std.debug.print("  {s:>" ++ widthStr(COLUMN_WIDTH_NAME) ++ "}" ++
+        "  min: {d:.2} -> {d:.2} ns/op ({s}{d:.1}%)  [gated]\n", .{
+        "",
+        entry.baseline_min,
+        entry.current_min,
+        sign,
+        entry.delta_min_percent,
+    });
 }
 
 /// Print a sub-line showing p99 comparison, indented under the main row.
@@ -1218,6 +1281,63 @@ test "compareReports: detects regressions and improvements" {
     std.debug.assert(result.count_removed == 0);
 }
 
+test "compareReports: gates on min, so a noisy mean swing alone is not a regression" {
+    // Both sides recorded a min. The mean jumped +30% (the kind of phantom
+    // swing identical-code reruns produce), but the best-of-N min moved only
+    // +3%. Because the status classifies on the min, the row stays clean —
+    // this is the whole point of the min gate.
+    var baseline: ParsedReport = .{};
+    var current: ParsedReport = .{};
+
+    baseline.entries[0] = makeTestEntryWithMin("noisy_mean", 1000.0, 1000.0);
+    current.entries[0] = makeTestEntryWithMin("noisy_mean", 1300.0, 1030.0);
+    baseline.count = 1;
+    current.count = 1;
+
+    const result = compareReports(&baseline, &current, 15.0);
+
+    std.debug.assert(result.entries[0].gated_on_min);
+    std.debug.assert(result.entries[0].status == .ok);
+    std.debug.assert(result.count_regressions == 0);
+}
+
+test "compareReports: a genuine min regression still flags even when the mean looks flat" {
+    // The mean barely moved (+1%) but the best-of-N min jumped +30%, which is
+    // a real, reproducible slowdown of the central cost — must flag.
+    var baseline: ParsedReport = .{};
+    var current: ParsedReport = .{};
+
+    baseline.entries[0] = makeTestEntryWithMin("min_regressed", 1000.0, 1000.0);
+    current.entries[0] = makeTestEntryWithMin("min_regressed", 1010.0, 1300.0);
+    baseline.count = 1;
+    current.count = 1;
+
+    const result = compareReports(&baseline, &current, 15.0);
+
+    std.debug.assert(result.entries[0].gated_on_min);
+    std.debug.assert(result.entries[0].status == .regression);
+    std.debug.assert(result.count_regressions == 1);
+}
+
+test "compareReports: falls back to mean gating when min is absent (old baseline)" {
+    // Neither entry carries a min (an older baseline schema). The gate must
+    // degrade to the mean-based classification it used before min existed:
+    // a +25% mean jump is still a regression.
+    var baseline: ParsedReport = .{};
+    var current: ParsedReport = .{};
+
+    baseline.entries[0] = makeTestEntry("legacy", 1000.0);
+    current.entries[0] = makeTestEntry("legacy", 1250.0);
+    baseline.count = 1;
+    current.count = 1;
+
+    const result = compareReports(&baseline, &current, 15.0);
+
+    std.debug.assert(!result.entries[0].gated_on_min);
+    std.debug.assert(result.entries[0].status == .regression);
+    std.debug.assert(result.count_regressions == 1);
+}
+
 test "compareReports: detects new and removed entries" {
     var baseline: ParsedReport = .{};
     var current: ParsedReport = .{};
@@ -1424,5 +1544,12 @@ fn makeTestEntryWithPercentiles(name: []const u8, time_per_op_ns: f64, p99: f64)
     e.has_percentiles = true;
     e.p50_per_op_ns = time_per_op_ns; // Use avg as p50 for simplicity.
     e.p99_per_op_ns = p99;
+    return e;
+}
+
+fn makeTestEntryWithMin(name: []const u8, time_per_op_ns: f64, min_per_op_ns: f64) ParsedEntry {
+    var e = makeTestEntry(name, time_per_op_ns);
+    e.has_min = true;
+    e.min_per_op_ns = min_per_op_ns;
     return e;
 }

--- a/src/bench/json_writer.zig
+++ b/src/bench/json_writer.zig
@@ -53,6 +53,15 @@ const os_name: []const u8 = @tagName(builtin.os.tag);
 const arch_name: []const u8 = @tagName(builtin.cpu.arch);
 
 // =============================================================================
+// Re-exports
+// =============================================================================
+
+/// The per-iteration timing accumulator the harnesses feed. Re-exported here
+/// because `json_writer.zig` is the root of the `bench` module, so harnesses
+/// reach it as `bench.Sampler` alongside `bench.entry` / `bench.Reporter`.
+pub const Sampler = @import("sampler.zig").Sampler;
+
+// =============================================================================
 // Entry — one benchmark result
 // =============================================================================
 
@@ -71,6 +80,15 @@ pub const Entry = struct {
 
     /// Number of timed iterations completed.
     iterations: u32 = 0,
+
+    /// Whether `min_per_op_ns` contains a recorded value. Every harness emits
+    /// it now, but the flag lets a hand-constructed `Entry` (or a future
+    /// caller) opt out, and mirrors the tolerant shape `has_percentiles` uses.
+    has_min: bool = false,
+
+    /// Minimum observed per-operation nanoseconds — the best-of-N estimator
+    /// the regression gate classifies on (see `bench/sampler.zig`).
+    min_per_op_ns: f64 = 0.0,
 
     /// Whether percentile fields contain meaningful data.
     /// True only for text benchmarks that collect per-iteration samples.
@@ -111,20 +129,26 @@ pub const Entry = struct {
 // Entry Constructors
 // =============================================================================
 
-/// Create an entry from the common benchmark result fields.
+/// Create an entry from the common benchmark result fields. `min_per_op_ns`
+/// is the best-of-N estimator from the harness `Sampler`; pass 0 only for a
+/// genuinely unmeasured entry.
 pub fn entry(
     name: []const u8,
     operation_count: u32,
     total_time_ns: u64,
     iterations: u32,
+    min_per_op_ns: f64,
 ) Entry {
     std.debug.assert(name.len > 0);
     std.debug.assert(iterations > 0);
+    std.debug.assert(min_per_op_ns >= 0.0);
 
     var e: Entry = .{
         .operation_count = operation_count,
         .total_time_ns = total_time_ns,
         .iterations = iterations,
+        .has_min = true,
+        .min_per_op_ns = min_per_op_ns,
     };
     const copy_length: u32 = @intCast(@min(name.len, MAX_NAME_LENGTH));
     @memcpy(e.name[0..copy_length], name[0..copy_length]);
@@ -132,19 +156,23 @@ pub fn entry(
     return e;
 }
 
-/// Create an entry that includes p50/p99 percentile data (text benchmarks).
+/// Create an entry that includes the min plus p50/p99 percentile data (text
+/// benchmarks). Arguments are ordered by ascending percentile — min (p0),
+/// p50, p99 — so the float arguments are hard to transpose at the call site.
 pub fn entryWithPercentiles(
     name: []const u8,
     operation_count: u32,
     total_time_ns: u64,
     iterations: u32,
+    min_per_op_ns: f64,
     p50_per_op_ns: f64,
     p99_per_op_ns: f64,
 ) Entry {
-    std.debug.assert(p50_per_op_ns >= 0.0);
+    std.debug.assert(min_per_op_ns >= 0.0);
+    std.debug.assert(p50_per_op_ns >= min_per_op_ns);
     std.debug.assert(p99_per_op_ns >= p50_per_op_ns);
 
-    var e = entry(name, operation_count, total_time_ns, iterations);
+    var e = entry(name, operation_count, total_time_ns, iterations, min_per_op_ns);
     e.has_percentiles = true;
     e.p50_per_op_ns = p50_per_op_ns;
     e.p99_per_op_ns = p99_per_op_ns;
@@ -215,10 +243,13 @@ const JsonBenchmarkEntry = struct {
     iterations: u32,
     avg_time_ms: f64,
     time_per_op_ns: f64,
+    min_per_op_ns: ?f64,
     p50_per_op_ns: ?f64,
     p99_per_op_ns: ?f64,
 
     /// Convert from the fixed-capacity Entry to a JSON-serializable form.
+    /// Optional fields serialize as `null` when unrecorded, so a reader on an
+    /// older schema (no min) can fall back tolerantly.
     fn fromEntry(e: *const Entry) JsonBenchmarkEntry {
         std.debug.assert(e.name_length > 0);
         std.debug.assert(e.iterations > 0);
@@ -230,6 +261,7 @@ const JsonBenchmarkEntry = struct {
             .iterations = e.iterations,
             .avg_time_ms = e.avgTimeMs(),
             .time_per_op_ns = e.timePerOpNs(),
+            .min_per_op_ns = if (e.has_min) e.min_per_op_ns else null,
             .p50_per_op_ns = if (e.has_percentiles) e.p50_per_op_ns else null,
             .p99_per_op_ns = if (e.has_percentiles) e.p99_per_op_ns else null,
         };
@@ -487,18 +519,28 @@ pub const Reporter = struct {
 // Tests
 // =============================================================================
 
+// Pull the shared Sampler's tests into this (the bench module root) test
+// binary. A bare `pub const Sampler = @import(...)` alias does not cause Zig
+// to discover the imported file's `test` blocks, so reference it explicitly.
+test {
+    _ = @import("sampler.zig");
+}
+
 test "entry: name is copied and truncated correctly" {
-    const e = entry("convex_128", 128, 5000, 10);
+    const e = entry("convex_128", 128, 5000, 10, 4.0);
     std.debug.assert(e.name_length == 10);
     std.debug.assert(std.mem.eql(u8, e.nameSlice(), "convex_128"));
     std.debug.assert(e.operation_count == 128);
     std.debug.assert(e.iterations == 10);
     std.debug.assert(!e.has_percentiles);
+    // `entry` always records a min, even when percentiles are absent.
+    std.debug.assert(e.has_min);
+    std.debug.assert(e.min_per_op_ns == 4.0);
 }
 
 test "entry: avgTimeMs and timePerOpNs compute correctly" {
     // 1_000_000 ns total, 10 iterations → 100_000 ns avg → 0.1 ms.
-    const e = entry("test", 100, 1_000_000, 10);
+    const e = entry("test", 100, 1_000_000, 10, 950.0);
     const avg_ms = e.avgTimeMs();
     const per_op_ns = e.timePerOpNs();
 
@@ -512,8 +554,10 @@ test "entry: avgTimeMs and timePerOpNs compute correctly" {
 }
 
 test "entryWithPercentiles: percentile fields are set" {
-    const e = entryWithPercentiles("shaped_warm", 50, 2_000_000, 20, 42.5, 128.7);
+    const e = entryWithPercentiles("shaped_warm", 50, 2_000_000, 20, 30.0, 42.5, 128.7);
     std.debug.assert(e.has_percentiles);
+    std.debug.assert(e.has_min);
+    std.debug.assert(e.min_per_op_ns == 30.0);
     std.debug.assert(e.p50_per_op_ns == 42.5);
     std.debug.assert(e.p99_per_op_ns == 128.7);
 }
@@ -523,8 +567,8 @@ test "reporter: addEntry collects entries" {
     std.debug.assert(reporter.count == 0);
     std.debug.assert(!reporter.json_enabled); // No --json-dir in empty argv.
 
-    reporter.addEntry(entry("bench_a", 10, 500, 5));
-    reporter.addEntry(entry("bench_b", 20, 1000, 10));
+    reporter.addEntry(entry("bench_a", 10, 500, 5, 40.0));
+    reporter.addEntry(entry("bench_b", 20, 1000, 10, 40.0));
     std.debug.assert(reporter.count == 2);
     std.debug.assert(std.mem.eql(u8, reporter.entries[0].nameSlice(), "bench_a"));
     std.debug.assert(std.mem.eql(u8, reporter.entries[1].nameSlice(), "bench_b"));
@@ -532,7 +576,7 @@ test "reporter: addEntry collects entries" {
 
 test "reporter: finish is no-op when json is disabled" {
     var reporter = Reporter.init("noop", Io.failing, &.{});
-    reporter.addEntry(entry("x", 1, 100, 1));
+    reporter.addEntry(entry("x", 1, 100, 1, 100.0));
     // Must not crash or attempt file I/O.
     reporter.finish();
 }
@@ -576,25 +620,38 @@ test "reporter: buildFilePath produces expected format" {
 }
 
 test "JsonBenchmarkEntry.fromEntry: converts without percentiles" {
-    const e = entry("test_bench", 64, 1_000_000, 10);
+    const e = entry("test_bench", 64, 1_000_000, 10, 1200.0);
     const json_entry = JsonBenchmarkEntry.fromEntry(&e);
 
     std.debug.assert(std.mem.eql(u8, json_entry.name, "test_bench"));
     std.debug.assert(json_entry.operation_count == 64);
     std.debug.assert(json_entry.total_time_ns == 1_000_000);
     std.debug.assert(json_entry.iterations == 10);
-    // Percentiles must be null when not collected.
+    // Min is recorded even without percentiles; the percentiles stay null.
+    std.debug.assert(json_entry.min_per_op_ns.? == 1200.0);
     std.debug.assert(json_entry.p50_per_op_ns == null);
     std.debug.assert(json_entry.p99_per_op_ns == null);
 }
 
 test "JsonBenchmarkEntry.fromEntry: converts with percentiles" {
-    const e = entryWithPercentiles("shaped_warm", 50, 2_000_000, 20, 42.5, 128.7);
+    const e = entryWithPercentiles("shaped_warm", 50, 2_000_000, 20, 30.0, 42.5, 128.7);
     const json_entry = JsonBenchmarkEntry.fromEntry(&e);
 
     std.debug.assert(std.mem.eql(u8, json_entry.name, "shaped_warm"));
+    std.debug.assert(json_entry.min_per_op_ns.? == 30.0);
     std.debug.assert(json_entry.p50_per_op_ns.? == 42.5);
     std.debug.assert(json_entry.p99_per_op_ns.? == 128.7);
+}
+
+/// Read a parsed JSON number as f64. JSON has a single number type, so the
+/// parser stores an integer-valued number (e.g. the float 5.0 stringified as
+/// `5`) as `.integer`; callers that expect a float must accept both.
+fn jsonNumberAsF64(v: std.json.Value) f64 {
+    return switch (v) {
+        .float => |f| f,
+        .integer => |i| @floatFromInt(i),
+        else => unreachable, // A JSON number is expected at this field.
+    };
 }
 
 test "reporter: serializePayload produces valid JSON" {
@@ -603,8 +660,8 @@ test "reporter: serializePayload produces valid JSON" {
     // per-test `std.testing.io` instance (backed by `Io.Threaded`)
     // instead of `Io.failing`, which would return `Timestamp.zero`.
     var reporter = Reporter.init("test_mod", std.testing.io, &.{});
-    reporter.addEntry(entry("alpha", 10, 500_000, 50));
-    reporter.addEntry(entryWithPercentiles("beta", 20, 1_000_000, 100, 5.0, 15.0));
+    reporter.addEntry(entry("alpha", 10, 500_000, 50, 900.0));
+    reporter.addEntry(entryWithPercentiles("beta", 20, 1_000_000, 100, 4.0, 5.0, 15.0));
 
     const json_bytes = try reporter.serializePayload();
     defer std.heap.page_allocator.free(json_bytes);
@@ -630,5 +687,12 @@ test "reporter: serializePayload produces valid JSON" {
     std.debug.assert(benchmarks.items.len == 2);
     std.debug.assert(std.mem.eql(u8, benchmarks.items[0].object.get("name").?.string, "alpha"));
     std.debug.assert(benchmarks.items[0].object.get("p50_per_op_ns").? == .null);
-    std.debug.assert(benchmarks.items[1].object.get("p50_per_op_ns").?.float == 5.0);
+    // JSON has no separate float type, so an integer-valued float like 5.0
+    // round-trips as `.integer`; read both percentiles tolerantly.
+    std.debug.assert(jsonNumberAsF64(benchmarks.items[1].object.get("p50_per_op_ns").?) == 5.0);
+    std.debug.assert(jsonNumberAsF64(benchmarks.items[1].object.get("p99_per_op_ns").?) == 15.0);
+    // Min is recorded for every entry now (even the percentile-less "alpha"),
+    // and round-trips as a number for the entry that set it explicitly.
+    std.debug.assert(benchmarks.items[0].object.get("min_per_op_ns").? != .null);
+    std.debug.assert(jsonNumberAsF64(benchmarks.items[1].object.get("min_per_op_ns").?) == 4.0);
 }

--- a/src/bench/sampler.zig
+++ b/src/bench/sampler.zig
@@ -1,0 +1,97 @@
+//! Per-iteration timing accumulator shared by every benchmark harness.
+//!
+//! Each harness times its hot path across many iterations. Historically each
+//! timed loop kept its own `total_time_ns` / `iterations` locals and summed
+//! them by hand, so adding a new statistic meant touching ~30 loops across the
+//! four `*/benchmarks.zig` files. `Sampler` centralizes that bookkeeping: the
+//! loops feed it one `record(elapsed_ns)` per iteration, and a new statistic is
+//! added here once — never threaded through the individual loops again.
+//!
+//! Why track the minimum: interference on a shared CI runner (scheduler
+//! preemption, CPU migration, cache eviction, thermal throttling) only ever
+//! *adds* time to a sample. The smallest observed iteration is therefore the
+//! estimator least perturbed by that noise — the "best-of-N" the regression
+//! gate wants, available for free since the harness already runs N timed
+//! iterations. The mean is retained for human-facing context, but the gate
+//! classifies on the min (see `bench/compare.zig`).
+
+const std = @import("std");
+
+/// Fixed-size, allocation-free accumulator over per-iteration timings.
+///
+/// `record` is the only mutator; the public fields are read directly by the
+/// harness loop condition (e.g. `sampler.total_time_ns < MIN_SAMPLE_TIME_NS`)
+/// and when constructing the result entry. All reads happen outside the timed
+/// region, so the accumulator never perturbs the measurement it collects.
+pub const Sampler = struct {
+    /// Total wall-clock nanoseconds across all recorded iterations.
+    total_time_ns: u64 = 0,
+
+    /// Smallest single-iteration time observed, in nanoseconds. Initialized to
+    /// the max sentinel so the first `record` always wins the `@min`; callers
+    /// must record at least one sample before reading it via `minTimeNs`.
+    min_time_ns: u64 = std.math.maxInt(u64),
+
+    /// Number of iterations recorded.
+    iterations: u32 = 0,
+
+    /// Record one iteration's elapsed time. `elapsed_ns` may legitimately be
+    /// zero when the work completes faster than the monotonic clock's
+    /// resolution — that is still a valid (floored) sample, not an error.
+    pub fn record(self: *Sampler, elapsed_ns: u64) void {
+        self.total_time_ns += elapsed_ns;
+        self.min_time_ns = @min(self.min_time_ns, elapsed_ns);
+        self.iterations += 1;
+        // The minimum can never exceed the running total once a sample exists,
+        // and a recorded sample always advances the count past zero.
+        std.debug.assert(self.min_time_ns <= self.total_time_ns);
+        std.debug.assert(self.iterations > 0);
+    }
+
+    /// Minimum observed iteration time in nanoseconds. Asserts at least one
+    /// sample has been recorded so the sentinel can never leak to a caller.
+    pub fn minTimeNs(self: *const Sampler) u64 {
+        std.debug.assert(self.iterations > 0);
+        std.debug.assert(self.min_time_ns != std.math.maxInt(u64));
+        return self.min_time_ns;
+    }
+
+    /// Minimum per-operation nanoseconds: the best-observed iteration divided
+    /// by the operations performed in one iteration. Mirrors the mean-based
+    /// `timePerOpNs` so the two estimators are directly comparable.
+    pub fn minPerOpNs(self: *const Sampler, operation_count: u32) f64 {
+        std.debug.assert(self.iterations > 0);
+        std.debug.assert(operation_count > 0);
+        const min_ns: f64 = @floatFromInt(self.minTimeNs());
+        return min_ns / @as(f64, @floatFromInt(operation_count));
+    }
+};
+
+test "Sampler: record accumulates total, count, and minimum" {
+    var sampler: Sampler = .{};
+    sampler.record(100);
+    sampler.record(40);
+    sampler.record(70);
+
+    try std.testing.expectEqual(@as(u64, 210), sampler.total_time_ns);
+    try std.testing.expectEqual(@as(u32, 3), sampler.iterations);
+    try std.testing.expectEqual(@as(u64, 40), sampler.minTimeNs());
+}
+
+test "Sampler: minPerOpNs divides the best iteration by operation count" {
+    var sampler: Sampler = .{};
+    sampler.record(1000);
+    sampler.record(800); // Best iteration.
+    sampler.record(1200);
+
+    // 800 ns over 16 ops = 50 ns/op.
+    try std.testing.expectEqual(@as(f64, 50.0), sampler.minPerOpNs(16));
+}
+
+test "Sampler: a single zero-duration sample is valid and floors the min" {
+    var sampler: Sampler = .{};
+    sampler.record(0);
+
+    try std.testing.expectEqual(@as(u64, 0), sampler.minTimeNs());
+    try std.testing.expectEqual(@as(u32, 1), sampler.iterations);
+}

--- a/src/context/benchmarks.zig
+++ b/src/context/benchmarks.zig
@@ -85,6 +85,15 @@ const BenchmarkResult = struct {
     operation_count: u32,
     total_time_ns: u64,
     iterations: u32,
+    min_time_ns: u64,
+
+    /// Minimum observed per-operation nanoseconds — the best-of-N estimator,
+    /// least perturbed by runner noise. Mirrors `timePerOpNs` on the min sample.
+    pub fn minPerOpNs(self: BenchmarkResult) f64 {
+        std.debug.assert(self.iterations > 0);
+        std.debug.assert(self.operation_count > 0);
+        return @as(f64, @floatFromInt(self.min_time_ns)) / @as(f64, @floatFromInt(self.operation_count));
+    }
 
     pub fn avgTimeMs(self: BenchmarkResult) f64 {
         std.debug.assert(self.iterations > 0);
@@ -249,24 +258,23 @@ fn benchTreeBuild(
     }
 
     // Sample: time reset + build together (both are per-frame costs).
-    var total_time: u64 = 0;
-    var iterations: u32 = 0;
+    var sampler: bench.Sampler = .{};
 
-    while (total_time < MIN_SAMPLE_TIME_NS or iterations < min_sample_iters) {
+    while (sampler.total_time_ns < MIN_SAMPLE_TIME_NS or sampler.iterations < min_sample_iters) {
         const start = time.Instant.now();
         tree.reset();
         _ = buildFn(&tree);
         const end = time.Instant.now();
 
-        total_time += end.since(start);
-        iterations += 1;
+        sampler.record(end.since(start));
     }
 
     return .{
         .name = name,
         .operation_count = operation_count,
-        .total_time_ns = total_time,
-        .iterations = iterations,
+        .total_time_ns = sampler.total_time_ns,
+        .iterations = sampler.iterations,
+        .min_time_ns = sampler.min_time_ns,
     };
 }
 
@@ -294,25 +302,26 @@ fn benchHitTest(
 
     // Sample: three hit test points per iteration (center, corner, edge).
     const hits_per_iter: u32 = 3;
-    var total_time: u64 = 0;
-    var iterations: u32 = 0;
+    var sampler: bench.Sampler = .{};
 
-    while (total_time < MIN_SAMPLE_TIME_NS or iterations < min_sample_iters) {
+    while (sampler.total_time_ns < MIN_SAMPLE_TIME_NS or sampler.iterations < min_sample_iters) {
         const start = time.Instant.now();
         std.mem.doNotOptimizeAway(tree.hitTest(500.0, 500.0));
         std.mem.doNotOptimizeAway(tree.hitTest(0.5, 0.5));
         std.mem.doNotOptimizeAway(tree.hitTest(999.0, 999.0));
         const end = time.Instant.now();
 
-        total_time += end.since(start);
-        iterations += 1;
+        sampler.record(end.since(start));
     }
 
     return .{
         .name = name,
         .operation_count = operation_count,
-        .total_time_ns = total_time / hits_per_iter,
-        .iterations = iterations,
+        // Both totals are scaled by hits_per_iter so mean and min stay
+        // comparable: each timed iteration covers three hitTest calls.
+        .total_time_ns = sampler.total_time_ns / hits_per_iter,
+        .iterations = sampler.iterations,
+        .min_time_ns = sampler.min_time_ns / hits_per_iter,
     };
 }
 
@@ -338,10 +347,9 @@ fn benchReset(
     }
 
     // Sample: time only the reset call.
-    var total_time: u64 = 0;
-    var iterations: u32 = 0;
+    var sampler: bench.Sampler = .{};
 
-    while (total_time < MIN_SAMPLE_TIME_NS or iterations < min_sample_iters) {
+    while (sampler.total_time_ns < MIN_SAMPLE_TIME_NS or sampler.iterations < min_sample_iters) {
         // Rebuild so reset has work to do.
         tree.reset();
         _ = buildFn(&tree);
@@ -350,15 +358,15 @@ fn benchReset(
         tree.reset();
         const end = time.Instant.now();
 
-        total_time += end.since(start);
-        iterations += 1;
+        sampler.record(end.since(start));
     }
 
     return .{
         .name = name,
         .operation_count = operation_count,
-        .total_time_ns = total_time,
-        .iterations = iterations,
+        .total_time_ns = sampler.total_time_ns,
+        .iterations = sampler.iterations,
+        .min_time_ns = sampler.min_time_ns,
     };
 }
 
@@ -386,10 +394,9 @@ fn benchFullFrame(
     }
 
     // Sample.
-    var total_time: u64 = 0;
-    var iterations: u32 = 0;
+    var sampler: bench.Sampler = .{};
 
-    while (total_time < MIN_SAMPLE_TIME_NS or iterations < min_sample_iters) {
+    while (sampler.total_time_ns < MIN_SAMPLE_TIME_NS or sampler.iterations < min_sample_iters) {
         const start = time.Instant.now();
         tree.reset();
         _ = buildFn(&tree);
@@ -397,15 +404,15 @@ fn benchFullFrame(
         std.mem.doNotOptimizeAway(tree.hitTest(500.0, 500.0));
         const end = time.Instant.now();
 
-        total_time += end.since(start);
-        iterations += 1;
+        sampler.record(end.since(start));
     }
 
     return .{
         .name = name,
         .operation_count = operation_count,
-        .total_time_ns = total_time,
-        .iterations = iterations,
+        .total_time_ns = sampler.total_time_ns,
+        .iterations = sampler.iterations,
+        .min_time_ns = sampler.min_time_ns,
     };
 }
 
@@ -443,10 +450,9 @@ fn benchMarkDirty(
     }
 
     // Sample: mark all entities dirty, then process.
-    var total_time: u64 = 0;
-    var iterations: u32 = 0;
+    var sampler: bench.Sampler = .{};
 
-    while (total_time < MIN_SAMPLE_TIME_NS or iterations < min_sample_iters) {
+    while (sampler.total_time_ns < MIN_SAMPLE_TIME_NS or sampler.iterations < min_sample_iters) {
         const start = time.Instant.now();
         for (ids[0..entity_count]) |id| {
             entities.markDirty(id);
@@ -454,15 +460,15 @@ fn benchMarkDirty(
         std.mem.doNotOptimizeAway(entities.processNotifications());
         const end = time.Instant.now();
 
-        total_time += end.since(start);
-        iterations += 1;
+        sampler.record(end.since(start));
     }
 
     return .{
         .name = name,
         .operation_count = entity_count,
-        .total_time_ns = total_time,
-        .iterations = iterations,
+        .total_time_ns = sampler.total_time_ns,
+        .iterations = sampler.iterations,
+        .min_time_ns = sampler.min_time_ns,
     };
 }
 
@@ -504,10 +510,9 @@ fn benchMarkDirtyDuplicates(
     }
 
     // Sample: mark all entities dirty `rounds` times, then process.
-    var total_time: u64 = 0;
-    var iterations: u32 = 0;
+    var sampler: bench.Sampler = .{};
 
-    while (total_time < MIN_SAMPLE_TIME_NS or iterations < min_sample_iters) {
+    while (sampler.total_time_ns < MIN_SAMPLE_TIME_NS or sampler.iterations < min_sample_iters) {
         const start = time.Instant.now();
         for (0..rounds) |_| {
             for (ids[0..entity_count]) |id| {
@@ -517,15 +522,15 @@ fn benchMarkDirtyDuplicates(
         std.mem.doNotOptimizeAway(entities.processNotifications());
         const end = time.Instant.now();
 
-        total_time += end.since(start);
-        iterations += 1;
+        sampler.record(end.since(start));
     }
 
     return .{
         .name = name,
         .operation_count = total_ops,
-        .total_time_ns = total_time,
-        .iterations = iterations,
+        .total_time_ns = sampler.total_time_ns,
+        .iterations = sampler.iterations,
+        .min_time_ns = sampler.min_time_ns,
     };
 }
 
@@ -700,6 +705,7 @@ fn collect(reporter: *bench.Reporter, result: BenchmarkResult) void {
         result.operation_count,
         result.total_time_ns,
         result.iterations,
+        result.minPerOpNs(),
     ));
 }
 

--- a/src/core/benchmarks.zig
+++ b/src/core/benchmarks.zig
@@ -98,6 +98,7 @@ const BenchmarkResult = struct {
     operation_count: u32,
     total_time_ns: u64,
     iterations: u32,
+    min_time_ns: u64,
 
     pub fn avgTimeMs(self: BenchmarkResult) f64 {
         std.debug.assert(self.iterations > 0);
@@ -112,6 +113,14 @@ const BenchmarkResult = struct {
         const avg_ns = @as(f64, @floatFromInt(self.total_time_ns)) /
             @as(f64, @floatFromInt(self.iterations));
         return avg_ns / @as(f64, @floatFromInt(self.operation_count));
+    }
+
+    /// Minimum observed per-operation nanoseconds — the best-of-N estimator,
+    /// least perturbed by runner noise. Mirrors `timePerOpNs` on the min sample.
+    pub fn minPerOpNs(self: BenchmarkResult) f64 {
+        std.debug.assert(self.iterations > 0);
+        std.debug.assert(self.operation_count > 0);
+        return @as(f64, @floatFromInt(self.min_time_ns)) / @as(f64, @floatFromInt(self.operation_count));
     }
 
     pub fn print(self: BenchmarkResult) void {
@@ -292,18 +301,16 @@ fn benchTriangulate(
 
     // Timed sampling.
     const min_iterations = getMinSampleIterations(operation_count);
-    var total_time_ns: u64 = 0;
-    var iterations: u32 = 0;
+    var sampler: bench.Sampler = .{};
     var last_index_count: usize = 0;
 
-    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_iterations) {
+    while (sampler.total_time_ns < MIN_SAMPLE_TIME_NS or sampler.iterations < min_iterations) {
         triangulator.reset();
         const start = time.Instant.now();
         const indices = triangulator.triangulate(polygon_vertices, polygon) catch unreachable;
         const end = time.Instant.now();
         last_index_count = indices.len;
-        total_time_ns += end.since(start);
-        iterations += 1;
+        sampler.record(end.since(start));
     }
 
     // Result must be consumed to prevent dead-code elimination.
@@ -312,8 +319,9 @@ fn benchTriangulate(
     return .{
         .name = name,
         .operation_count = operation_count,
-        .total_time_ns = total_time_ns,
-        .iterations = iterations,
+        .total_time_ns = sampler.total_time_ns,
+        .iterations = sampler.iterations,
+        .min_time_ns = sampler.min_time_ns,
     };
 }
 
@@ -347,17 +355,15 @@ fn benchStrokeExpand(
 
     // Timed sampling.
     const min_iterations = getMinSampleIterations(operation_count);
-    var total_time_ns: u64 = 0;
-    var iterations: u32 = 0;
+    var sampler: bench.Sampler = .{};
     var last_output_count: usize = 0;
 
-    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_iterations) {
+    while (sampler.total_time_ns < MIN_SAMPLE_TIME_NS or sampler.iterations < min_iterations) {
         const start = time.Instant.now();
         const result = stroke_mod.expandStroke(path_points, stroke_width, cap, join, miter_limit, closed) catch unreachable;
         const end = time.Instant.now();
         last_output_count = result.points.len;
-        total_time_ns += end.since(start);
-        iterations += 1;
+        sampler.record(end.since(start));
     }
 
     std.debug.assert(last_output_count > 0);
@@ -365,8 +371,9 @@ fn benchStrokeExpand(
     return .{
         .name = name,
         .operation_count = operation_count,
-        .total_time_ns = total_time_ns,
-        .iterations = iterations,
+        .total_time_ns = sampler.total_time_ns,
+        .iterations = sampler.iterations,
+        .min_time_ns = sampler.min_time_ns,
     };
 }
 
@@ -396,17 +403,15 @@ fn benchStrokeToTriangles(
 
     // Timed sampling.
     const min_iterations = getMinSampleIterations(operation_count);
-    var total_time_ns: u64 = 0;
-    var iterations: u32 = 0;
+    var sampler: bench.Sampler = .{};
     var last_triangle_count: usize = 0;
 
-    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_iterations) {
+    while (sampler.total_time_ns < MIN_SAMPLE_TIME_NS or sampler.iterations < min_iterations) {
         const start = time.Instant.now();
         const result = stroke_mod.expandStrokeToTriangles(path_points, stroke_width, cap, join, miter_limit, closed) catch unreachable;
         const end = time.Instant.now();
         last_triangle_count = result.indices.len / 3;
-        total_time_ns += end.since(start);
-        iterations += 1;
+        sampler.record(end.since(start));
     }
 
     std.debug.assert(last_triangle_count > 0);
@@ -414,8 +419,9 @@ fn benchStrokeToTriangles(
     return .{
         .name = name,
         .operation_count = operation_count,
-        .total_time_ns = total_time_ns,
-        .iterations = iterations,
+        .total_time_ns = sampler.total_time_ns,
+        .iterations = sampler.iterations,
+        .min_time_ns = sampler.min_time_ns,
     };
 }
 
@@ -448,10 +454,9 @@ fn benchFixedArrayAppendClear(
 
     // Timed sampling.
     const min_iterations = getMinSampleIterations(operation_count);
-    var total_time_ns: u64 = 0;
-    var iterations: u32 = 0;
+    var sampler: bench.Sampler = .{};
 
-    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_iterations) {
+    while (sampler.total_time_ns < MIN_SAMPLE_TIME_NS or sampler.iterations < min_iterations) {
         var array: FixedArray(u32, 8192) = .{};
         const start = time.Instant.now();
         for (0..item_count) |i| {
@@ -464,15 +469,15 @@ fn benchFixedArrayAppendClear(
         array.clear();
         const end = time.Instant.now();
         std.debug.assert(array.len == 0);
-        total_time_ns += end.since(start);
-        iterations += 1;
+        sampler.record(end.since(start));
     }
 
     return .{
         .name = name,
         .operation_count = operation_count,
-        .total_time_ns = total_time_ns,
-        .iterations = iterations,
+        .total_time_ns = sampler.total_time_ns,
+        .iterations = sampler.iterations,
+        .min_time_ns = sampler.min_time_ns,
     };
 }
 
@@ -503,10 +508,9 @@ fn benchFixedArrayPopCycle(
 
     // Timed sampling: fill outside timing window, pop inside.
     const min_iterations = getMinSampleIterations(operation_count);
-    var total_time_ns: u64 = 0;
-    var iterations: u32 = 0;
+    var sampler: bench.Sampler = .{};
 
-    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_iterations) {
+    while (sampler.total_time_ns < MIN_SAMPLE_TIME_NS or sampler.iterations < min_iterations) {
         var array: FixedArray(u32, 8192) = .{};
         for (0..item_count) |i| {
             array.appendAssumeCapacity(@intCast(i));
@@ -524,15 +528,15 @@ fn benchFixedArrayPopCycle(
         // Sink must be observable per-iteration to prevent cross-iteration folding.
         std.mem.doNotOptimizeAway(pop_sink);
         std.debug.assert(array.len == 0);
-        total_time_ns += end.since(start);
-        iterations += 1;
+        sampler.record(end.since(start));
     }
 
     return .{
         .name = name,
         .operation_count = operation_count,
-        .total_time_ns = total_time_ns,
-        .iterations = iterations,
+        .total_time_ns = sampler.total_time_ns,
+        .iterations = sampler.iterations,
+        .min_time_ns = sampler.min_time_ns,
     };
 }
 
@@ -563,10 +567,9 @@ fn benchFixedArraySwapRemove(
 
     // Timed sampling: fill outside timing window, remove inside.
     const min_iterations = getMinSampleIterations(operation_count);
-    var total_time_ns: u64 = 0;
-    var iterations: u32 = 0;
+    var sampler: bench.Sampler = .{};
 
-    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_iterations) {
+    while (sampler.total_time_ns < MIN_SAMPLE_TIME_NS or sampler.iterations < min_iterations) {
         var array: FixedArray(u32, 8192) = .{};
         for (0..item_count) |i| {
             array.appendAssumeCapacity(@intCast(i));
@@ -577,15 +580,15 @@ fn benchFixedArraySwapRemove(
         }
         const end = time.Instant.now();
         std.debug.assert(array.len == 0);
-        total_time_ns += end.since(start);
-        iterations += 1;
+        sampler.record(end.since(start));
     }
 
     return .{
         .name = name,
         .operation_count = operation_count,
-        .total_time_ns = total_time_ns,
-        .iterations = iterations,
+        .total_time_ns = sampler.total_time_ns,
+        .iterations = sampler.iterations,
+        .min_time_ns = sampler.min_time_ns,
     };
 }
 
@@ -617,10 +620,9 @@ fn benchFixedArrayOrderedRemove(
 
     // Timed sampling: fill outside timing window, remove inside.
     const min_iterations = getMinSampleIterations(operation_count);
-    var total_time_ns: u64 = 0;
-    var iterations: u32 = 0;
+    var sampler: bench.Sampler = .{};
 
-    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_iterations) {
+    while (sampler.total_time_ns < MIN_SAMPLE_TIME_NS or sampler.iterations < min_iterations) {
         var array: FixedArray(u32, 8192) = .{};
         for (0..item_count) |i| {
             array.appendAssumeCapacity(@intCast(i));
@@ -631,15 +633,15 @@ fn benchFixedArrayOrderedRemove(
         }
         const end = time.Instant.now();
         std.debug.assert(array.len == 0);
-        total_time_ns += end.since(start);
-        iterations += 1;
+        sampler.record(end.since(start));
     }
 
     return .{
         .name = name,
         .operation_count = operation_count,
-        .total_time_ns = total_time_ns,
-        .iterations = iterations,
+        .total_time_ns = sampler.total_time_ns,
+        .iterations = sampler.iterations,
+        .min_time_ns = sampler.min_time_ns,
     };
 }
 
@@ -678,17 +680,15 @@ fn benchVec2Normalize(
 
     // Timed sampling.
     const min_iterations = getMinSampleIterations(operation_count);
-    var total_time_ns: u64 = 0;
-    var iterations: u32 = 0;
+    var sampler: bench.Sampler = .{};
 
-    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_iterations) {
+    while (sampler.total_time_ns < MIN_SAMPLE_TIME_NS or sampler.iterations < min_iterations) {
         const start = time.Instant.now();
         for (0..vector_count) |i| {
             sink = sink.add(vectors[i].normalize());
         }
         const end = time.Instant.now();
-        total_time_ns += end.since(start);
-        iterations += 1;
+        sampler.record(end.since(start));
     }
 
     // Accumulated length must be finite (ensures work was not optimized away).
@@ -698,8 +698,9 @@ fn benchVec2Normalize(
     return .{
         .name = name,
         .operation_count = operation_count,
-        .total_time_ns = total_time_ns,
-        .iterations = iterations,
+        .total_time_ns = sampler.total_time_ns,
+        .iterations = sampler.iterations,
+        .min_time_ns = sampler.min_time_ns,
     };
 }
 
@@ -746,10 +747,9 @@ fn benchRectContains(
 
     // Timed sampling.
     const min_iterations = getMinSampleIterations(operation_count);
-    var total_time_ns: u64 = 0;
-    var iterations: u32 = 0;
+    var sampler: bench.Sampler = .{};
 
-    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_iterations) {
+    while (sampler.total_time_ns < MIN_SAMPLE_TIME_NS or sampler.iterations < min_iterations) {
         const start = time.Instant.now();
         for (0..point_count) |i| {
             if (rect.contains(test_points[i])) {
@@ -757,8 +757,7 @@ fn benchRectContains(
             }
         }
         const end = time.Instant.now();
-        total_time_ns += end.since(start);
-        iterations += 1;
+        sampler.record(end.since(start));
     }
 
     // Hit count must be non-zero (some points are inside the rect).
@@ -767,8 +766,9 @@ fn benchRectContains(
     return .{
         .name = name,
         .operation_count = operation_count,
-        .total_time_ns = total_time_ns,
-        .iterations = iterations,
+        .total_time_ns = sampler.total_time_ns,
+        .iterations = sampler.iterations,
+        .min_time_ns = sampler.min_time_ns,
     };
 }
 
@@ -810,18 +810,16 @@ fn benchElementIdHash(
 
     // Timed sampling.
     const min_iterations = getMinSampleIterations(operation_count);
-    var total_time_ns: u64 = 0;
-    var iterations: u32 = 0;
+    var sampler: bench.Sampler = .{};
 
-    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_iterations) {
+    while (sampler.total_time_ns < MIN_SAMPLE_TIME_NS or sampler.iterations < min_iterations) {
         const start = time.Instant.now();
         for (0..hash_count) |i| {
             const element_id = ElementId.named(element_names[i % element_names.len]);
             hash_sink +%= element_id.hash();
         }
         const end = time.Instant.now();
-        total_time_ns += end.since(start);
-        iterations += 1;
+        sampler.record(end.since(start));
     }
 
     // Hash sink must have accumulated values.
@@ -830,8 +828,9 @@ fn benchElementIdHash(
     return .{
         .name = name,
         .operation_count = operation_count,
-        .total_time_ns = total_time_ns,
-        .iterations = iterations,
+        .total_time_ns = sampler.total_time_ns,
+        .iterations = sampler.iterations,
+        .min_time_ns = sampler.min_time_ns,
     };
 }
 
@@ -872,10 +871,9 @@ fn benchElementIdEquality(
 
     // Timed sampling.
     const min_iterations = getMinSampleIterations(operation_count);
-    var total_time_ns: u64 = 0;
-    var iterations: u32 = 0;
+    var sampler: bench.Sampler = .{};
 
-    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_iterations) {
+    while (sampler.total_time_ns < MIN_SAMPLE_TIME_NS or sampler.iterations < min_iterations) {
         const start = time.Instant.now();
         for (0..comparison_count) |i| {
             if (ids_a[i].eql(ids_b[i])) {
@@ -883,8 +881,7 @@ fn benchElementIdEquality(
             }
         }
         const end = time.Instant.now();
-        total_time_ns += end.since(start);
-        iterations += 1;
+        sampler.record(end.since(start));
     }
 
     // Some comparisons must have matched (even indices are equal).
@@ -893,8 +890,9 @@ fn benchElementIdEquality(
     return .{
         .name = name,
         .operation_count = operation_count,
-        .total_time_ns = total_time_ns,
-        .iterations = iterations,
+        .total_time_ns = sampler.total_time_ns,
+        .iterations = sampler.iterations,
+        .min_time_ns = sampler.min_time_ns,
     };
 }
 
@@ -1091,6 +1089,7 @@ fn collect(reporter: *bench.Reporter, result: BenchmarkResult) void {
         result.operation_count,
         result.total_time_ns,
         result.iterations,
+        result.minPerOpNs(),
     ));
 }
 

--- a/src/layout/benchmarks.zig
+++ b/src/layout/benchmarks.zig
@@ -78,6 +78,7 @@ const BenchmarkResult = struct {
     node_count: u32,
     total_time_ns: u64,
     iterations: u32,
+    min_time_ns: u64,
 
     pub fn avgTimeMs(self: BenchmarkResult) f64 {
         const avg_ns: f64 = @as(f64, @floatFromInt(self.total_time_ns)) /
@@ -89,6 +90,14 @@ const BenchmarkResult = struct {
         const avg_ns = @as(f64, @floatFromInt(self.total_time_ns)) /
             @as(f64, @floatFromInt(self.iterations));
         return avg_ns / @as(f64, @floatFromInt(self.node_count));
+    }
+
+    /// Minimum observed per-node nanoseconds — the best-of-N estimator, least
+    /// perturbed by runner noise. Mirrors `timePerOpNs` on the min sample.
+    pub fn minPerOpNs(self: BenchmarkResult) f64 {
+        std.debug.assert(self.iterations > 0);
+        std.debug.assert(self.node_count > 0);
+        return @as(f64, @floatFromInt(self.min_time_ns)) / @as(f64, @floatFromInt(self.node_count));
     }
 
     pub fn print(self: BenchmarkResult) void {
@@ -139,10 +148,9 @@ fn runBenchmark(
     }
 
     // Sample - measure only layout computation (endFrame), not tree building
-    var total_time: u64 = 0;
-    var iterations: u32 = 0;
+    var sampler: bench.Sampler = .{};
 
-    while (total_time < MIN_SAMPLE_TIME_NS or iterations < min_sample_iters) {
+    while (sampler.total_time_ns < MIN_SAMPLE_TIME_NS or sampler.iterations < min_sample_iters) {
         engine.beginFrame(1000, 1000);
         _ = buildFn(&engine) catch unreachable;
 
@@ -150,15 +158,15 @@ fn runBenchmark(
         _ = engine.endFrame() catch unreachable;
         const end = time.Instant.now();
 
-        total_time += end.since(start);
-        iterations += 1;
+        sampler.record(end.since(start));
     }
 
     return .{
         .name = name,
         .node_count = node_count,
-        .total_time_ns = total_time,
-        .iterations = iterations,
+        .total_time_ns = sampler.total_time_ns,
+        .iterations = sampler.iterations,
+        .min_time_ns = sampler.min_time_ns,
     };
 }
 
@@ -190,25 +198,24 @@ fn runFullFrameBenchmark(
     }
 
     // Sample - measure entire frame: beginFrame + tree build + endFrame
-    var total_time: u64 = 0;
-    var iterations: u32 = 0;
+    var sampler: bench.Sampler = .{};
 
-    while (total_time < MIN_SAMPLE_TIME_NS or iterations < min_sample_iters) {
+    while (sampler.total_time_ns < MIN_SAMPLE_TIME_NS or sampler.iterations < min_sample_iters) {
         const start = time.Instant.now();
         engine.beginFrame(1000, 1000);
         _ = buildFn(&engine) catch unreachable;
         _ = engine.endFrame() catch unreachable;
         const end = time.Instant.now();
 
-        total_time += end.since(start);
-        iterations += 1;
+        sampler.record(end.since(start));
     }
 
     return .{
         .name = name,
         .node_count = node_count,
-        .total_time_ns = total_time,
-        .iterations = iterations,
+        .total_time_ns = sampler.total_time_ns,
+        .iterations = sampler.iterations,
+        .min_time_ns = sampler.min_time_ns,
     };
 }
 
@@ -849,6 +856,7 @@ fn collect(reporter: *bench.Reporter, result: BenchmarkResult) void {
         result.node_count,
         result.total_time_ns,
         result.iterations,
+        result.minPerOpNs(),
     ));
 }
 

--- a/src/text/benchmarks.zig
+++ b/src/text/benchmarks.zig
@@ -146,6 +146,8 @@ const IterationSamples = struct {
         const ops_f: f64 = @floatFromInt(operation_count);
 
         return .{
+            // The slice is sorted ascending, so slice[0] is the fastest sample (the min).
+            .min_per_op_ns = @as(f64, @floatFromInt(slice[0])) / ops_f,
             .p50_per_op_ns = @as(f64, @floatFromInt(slice[p50_index])) / ops_f,
             .p99_per_op_ns = @as(f64, @floatFromInt(slice[p99_index])) / ops_f,
         };
@@ -154,6 +156,7 @@ const IterationSamples = struct {
 
 /// Percentile statistics computed from iteration samples.
 const PercentileResult = struct {
+    min_per_op_ns: f64,
     p50_per_op_ns: f64,
     p99_per_op_ns: f64,
 };
@@ -167,6 +170,7 @@ const BenchmarkResult = struct {
     operation_count: u32,
     total_time_ns: u64,
     iterations: u32,
+    min_per_op_ns: f64,
     p50_per_op_ns: f64,
     p99_per_op_ns: f64,
 
@@ -375,6 +379,7 @@ fn benchAtlasReserve(
         .operation_count = count,
         .total_time_ns = total_time_ns,
         .iterations = iterations,
+        .min_per_op_ns = percentiles.min_per_op_ns,
         .p50_per_op_ns = percentiles.p50_per_op_ns,
         .p99_per_op_ns = percentiles.p99_per_op_ns,
     };
@@ -430,6 +435,7 @@ fn benchAtlasReserveMixed(
         .operation_count = count,
         .total_time_ns = total_time_ns,
         .iterations = iterations,
+        .min_per_op_ns = percentiles.min_per_op_ns,
         .p50_per_op_ns = percentiles.p50_per_op_ns,
         .p99_per_op_ns = percentiles.p99_per_op_ns,
     };
@@ -513,6 +519,7 @@ fn benchAtlasSet(
         .operation_count = count,
         .total_time_ns = total_time_ns,
         .iterations = iterations,
+        .min_per_op_ns = percentiles.min_per_op_ns,
         .p50_per_op_ns = percentiles.p50_per_op_ns,
         .p99_per_op_ns = percentiles.p99_per_op_ns,
     };
@@ -582,6 +589,7 @@ fn benchAtlasReserveAndSet(
         .operation_count = count,
         .total_time_ns = total_time_ns,
         .iterations = iterations,
+        .min_per_op_ns = percentiles.min_per_op_ns,
         .p50_per_op_ns = percentiles.p50_per_op_ns,
         .p99_per_op_ns = percentiles.p99_per_op_ns,
     };
@@ -643,6 +651,7 @@ fn benchAtlasGrow(
         .operation_count = 1,
         .total_time_ns = total_time_ns,
         .iterations = iterations,
+        .min_per_op_ns = percentiles.min_per_op_ns,
         .p50_per_op_ns = percentiles.p50_per_op_ns,
         .p99_per_op_ns = percentiles.p99_per_op_ns,
     };
@@ -706,6 +715,7 @@ fn benchShapeCold(
         .operation_count = 1,
         .total_time_ns = total_time_ns,
         .iterations = iterations,
+        .min_per_op_ns = percentiles.min_per_op_ns,
         .p50_per_op_ns = percentiles.p50_per_op_ns,
         .p99_per_op_ns = percentiles.p99_per_op_ns,
     };
@@ -771,6 +781,7 @@ fn benchShapeWarm(
         .operation_count = count,
         .total_time_ns = total_time_ns,
         .iterations = iterations,
+        .min_per_op_ns = percentiles.min_per_op_ns,
         .p50_per_op_ns = percentiles.p50_per_op_ns,
         .p99_per_op_ns = percentiles.p99_per_op_ns,
     };
@@ -847,6 +858,7 @@ fn benchShapeWarmArena(
         .operation_count = count,
         .total_time_ns = total_time_ns,
         .iterations = iterations,
+        .min_per_op_ns = percentiles.min_per_op_ns,
         .p50_per_op_ns = percentiles.p50_per_op_ns,
         .p99_per_op_ns = percentiles.p99_per_op_ns,
     };
@@ -914,6 +926,7 @@ fn benchShapeWarmInto(
         .operation_count = count,
         .total_time_ns = total_time_ns,
         .iterations = iterations,
+        .min_per_op_ns = percentiles.min_per_op_ns,
         .p50_per_op_ns = percentiles.p50_per_op_ns,
         .p99_per_op_ns = percentiles.p99_per_op_ns,
     };
@@ -973,6 +986,7 @@ fn benchMeasureText(
         .operation_count = count,
         .total_time_ns = total_time_ns,
         .iterations = iterations,
+        .min_per_op_ns = percentiles.min_per_op_ns,
         .p50_per_op_ns = percentiles.p50_per_op_ns,
         .p99_per_op_ns = percentiles.p99_per_op_ns,
     };
@@ -1031,6 +1045,7 @@ fn benchMeasureTextWrapped(
         .operation_count = count,
         .total_time_ns = total_time_ns,
         .iterations = iterations,
+        .min_per_op_ns = percentiles.min_per_op_ns,
         .p50_per_op_ns = percentiles.p50_per_op_ns,
         .p99_per_op_ns = percentiles.p99_per_op_ns,
     };
@@ -1096,6 +1111,7 @@ fn benchGlyphRasterCold(
         .operation_count = glyph_count,
         .total_time_ns = total_time_ns,
         .iterations = iterations,
+        .min_per_op_ns = percentiles.min_per_op_ns,
         .p50_per_op_ns = percentiles.p50_per_op_ns,
         .p99_per_op_ns = percentiles.p99_per_op_ns,
     };
@@ -1165,6 +1181,7 @@ fn benchGlyphRasterWarm(
         .operation_count = operation_count,
         .total_time_ns = total_time_ns,
         .iterations = iterations,
+        .min_per_op_ns = percentiles.min_per_op_ns,
         .p50_per_op_ns = percentiles.p50_per_op_ns,
         .p99_per_op_ns = percentiles.p99_per_op_ns,
     };
@@ -1241,6 +1258,7 @@ fn benchGlyphRasterWarmSubpixel(
         .operation_count = operation_count,
         .total_time_ns = total_time_ns,
         .iterations = iterations,
+        .min_per_op_ns = percentiles.min_per_op_ns,
         .p50_per_op_ns = percentiles.p50_per_op_ns,
         .p99_per_op_ns = percentiles.p99_per_op_ns,
     };
@@ -1327,6 +1345,7 @@ fn benchGlyphRasterWarmPerGlyph(
         .operation_count = operation_count,
         .total_time_ns = total_time_ns,
         .iterations = iterations,
+        .min_per_op_ns = percentiles.min_per_op_ns,
         .p50_per_op_ns = percentiles.p50_per_op_ns,
         .p99_per_op_ns = percentiles.p99_per_op_ns,
     };
@@ -1423,6 +1442,7 @@ fn benchGlyphRasterWarmBatch(
         .operation_count = operation_count,
         .total_time_ns = total_time_ns,
         .iterations = iterations,
+        .min_per_op_ns = percentiles.min_per_op_ns,
         .p50_per_op_ns = percentiles.p50_per_op_ns,
         .p99_per_op_ns = percentiles.p99_per_op_ns,
     };
@@ -1466,6 +1486,7 @@ fn benchRenderText(
             .operation_count = operation_count,
             .total_time_ns = 0,
             .iterations = 0,
+            .min_per_op_ns = 0,
             .p50_per_op_ns = 0,
             .p99_per_op_ns = 0,
         };
@@ -1513,6 +1534,7 @@ fn benchRenderText(
         .operation_count = operation_count,
         .total_time_ns = total_time_ns,
         .iterations = iterations,
+        .min_per_op_ns = percentiles.min_per_op_ns,
         .p50_per_op_ns = percentiles.p50_per_op_ns,
         .p99_per_op_ns = percentiles.p99_per_op_ns,
     };
@@ -1890,6 +1912,7 @@ fn collect(reporter: *bench.Reporter, result: BenchmarkResult) void {
         result.operation_count,
         result.total_time_ns,
         result.iterations,
+        result.min_per_op_ns,
         result.p50_per_op_ns,
         result.p99_per_op_ns,
     ));


### PR DESCRIPTION
Follow-up to #25 (noise-robust gate). Attacks measurement variance at the source so the bench gate can eventually be marked `required`.

## Commits (4)
1. `cc5fa03` **fix(bench): gate sub-floor blowups by multiple, not fixed ns delta** — orphan refinement committed to `fix/bench-gate-noise-robustness` *after* #25 merged, so it never reached integration. Bundled here (it's the gate logic this work builds on).
2. `9ee2c65` **feat(bench): record best-of-N min per op via shared Sampler** — new `src/bench/sampler.zig`; `min_per_op_ns` in the `Entry`/JSON schema; core/context/layout/text harnesses converted; bench-module tests wired into the macOS+Linux `test` steps (they were never run in CI before — which had hidden a latent float-vs-integer assertion in the serialize test, now fixed).
3. `e2cfce5` **feat(bench): gate regression check on min, fall back to mean** — `compare.zig` classifies central tendency on the min (best-of-N) when both sides have it, falls back to the mean for older baselines. Existing floor / magnitude-scaling / p99 layers unchanged.
4. `7429d0c` **ci(bench): run CI (and bench-gate) on integration branches** — `pull_request`/`push` now also trigger on `integration/**` (previously PRs onto integration ran no CI at all).

## Why min
Interference on a shared runner only ever *adds* time, so the smallest observed iteration is the estimator least perturbed by noise — the "best-of-N" the gate wants, free since the harness already runs N timed iterations.

## Validation (local)
- `zig build test` → **1156/1156** passing; `zig fmt --check` clean.
- `zig build bench-all` runs all four harnesses; JSON now carries `min_per_op_ns`.
- Same-commit A/B comparison through the gate: **0 false regressions** across all four modules (previously flagged phantom swings up to +50%).

## Transitional note
The min gate engages only once *both* sides carry `min_per_op_ns`. The first PR after this lands has a min-less baseline and gates on the mean (fallback); subsequent cycles gate on min.

## Known follow-up (not in this PR)
`bench-gate` still downloads its baseline from a hardcoded `branch=main`. The full same-runner / `base.ref` rework is the next branch.