### PR TITLE
integration/v0.2.1: scene, animation, element-states & accessibility benchmark suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,7 +355,7 @@ jobs:
           FAILED=0
           : > bench-report.txt
 
-          for module in core layout context text; do
+          for module in core layout context text scene animation element-states accessibility; do
             BASELINE=$(ls baseline/*-*-"${module}"-benchmarks-*.json 2>/dev/null | head -1)
             CURRENT=$(ls current/*-*-"${module}"-benchmarks-*.json 2>/dev/null | head -1)
 

--- a/build.zig
+++ b/build.zig
@@ -324,6 +324,139 @@ pub fn build(b: *std.Build) void {
         text_bench_step.dependOn(&text_bench_run.step);
 
         // =====================================================================
+        // Scene Benchmarks (data plane: scene build, batch iteration, frame e2e)
+        // =====================================================================
+
+        const scene_bench_exe = b.addExecutable(.{
+            .name = "scene-bench",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/scene/benchmarks.zig"),
+                .target = target,
+                .optimize = .ReleaseFast,
+                .imports = &.{
+                    .{ .name = "gooey", .module = mod },
+                    .{ .name = "bench", .module = bench_mod },
+                },
+            }),
+        });
+
+        const scene_bench_step = b.step("bench-scene", "Run scene module (data plane) benchmarks");
+        const scene_bench_run = b.addRunArtifact(scene_bench_exe);
+        if (bench_json_dir) |dir| {
+            scene_bench_run.addArgs(&.{ "--json-dir", dir });
+        }
+        scene_bench_step.dependOn(&scene_bench_run.step);
+
+        // The scene benchmark's `validate:` tests (primitive counts, batch
+        // coalescing, and the steady-state zero-allocation invariant) only run
+        // in Debug, where assertions are live. Wire them into `test` so the
+        // data-plane zero-alloc guarantee is a CI-gated fact, mirroring how
+        // `bench_tests` / `compare_tests` are already gated below.
+        const scene_bench_tests = b.addTest(.{
+            .root_module = scene_bench_exe.root_module,
+        });
+        const run_scene_bench_tests = b.addRunArtifact(scene_bench_tests);
+        test_step.dependOn(&run_scene_bench_tests.step);
+
+        // =====================================================================
+        // Animation Benchmarks (per-frame spring physics + store dispatch)
+        // =====================================================================
+
+        const animation_bench_exe = b.addExecutable(.{
+            .name = "animation-bench",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/animation/benchmarks.zig"),
+                .target = target,
+                .optimize = .ReleaseFast,
+                .imports = &.{
+                    .{ .name = "gooey", .module = mod },
+                    .{ .name = "bench", .module = bench_mod },
+                },
+            }),
+        });
+
+        const animation_bench_step = b.step("bench-animation", "Run animation module benchmarks");
+        const animation_bench_run = b.addRunArtifact(animation_bench_exe);
+        if (bench_json_dir) |dir| {
+            animation_bench_run.addArgs(&.{ "--json-dir", dir });
+        }
+        animation_bench_step.dependOn(&animation_bench_run.step);
+
+        // The animation benchmark's `validate:` tests (spring physics sanity +
+        // the steady-state zero-allocation invariant) run only in Debug, where
+        // assertions are live. Wire them into `test` so the store's zero-alloc
+        // guarantee is a CI-gated fact, mirroring the scene suite above.
+        const animation_bench_tests = b.addTest(.{
+            .root_module = animation_bench_exe.root_module,
+        });
+        const run_animation_bench_tests = b.addRunArtifact(animation_bench_tests);
+        test_step.dependOn(&run_animation_bench_tests.step);
+
+        // =====================================================================
+        // Element-State Benchmarks (the keyed per-element retained-state pool)
+        // =====================================================================
+
+        const element_states_bench_exe = b.addExecutable(.{
+            .name = "element-states-bench",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/context/element_states_benchmarks.zig"),
+                .target = target,
+                .optimize = .ReleaseFast,
+                .imports = &.{
+                    .{ .name = "gooey", .module = mod },
+                    .{ .name = "bench", .module = bench_mod },
+                },
+            }),
+        });
+
+        const element_states_bench_step = b.step("bench-element-states", "Run element-state pool benchmarks");
+        const element_states_bench_run = b.addRunArtifact(element_states_bench_exe);
+        if (bench_json_dir) |dir| {
+            element_states_bench_run.addArgs(&.{ "--json-dir", dir });
+        }
+        element_states_bench_step.dependOn(&element_states_bench_run.step);
+
+        // Element-state `validate:` tests (lookup correctness + the steady-state
+        // zero-allocation invariant) run only in Debug — wire them into `test`.
+        const element_states_bench_tests = b.addTest(.{
+            .root_module = element_states_bench_exe.root_module,
+        });
+        const run_element_states_bench_tests = b.addRunArtifact(element_states_bench_tests);
+        test_step.dependOn(&run_element_states_bench_tests.step);
+
+        // =====================================================================
+        // Accessibility Benchmarks (per-frame fingerprint + tree diff)
+        // =====================================================================
+
+        const accessibility_bench_exe = b.addExecutable(.{
+            .name = "accessibility-bench",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/accessibility/benchmarks.zig"),
+                .target = target,
+                .optimize = .ReleaseFast,
+                .imports = &.{
+                    .{ .name = "gooey", .module = mod },
+                    .{ .name = "bench", .module = bench_mod },
+                },
+            }),
+        });
+
+        const accessibility_bench_step = b.step("bench-accessibility", "Run accessibility module benchmarks");
+        const accessibility_bench_run = b.addRunArtifact(accessibility_bench_exe);
+        if (bench_json_dir) |dir| {
+            accessibility_bench_run.addArgs(&.{ "--json-dir", dir });
+        }
+        accessibility_bench_step.dependOn(&accessibility_bench_run.step);
+
+        // Accessibility `validate:` tests (the diff's dirty/removed counts) run
+        // only in Debug — wire them into `test`.
+        const accessibility_bench_tests = b.addTest(.{
+            .root_module = accessibility_bench_exe.root_module,
+        });
+        const run_accessibility_bench_tests = b.addRunArtifact(accessibility_bench_tests);
+        test_step.dependOn(&run_accessibility_bench_tests.step);
+
+        // =====================================================================
         // Run All Benchmarks
         // =====================================================================
 
@@ -332,6 +465,10 @@ pub fn build(b: *std.Build) void {
         bench_all_step.dependOn(&context_bench_run.step);
         bench_all_step.dependOn(&core_bench_run.step);
         bench_all_step.dependOn(&text_bench_run.step);
+        bench_all_step.dependOn(&scene_bench_run.step);
+        bench_all_step.dependOn(&animation_bench_run.step);
+        bench_all_step.dependOn(&element_states_bench_run.step);
+        bench_all_step.dependOn(&accessibility_bench_run.step);
 
         // =====================================================================
         // Hot Reload Watcher
@@ -608,6 +745,155 @@ pub fn build(b: *std.Build) void {
         text_bench_step.dependOn(&text_bench_run.step);
 
         // =====================================================================
+        // Scene Benchmarks (data plane: scene build, batch iteration, frame e2e)
+        // =====================================================================
+
+        const scene_bench_exe = b.addExecutable(.{
+            .name = "scene-bench",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/scene/benchmarks.zig"),
+                .target = target,
+                .optimize = .ReleaseFast,
+                .imports = &.{
+                    .{ .name = "gooey", .module = mod },
+                    .{ .name = "bench", .module = bench_mod },
+                },
+            }),
+        });
+        linkLinuxLibraries(scene_bench_exe);
+
+        const scene_bench_step = b.step("bench-scene", "Run scene module (data plane) benchmarks");
+        const scene_bench_run = b.addRunArtifact(scene_bench_exe);
+        if (bench_json_dir) |dir| {
+            scene_bench_run.addArgs(&.{ "--json-dir", dir });
+        }
+        scene_bench_step.dependOn(&scene_bench_run.step);
+
+        // Scene benchmark `validate:` tests (counts, batch coalescing, and the
+        // steady-state zero-allocation invariant) run only in Debug. The
+        // dependOn is added in the Tests section below, once `test_step` exists.
+        const scene_bench_tests = b.addTest(.{
+            .root_module = scene_bench_exe.root_module,
+            .use_llvm = true,
+        });
+        linkLinuxLibraries(scene_bench_tests);
+        if (!skip_shader_compile) {
+            scene_bench_tests.step.dependOn(compile_shaders_step);
+        }
+        const run_scene_bench_tests = b.addRunArtifact(scene_bench_tests);
+
+        // =====================================================================
+        // Animation Benchmarks (per-frame spring physics + store dispatch)
+        // =====================================================================
+
+        const animation_bench_exe = b.addExecutable(.{
+            .name = "animation-bench",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/animation/benchmarks.zig"),
+                .target = target,
+                .optimize = .ReleaseFast,
+                .imports = &.{
+                    .{ .name = "gooey", .module = mod },
+                    .{ .name = "bench", .module = bench_mod },
+                },
+            }),
+        });
+        linkLinuxLibraries(animation_bench_exe);
+
+        const animation_bench_step = b.step("bench-animation", "Run animation module benchmarks");
+        const animation_bench_run = b.addRunArtifact(animation_bench_exe);
+        if (bench_json_dir) |dir| {
+            animation_bench_run.addArgs(&.{ "--json-dir", dir });
+        }
+        animation_bench_step.dependOn(&animation_bench_run.step);
+
+        // Animation `validate:` tests (physics sanity + steady-state zero-alloc)
+        // run only in Debug. The dependOn is added in the Tests section below.
+        const animation_bench_tests = b.addTest(.{
+            .root_module = animation_bench_exe.root_module,
+            .use_llvm = true,
+        });
+        linkLinuxLibraries(animation_bench_tests);
+        if (!skip_shader_compile) {
+            animation_bench_tests.step.dependOn(compile_shaders_step);
+        }
+        const run_animation_bench_tests = b.addRunArtifact(animation_bench_tests);
+
+        // =====================================================================
+        // Element-State Benchmarks (the keyed per-element retained-state pool)
+        // =====================================================================
+
+        const element_states_bench_exe = b.addExecutable(.{
+            .name = "element-states-bench",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/context/element_states_benchmarks.zig"),
+                .target = target,
+                .optimize = .ReleaseFast,
+                .imports = &.{
+                    .{ .name = "gooey", .module = mod },
+                    .{ .name = "bench", .module = bench_mod },
+                },
+            }),
+        });
+        linkLinuxLibraries(element_states_bench_exe);
+
+        const element_states_bench_step = b.step("bench-element-states", "Run element-state pool benchmarks");
+        const element_states_bench_run = b.addRunArtifact(element_states_bench_exe);
+        if (bench_json_dir) |dir| {
+            element_states_bench_run.addArgs(&.{ "--json-dir", dir });
+        }
+        element_states_bench_step.dependOn(&element_states_bench_run.step);
+
+        // Element-state `validate:` tests run only in Debug. The dependOn is
+        // added in the Tests section below.
+        const element_states_bench_tests = b.addTest(.{
+            .root_module = element_states_bench_exe.root_module,
+            .use_llvm = true,
+        });
+        linkLinuxLibraries(element_states_bench_tests);
+        if (!skip_shader_compile) {
+            element_states_bench_tests.step.dependOn(compile_shaders_step);
+        }
+        const run_element_states_bench_tests = b.addRunArtifact(element_states_bench_tests);
+
+        // =====================================================================
+        // Accessibility Benchmarks (per-frame fingerprint + tree diff)
+        // =====================================================================
+
+        const accessibility_bench_exe = b.addExecutable(.{
+            .name = "accessibility-bench",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/accessibility/benchmarks.zig"),
+                .target = target,
+                .optimize = .ReleaseFast,
+                .imports = &.{
+                    .{ .name = "gooey", .module = mod },
+                    .{ .name = "bench", .module = bench_mod },
+                },
+            }),
+        });
+        linkLinuxLibraries(accessibility_bench_exe);
+
+        const accessibility_bench_step = b.step("bench-accessibility", "Run accessibility module benchmarks");
+        const accessibility_bench_run = b.addRunArtifact(accessibility_bench_exe);
+        if (bench_json_dir) |dir| {
+            accessibility_bench_run.addArgs(&.{ "--json-dir", dir });
+        }
+        accessibility_bench_step.dependOn(&accessibility_bench_run.step);
+
+        // Accessibility `validate:` tests run only in Debug. The dependOn is
+        // added in the Tests section below.
+        const accessibility_bench_tests = b.addTest(.{
+            .root_module = accessibility_bench_exe.root_module,
+            .use_llvm = true,
+        });
+        linkLinuxLibraries(accessibility_bench_tests);
+        if (!skip_shader_compile) {
+            accessibility_bench_tests.step.dependOn(compile_shaders_step);
+        }
+        const run_accessibility_bench_tests = b.addRunArtifact(accessibility_bench_tests);
+
+        // =====================================================================
         // Run All Benchmarks
         // =====================================================================
 
@@ -616,6 +902,10 @@ pub fn build(b: *std.Build) void {
         bench_all_step.dependOn(&context_bench_run.step);
         bench_all_step.dependOn(&core_bench_run.step);
         bench_all_step.dependOn(&text_bench_run.step);
+        bench_all_step.dependOn(&scene_bench_run.step);
+        bench_all_step.dependOn(&animation_bench_run.step);
+        bench_all_step.dependOn(&element_states_bench_run.step);
+        bench_all_step.dependOn(&accessibility_bench_run.step);
 
         // =====================================================================
         // Tests
@@ -641,6 +931,10 @@ pub fn build(b: *std.Build) void {
         test_step.dependOn(&run_mod_tests.step);
         test_step.dependOn(&run_compare_tests.step);
         test_step.dependOn(&run_bench_tests.step);
+        test_step.dependOn(&run_scene_bench_tests.step);
+        test_step.dependOn(&run_animation_bench_tests.step);
+        test_step.dependOn(&run_element_states_bench_tests.step);
+        test_step.dependOn(&run_accessibility_bench_tests.step);
 
         // =====================================================================
         // Valgrind Memory Leak Detection

--- a/docs/accessibility-diff-performance.md
+++ b/docs/accessibility-diff-performance.md
@@ -1,0 +1,167 @@
+# Accessibility Diff Performance
+
+Benchmark notes and design analysis for the per-frame accessibility diff
+(`src/accessibility/tree.zig` + `fingerprint.zig`). Companion to
+`scene-data-plane-performance.md`; numbers are produced by
+`src/accessibility/benchmarks.zig` (`zig build bench-accessibility`).
+
+## Context
+
+Immediate mode rebuilds the UI every frame, but platform accessibility APIs
+expect **stable object identity** — VoiceOver tracks focus by object pointer,
+AT-SPI2 by stable D-Bus path. `accessibility/` bridges that gap by rebuilding a
+parallel a11y tree each frame and diffing it against the previous frame: each
+element gets a content-derived `Fingerprint` for cross-frame identity, and
+`endFrame` computes the **dirty** set (content changed or new) and the
+**removed** set (gone this frame) that the platform bridge syncs.
+
+That rebuild-and-diff runs every frame a window is visible, so it is a per-frame
+cost on the critical path. Nothing benched it until now. This suite mirrors the
+scene suite's frame-e2e group directly: a whole-frame µs number against the
+budget is the only thing that answers "does the a11y diff fit the frame?".
+
+**Scope.** The tree is static-allocation end to end (`constants.MAX_ELEMENTS`
+fixed arrays, a 4096-bucket open-addressing `FingerprintMap`), so there is no
+per-frame allocator churn to gate — the only heap touch is the one-time `Tree`
+allocation (~350 KiB, heap-allocated per CLAUDE.md §14). The platform bridge sync
+itself (NSAccessibility / AT-SPI2 / ARIA) needs a live screen reader and cannot
+run headless; this measures the headless diff that produces the sync sets.
+
+---
+
+## The suite
+
+Run: `zig build bench-accessibility` (add `-Dbench-json-dir=<dir>` for JSON).
+Validate (Debug, assertions live): the `validate:` tests run under `zig build
+test` — they assert a stable rebuild reports zero dirty after frame 1, and that
+content churn marks exactly the changed elements dirty (and zero removed).
+
+| Group | What it times | Reports |
+| --- | --- | --- |
+| Fingerprint | `fingerprint.compute` over N calls | ns / fingerprint |
+| Frame diff (stable) | `beginFrame → pushElement×N → endFrame`, no churn | whole-frame µs vs budget |
+| Frame diff (churn) | same, with a fraction changing content each frame | whole-frame µs vs budget |
+
+All groups collect p50/p99; the gate classifies on the best-of-N minimum.
+
+---
+
+## Results (macOS arm64, M-series, `ReleaseFast`)
+
+These are the shape of the curve, not acceptance criteria.
+
+### Fingerprint — ~1.4 ns, parent contribution is free
+
+| Test | Ops | ns/op | p99 |
+| --- | --- | --- | --- |
+| fingerprint_flat_4k | 4000 | 1.43 | 1.69 |
+| fingerprint_parented_4k | 4000 | 1.44 | 3.29 |
+
+`fingerprint.compute` is a Wyhash over the element name plus a few bit-packs into
+a `u64` — **~1.4 ns**. Folding in a parent fingerprint (two XORs and a shift) is
+free within timer resolution. This is the per-element identity primitive; the
+frame diff calls it once per element during `pushElement`.
+
+### Frame diff — flat per-element cost, comfortably under budget
+
+| Test | Elements | Avg/frame | p99/frame | % 60 Hz | % 120 Hz | ns/element |
+| --- | --- | --- | --- | --- | --- | --- |
+| frame_stable_64 | 65 | 8.29 µs | 16.38 µs | 0.05% | 0.10% | 127 |
+| frame_stable_256 | 257 | 31.43 µs | 43.29 µs | 0.19% | 0.38% | 122 |
+| frame_stable_1000 | 1001 | 128.14 µs | 153.92 µs | 0.77% | 1.54% | 128 |
+| frame_churn_256 | 257 | 32.03 µs | 45.79 µs | 0.19% | 0.38% | 125 |
+| frame_churn_1000 | 1001 | 129.39 µs | 156.58 µs | 0.78% | 1.55% | 129 |
+
+Two things stand out:
+
+1. **Per-element cost is flat at ~122–129 ns from 64 to 1000 elements.** That is
+   the headline: the whole diff is **O(n), not O(n²)**. It is what the
+   `FingerprintMap` buys — `computeDirtyElements`/`computeRemovedElements` do
+   O(1) hash lookups instead of the O(n) scans the `tree.zig` comments call out
+   ("Uses hash map for O(n) total instead of O(n²)"). A 1000-element tree — well
+   above the 200–500 a complex UI runs (`constants.zig`) — is **~128 µs, 0.77% of
+   the 60 Hz budget.**
+2. **Churn is nearly free on top of the rebuild.** Flipping the content of a
+   fraction of live `.status` elements each frame (driving the dirty-detection +
+   auto-announce path) adds **~1 ns/element** over the stable rebuild (129 vs
+   128 µs at 1000). The frame cost is dominated by the *unconditional*
+   per-element work — fingerprint, content hash, map insert/lookup — not by
+   marking the handful that changed.
+
+Tails are reasonable (p99 ≈ 1.2–2× avg); the 64-element p99 is the noisiest, as
+expected for the shortest-running entry.
+
+---
+
+## Where the ~128 ns/element goes (and a latent halving)
+
+Fingerprint is only ~1.4 ns of the ~128 ns/element, so the per-element cost is
+dominated by the rest of the cycle: `pushElement` (element init + one
+`FingerprintMap.insert`), the `endFrame` dirty pass (one `FingerprintMap.find` +
+a `contentHash`), and the `beginFrame` snapshot (one `contentHash` +
+`FingerprintMap.insert` to build the previous-frame map).
+
+A latent finding falls out of that breakdown: **`contentHash` is computed twice
+per element per frame.** `endFrame` hashes each current element in
+`computeDirtyElements`; the next frame's `beginFrame` hashes those same elements
+again to fill `prev_hashes` for the snapshot. The hash is a Wyhash over name +
+value + description + state + numeric fields — not free at ~tens of ns.
+
+**Prescription (when warranted):** store the hash `endFrame` already computes on
+the `Element` (a `content_hash: u32` field), and have `beginFrame` read it from
+the previous-frame elements instead of recomputing. That removes one of the two
+hashes per element per frame. The win is partial (the hash is a fraction of the
+128 ns), and at 0.77% of budget for 1000 elements there is no pressure to take
+it today — but `frame_stable_1000` is the entry that would show the improvement
+if a UI ever pushes element counts high enough to care.
+
+---
+
+## External validation
+
+- **Rebuild-and-diff for retained identity.** Computing a content fingerprint so
+  an immediate-mode tree can present stable identity to a retained platform API
+  is the documented approach in `fingerprint.zig` (VoiceOver object identity,
+  AT-SPI2 D-Bus paths). The same "rebuild every frame, reconcile against last
+  frame" model is what Dear ImGui and React's reconciler use; here the
+  reconciliation key is the semantic fingerprint rather than a React `key` or an
+  ImGui ID stack.
+- **O(n) diff via a hash map.** The flat ~128 ns/element curve is the empirical
+  confirmation of the `FingerprintMap` optimization the `tree.zig` comments
+  describe — without it, `computeDirtyElements` and `computeRemovedElements`
+  would be O(n²) and the per-element cost would climb with element count instead
+  of staying flat. The benchmark is what would catch a regression back to the
+  scan.
+- **Frame budget.** Same 16.67 ms (60 Hz) / 8.33 ms (120 Hz) budget as the scene
+  suite. A realistic 200–500-element UI diffs in ~25–64 µs (≤0.4% of 60 Hz), so
+  the a11y diff — like scene assembly — is not where the frame budget goes.
+
+> Caveat: these are headless diff numbers on M-series silicon. The platform
+> bridge sync (IPC to the screen reader) is a separate, unmeasured cost that
+> only the dirty/removed *sets* feed; keeping those sets small (the diff's job)
+> is what keeps that sync cheap.
+
+---
+
+## Findings
+
+1. **The diff fits the frame with room to spare.** 1000 elements at 0.77% of the
+   60 Hz budget, flat per-element — the `FingerprintMap` makes the diff O(n) and
+   that is the property worth protecting.
+2. **Churn is cheap.** Content changes cost ~1 ns/element over the rebuild, so a
+   chatty live region or a list whose values tick every frame is not a concern.
+3. **One latent halving exists** (cache `contentHash` across the
+   endFrame→beginFrame boundary) but is not worth taking at current element
+   counts — recorded here so `frame_stable_1000` can size it if that changes.
+
+---
+
+## References
+
+- Source: `src/accessibility/benchmarks.zig`, `src/accessibility/tree.zig`,
+  `src/accessibility/fingerprint.zig`, `src/accessibility/element.zig`,
+  `src/accessibility/constants.zig`
+- Accessibility architecture overview: `docs/accessibility.md`
+- Dear ImGui — *About the IMGUI paradigm* —
+  <https://github.com/ocornut/imgui/wiki/About-the-IMGUI-paradigm>
+- Baselines + regression workflow: `docs/benchmarks/README.md`

--- a/docs/animation-performance.md
+++ b/docs/animation-performance.md
@@ -1,0 +1,190 @@
+# Animation Performance
+
+Benchmark notes and design analysis for the per-frame animation tick
+(`src/animation/`): the spring physics (`spring.zig`), motion containers
+(`motion.zig`), and the `AnimationStore` dispatch (`store.zig`) that polls them.
+Companion to `scene-data-plane-performance.md`; numbers are produced by
+`src/animation/benchmarks.zig` (`zig build bench-animation`).
+
+## Context
+
+The control-plane suites (`bench`, `bench-context`, `bench-core`, `bench-text`)
+and the scene data-plane suite cover layout, dispatch, geometry, text, and the
+scene→batch→frame path. The animation engine — which runs on every animating
+window, every frame — was unbenched until now.
+
+`spring.zig`'s header makes two explicit back-of-envelope claims (CLAUDE.md §7):
+
+> Per-frame cost per active spring: one RK4 step = ~20 multiply-adds … At-rest
+> springs cost one branch (early return in `tickSpring`). Zero physics.
+
+`bench-animation` turns both halves of that claim into measured numbers, and
+separates the **physics** cost (the RK4 step) from the **dispatch** cost (the
+hash-map lookup + tick funnel the store walks each frame).
+
+**Scope.** The store ticks via `tickSpring`, whose `dt` comes from the monotonic
+`awake` clock. A benchmark frame completes well under one millisecond, so the
+clock-derived `dt` rounds toward zero and the store path measures lookup +
+dispatch overhead, not RK4 work. That separation is deliberate (CLAUDE.md §8,
+control vs data plane): the RK4 cost is isolated in the Spring-step group with a
+fixed `dt`, the dispatch cost in the Store-frame group.
+
+---
+
+## The suite
+
+Run: `zig build bench-animation` (add `-Dbench-json-dir=<dir>` to capture JSON).
+Validate (Debug, assertions live): the `validate:` tests in
+`src/animation/benchmarks.zig` run under `zig build test` — they check that the
+physics converges, that the at-rest tick leaves state untouched, and the
+**steady-state zero-allocation invariant** via a counting allocator.
+
+| Group | What it times | Reports |
+| --- | --- | --- |
+| Spring step | `stepSpring` RK4 integration at a fixed 1/60 s `dt` | ns / spring (physics) |
+| Spring tick | `tickSpring` on settled springs (the early return) | ns / spring (at-rest) |
+| Store frame (springs) | `beginFrame → springById×N → endFrame` | whole-frame µs vs budget |
+| Store frame (motions) | the same cycle via `springMotionById` | whole-frame µs vs budget |
+
+All groups collect p50/p99; the regression gate (`bench-compare`) classifies on
+the best-of-N minimum.
+
+---
+
+## Results (macOS arm64, M-series, `ReleaseFast`)
+
+These are the shape of the curve, not acceptance criteria.
+
+### Spring step vs at-rest tick — "at-rest ≈ free" confirmed
+
+| Test | Ops | ns/op | p99 |
+| --- | --- | --- | --- |
+| spring_step_256 | 256 | 9.86 | 17.25 |
+| spring_step_1k | 1024 | 8.43 | 14.69 |
+| spring_tick_atrest_256 | 256 | 1.09 | 1.14 |
+| spring_tick_atrest_1k | 1024 | 1.21 | 1.46 |
+
+The headline design claim holds. A full RK4 step costs **~8–10 ns/spring** —
+four acceleration evaluations and a weighted average, exactly the ~20
+multiply-adds `spring.zig` budgeted. An at-rest `tickSpring` costs **~1.1
+ns/spring**: it reads `state.at_rest`, fills a handle, and returns. That is the
+**~8× gap** that makes the design work — a window can register dozens of springs
+and pay almost nothing for the ones sitting at rest, which is the overwhelmingly
+common case (a toggle that settled three frames ago).
+
+This is why the wake-on-target-change logic in `store.zig` (`springById`) and
+`motion.zig` (`tickSpringMotion`) matters so much: it is the gate that keeps a
+spring on the 1.1 ns path until something actually moves it.
+
+### Store frame — per-frame dispatch is a rounding error
+
+| Test | Springs | Avg/frame | p99/frame | % 60 Hz | % 120 Hz |
+| --- | --- | --- | --- | --- | --- |
+| frame_springs_16 | 16 | 0.15 µs | 0.17 µs | 0.00% | 0.00% |
+| frame_springs_64 | 64 | 0.91 µs | 0.96 µs | 0.01% | 0.01% |
+| frame_springs_256 | 256 | 5.99 µs | 6.63 µs | 0.04% | 0.07% |
+| frame_spring_motions_64 | 64 | 0.98 µs | 1.00 µs | 0.01% | 0.01% |
+| frame_spring_motions_256 | 256 | 6.19 µs | 10.83 µs | 0.04% | 0.07% |
+
+Polling 256 springs through the store — `beginFrame`, 256 hash-map `getOrPut`s,
+256 ticks, `endFrame` — is **~6 µs, 0.04% of the 60 Hz budget**. Per-spring
+dispatch rises from ~9 ns (16 springs) to ~23 ns (256 springs) as the
+`AutoArrayHashMapUnmanaged` working set spills out of L1, but even the 256-spring
+frame is invisible next to layout, text, and GPU submission. Spring-motions track
+the springs they wrap, with a slightly fatter tail (the extra `tickSpringMotion`
+phase-derivation branch).
+
+The **steady-state zero-allocation invariant passes**: after the pools grow to
+hold every registered spring/motion during warmup, a frame's `getOrPut` on
+existing keys never touches the heap (CLAUDE.md §2). This is gated in the
+validate tests with a counting allocator.
+
+### Back-of-envelope: a fully-active frame
+
+The store frame measures idle dispatch; the physics is the Spring-step group.
+A worst-case frame where **all 256 springs are in flight** is the sum:
+
+```
+6 µs (dispatch) + 256 × ~9 ns (RK4) ≈ 6 µs + 2.3 µs ≈ 8.3 µs
+```
+
+— still **~0.05%** of the 60 Hz budget. There is no realistic UI spring count
+that makes the animation tick a frame-budget concern; the cost lives entirely in
+what the springs *drive* (relayout, repaint), not in the springs themselves.
+
+---
+
+## External validation
+
+The numbers were sanity-checked against the lineage gooey's animation model
+draws from. These are structural cross-checks, not absolute-number comparisons.
+
+### Interruptible springs (Framer Motion / react-spring / Apple)
+
+gooey's spring is **declarative and interruptible**: you set the target every
+frame, and the spring redirects from its current position and velocity without a
+restart (`SpringState` carries `position` + `velocity`, `springById` only
+updates `target`). That is the same model Framer Motion and react-spring
+popularized for the web, and that Apple's `CASpringAnimation` / SwiftUI
+`.spring()` use natively. The "preserve velocity on target change" behaviour is
+the defining property of that family, and the at-rest-is-free result is what
+makes it cheap enough to apply per-frame to many elements.
+
+### RK4 over Euler
+
+`spring.zig` integrates with 4th-order Runge–Kutta rather than explicit Euler.
+The rationale (documented in the file and confirmed by the
+`rk4 is stable at large timestep` test) is the standard numerical-methods
+result: explicit Euler gains energy and oscillates or diverges at stiff
+spring constants and large/dropped-frame timesteps, while RK4 stays stable for
+the stiffness/damping range UIs use at one step per frame. The measured ~9 ns
+for four acceleration evaluations is the price of that stability, and it is
+negligible.
+
+### Animate-only-while-active scheduling
+
+The design only does physics work for springs that are not at rest, and
+`AnimationStore.hasActiveAnimations()` lets the window skip scheduling a frame
+when nothing is in flight. This mirrors the general
+`requestAnimationFrame`-while-animating pattern (and GPUI/Zed's frame scheduling,
+where a frame is only driven when something needs to change). The 1.1 ns at-rest
+tick is what makes "poll every registered spring every frame to see if it woke"
+affordable, so the scheduler can stay simple.
+
+> Caveat: cross-framework figures are not directly comparable (different
+> languages, integrators, and hardware). The robust takeaways are the
+> structural ones: the ~8× at-rest/in-flight gap, the negligible store-dispatch
+> cost, and the passing zero-allocation gate.
+
+---
+
+## Findings
+
+1. **The at-rest fast path is real and load-bearing.** 1.1 ns vs ~9 ns is the
+   single most important number here: it validates registering many springs and
+   polling them unconditionally each frame. Any future refactor that adds work
+   to the at-rest branch of `tickSpring` (or that forgets the wake-gate and
+   leaves springs spuriously in-flight) would erase that margin — the
+   `spring_tick_atrest_*` entries gate against exactly that.
+2. **Dispatch is the cost, and it is tiny.** Per-spring store cost (~9→23 ns) is
+   dominated by the hash-map lookup, not physics. If a profile ever shows the
+   animation tick on a frame budget, the lever is the lookup (the pools are
+   `AutoArrayHashMapUnmanaged` keyed by `u32`), not the integrator.
+3. **No regressions to chase yet.** Unlike the scene suite's sort hot spot,
+   nothing here prescribes a fix — the suite's value is locking in the at-rest
+   margin and the zero-allocation guarantee so they can't silently regress.
+
+---
+
+## References
+
+- Source: `src/animation/benchmarks.zig`, `src/animation/spring.zig`,
+  `src/animation/motion.zig`, `src/animation/store.zig`
+- Framer Motion — spring transitions (interruptible, velocity-preserving) —
+  <https://www.framer.com/motion/transition/>
+- react-spring — spring physics for UI — <https://www.react-spring.dev/>
+- Apple — `CASpringAnimation` —
+  <https://developer.apple.com/documentation/quartzcore/caspringanimation>
+- Scandurra, A. *Leveraging Rust and the GPU to render user interfaces at
+  120 FPS* (GPUI), Zed, 2023 — <https://zed.dev/blog/videogame>
+- Baselines + regression workflow: `docs/benchmarks/README.md`

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -18,12 +18,16 @@ capture date:
 
 Modules captured:
 
-| File                                               | Source                       | Entries |
-| -------------------------------------------------- | ---------------------------- | ------- |
-| `macos-aarch64-layout-benchmarks-04-23-2026.json`  | `src/layout/benchmarks.zig`  | 24      |
-| `macos-aarch64-context-benchmarks-04-23-2026.json` | `src/context/benchmarks.zig` | 49      |
-| `macos-aarch64-core-benchmarks-04-23-2026.json`    | `src/core/benchmarks.zig`    | 59      |
-| `macos-aarch64-text-benchmarks-04-23-2026.json`    | `src/text/benchmarks.zig`    | 40      |
+| File                                                      | Source                                      | Entries |
+| --------------------------------------------------------- | ------------------------------------------- | ------- |
+| `macos-aarch64-layout-benchmarks-04-23-2026.json`         | `src/layout/benchmarks.zig`                 | 24      |
+| `macos-aarch64-context-benchmarks-04-23-2026.json`        | `src/context/benchmarks.zig`                | 49      |
+| `macos-aarch64-core-benchmarks-04-23-2026.json`           | `src/core/benchmarks.zig`                   | 59      |
+| `macos-aarch64-text-benchmarks-04-23-2026.json`           | `src/text/benchmarks.zig`                   | 40      |
+| `macos-aarch64-scene-benchmarks-05-30-2026.json`          | `src/scene/benchmarks.zig`                  | 23      |
+| `macos-aarch64-animation-benchmarks-05-30-2026.json`      | `src/animation/benchmarks.zig`              | 9       |
+| `macos-aarch64-element-states-benchmarks-05-30-2026.json` | `src/context/element_states_benchmarks.zig` | 8       |
+| `macos-aarch64-accessibility-benchmarks-05-30-2026.json`  | `src/accessibility/benchmarks.zig`          | 7       |
 
 Each entry carries `operation_count`, `total_time_ns`, `iterations`,
 `avg_time_ms`, `time_per_op_ns`, and (where measured) `p50_per_op_ns` /
@@ -39,9 +43,10 @@ even when the average is steady.
 zig build bench-all -Dbench-json-dir=docs/benchmarks
 ```
 
-Individual suites (`bench`, `bench-context`, `bench-core`, `bench-text`)
-accept the same `-Dbench-json-dir=` flag — useful when iterating on a
-single module.
+Individual suites (`bench`, `bench-context`, `bench-core`, `bench-text`,
+`bench-scene`, `bench-animation`, `bench-element-states`,
+`bench-accessibility`) accept the same `-Dbench-json-dir=` flag — useful when
+iterating on a single module.
 
 All benchmarks build at `ReleaseFast`. Adaptive iteration counts target
 ~50 ms wall-clock per entry, so a full `bench-all` run is bounded at a
@@ -110,6 +115,28 @@ A few orientation points from the initial capture (macOS arm64, M-series,
   the `endFrame` render path exploits.
 - **Context** — tree build is ~7–9 ns/op pushNode amortized, flat
   across widths up to 2000 siblings.
+- **Scene (data plane)** — primitive emission is flat ~4 ns/op and
+  allocation-free in steady state; `BatchIterator` drains coalesced
+  scenes at ~1 ns/prim (1 batch) vs ~20 ns/prim when fully interleaved
+  (1 batch/prim) — the cost of poor batching, quantified. `finish()`
+  sorting 128-byte `Quad` structs is the one hot spot (~3.3 ms for 8k
+  out-of-order quads); see `../scene-data-plane-performance.md`.
+  A realistic 5k-primitive frame (build + finish + batch drain) is
+  ~31 µs — under 0.4% of the 8.33 ms / 120 Hz budget.
+- **Animation** — an at-rest spring tick is ~1.1 ns (a single branch),
+  ~8× cheaper than the ~9 ns RK4 step it skips, so idle springs are
+  effectively free; a 256-spring store frame is ~6 µs (0.04% of the
+  60 Hz budget) and allocation-free in steady state. See
+  `../animation-performance.md`.
+- **Element states** — `get`/`withElementState` on a present key is an
+  O(count) linear scan: ~3.6 ns at 8 entries but ~981 ns at 4096, a
+  clean ~0.48 ns/comparison line that quantifies exactly when
+  `findIndex` should become a hash map. Steady-state lookups allocate
+  zero. See `../element-states-performance.md`.
+- **Accessibility** — `fingerprint.compute` is ~1.4 ns; a full
+  1000-element frame diff (snapshot + rebuild + dirty/removed) is
+  ~128 µs (~0.8% of the 60 Hz budget), and content churn adds
+  negligible cost on top. See `../accessibility-diff-performance.md`.
 
 These are not acceptance criteria — they're the shape of the curve.
 Regressions show up as shape changes, not absolute-number changes.

--- a/docs/benchmarks/macos-aarch64-accessibility-benchmarks-05-30-2026.json
+++ b/docs/benchmarks/macos-aarch64-accessibility-benchmarks-05-30-2026.json
@@ -1,0 +1,89 @@
+{
+  "metadata": {
+    "module": "accessibility",
+    "os": "macos",
+    "arch": "aarch64",
+    "date": "05-30-2026",
+    "timestamp_unix": 1780111785,
+    "entry_count": 7
+  },
+  "benchmarks": [
+    {
+      "name": "fingerprint_flat_4k",
+      "operation_count": 4000,
+      "total_time_ns": 50003007,
+      "iterations": 8740,
+      "avg_time_ms": 0.005721167848970252,
+      "time_per_op_ns": 1.430291962242563,
+      "min_per_op_ns": 1.3645,
+      "p50_per_op_ns": 1.3855,
+      "p99_per_op_ns": 1.6875
+    },
+    {
+      "name": "fingerprint_parented_4k",
+      "operation_count": 4000,
+      "total_time_ns": 50001675,
+      "iterations": 8655,
+      "avg_time_ms": 0.005777201039861352,
+      "time_per_op_ns": 1.444300259965338,
+      "min_per_op_ns": 1.35425,
+      "p50_per_op_ns": 1.3855,
+      "p99_per_op_ns": 3.29175
+    },
+    {
+      "name": "frame_stable_64",
+      "operation_count": 65,
+      "total_time_ns": 50004301,
+      "iterations": 6035,
+      "avg_time_ms": 0.008285716818558409,
+      "time_per_op_ns": 127.47256643936014,
+      "min_per_op_ns": 116.03076923076924,
+      "p50_per_op_ns": 123.72307692307692,
+      "p99_per_op_ns": 251.92307692307693
+    },
+    {
+      "name": "frame_stable_256",
+      "operation_count": 257,
+      "total_time_ns": 50006506,
+      "iterations": 1591,
+      "avg_time_ms": 0.03143086486486486,
+      "time_per_op_ns": 122.29908507729519,
+      "min_per_op_ns": 115.59533073929961,
+      "p50_per_op_ns": 117.86381322957199,
+      "p99_per_op_ns": 168.44747081712063
+    },
+    {
+      "name": "frame_stable_1000",
+      "operation_count": 1001,
+      "total_time_ns": 50102130,
+      "iterations": 391,
+      "avg_time_ms": 0.12813843989769821,
+      "time_per_op_ns": 128.01042946822997,
+      "min_per_op_ns": 120.17182817182817,
+      "p50_per_op_ns": 124.70829170829171,
+      "p99_per_op_ns": 153.76223776223776
+    },
+    {
+      "name": "frame_churn_256",
+      "operation_count": 257,
+      "total_time_ns": 50005949,
+      "iterations": 1561,
+      "avg_time_ms": 0.03203456053811659,
+      "time_per_op_ns": 124.64809547905288,
+      "min_per_op_ns": 117.54474708171206,
+      "p50_per_op_ns": 120.13618677042801,
+      "p99_per_op_ns": 178.17898832684824
+    },
+    {
+      "name": "frame_churn_1000",
+      "operation_count": 1001,
+      "total_time_ns": 50075459,
+      "iterations": 387,
+      "avg_time_ms": 0.12939395090439276,
+      "time_per_op_ns": 129.2646862181746,
+      "min_per_op_ns": 122.54445554445554,
+      "p50_per_op_ns": 126.45754245754246,
+      "p99_per_op_ns": 156.4265734265734
+    }
+  ]
+}

--- a/docs/benchmarks/macos-aarch64-animation-benchmarks-05-30-2026.json
+++ b/docs/benchmarks/macos-aarch64-animation-benchmarks-05-30-2026.json
@@ -1,0 +1,111 @@
+{
+  "metadata": {
+    "module": "animation",
+    "os": "macos",
+    "arch": "aarch64",
+    "date": "05-30-2026",
+    "timestamp_unix": 1780111745,
+    "entry_count": 9
+  },
+  "benchmarks": [
+    {
+      "name": "spring_step_256",
+      "operation_count": 256,
+      "total_time_ns": 50002004,
+      "iterations": 19817,
+      "avg_time_ms": 0.0025231873643841145,
+      "time_per_op_ns": 9.856200642125447,
+      "min_per_op_ns": 11.390625,
+      "p50_per_op_ns": 11.71875,
+      "p99_per_op_ns": 17.25390625
+    },
+    {
+      "name": "spring_step_1k",
+      "operation_count": 1024,
+      "total_time_ns": 50005859,
+      "iterations": 5791,
+      "avg_time_ms": 0.008635099119323088,
+      "time_per_op_ns": 8.432713983713953,
+      "min_per_op_ns": 8.1376953125,
+      "p50_per_op_ns": 8.259765625,
+      "p99_per_op_ns": 14.689453125
+    },
+    {
+      "name": "spring_tick_atrest_256",
+      "operation_count": 256,
+      "total_time_ns": 50000099,
+      "iterations": 179259,
+      "avg_time_ms": 0.00027892657551364225,
+      "time_per_op_ns": 1.089556935600165,
+      "min_per_op_ns": 0.9765625,
+      "p50_per_op_ns": 1.13671875,
+      "p99_per_op_ns": 1.140625
+    },
+    {
+      "name": "spring_tick_atrest_1k",
+      "operation_count": 1024,
+      "total_time_ns": 50000027,
+      "iterations": 40269,
+      "avg_time_ms": 0.0012416505748839058,
+      "time_per_op_ns": 1.2125493895350643,
+      "min_per_op_ns": 1.138671875,
+      "p50_per_op_ns": 1.220703125,
+      "p99_per_op_ns": 1.46484375
+    },
+    {
+      "name": "frame_springs_16",
+      "operation_count": 16,
+      "total_time_ns": 50000128,
+      "iterations": 332032,
+      "avg_time_ms": 0.0001505882806476484,
+      "time_per_op_ns": 9.411767540478026,
+      "min_per_op_ns": 5.1875,
+      "p50_per_op_ns": 10.375,
+      "p99_per_op_ns": 10.4375
+    },
+    {
+      "name": "frame_springs_64",
+      "operation_count": 64,
+      "total_time_ns": 50000852,
+      "iterations": 54794,
+      "avg_time_ms": 0.0009125242179800708,
+      "time_per_op_ns": 14.258190905938607,
+      "min_per_op_ns": 13.015625,
+      "p50_per_op_ns": 13.671875,
+      "p99_per_op_ns": 14.96875
+    },
+    {
+      "name": "frame_springs_256",
+      "operation_count": 256,
+      "total_time_ns": 50004130,
+      "iterations": 8341,
+      "avg_time_ms": 0.005994980218199256,
+      "time_per_op_ns": 23.417891477340845,
+      "min_per_op_ns": 22.78515625,
+      "p50_per_op_ns": 23.2734375,
+      "p99_per_op_ns": 25.87890625
+    },
+    {
+      "name": "frame_spring_motions_64",
+      "operation_count": 64,
+      "total_time_ns": 50000941,
+      "iterations": 51205,
+      "avg_time_ms": 0.0009764855189922859,
+      "time_per_op_ns": 15.257586234254468,
+      "min_per_op_ns": 14.3125,
+      "p50_per_op_ns": 14.984375,
+      "p99_per_op_ns": 15.625
+    },
+    {
+      "name": "frame_spring_motions_256",
+      "operation_count": 256,
+      "total_time_ns": 50001144,
+      "iterations": 8081,
+      "avg_time_ms": 0.006187494617002846,
+      "time_per_op_ns": 24.169900847667368,
+      "min_per_op_ns": 23.4375,
+      "p50_per_op_ns": 23.92578125,
+      "p99_per_op_ns": 42.31640625
+    }
+  ]
+}

--- a/docs/benchmarks/macos-aarch64-element-states-benchmarks-05-30-2026.json
+++ b/docs/benchmarks/macos-aarch64-element-states-benchmarks-05-30-2026.json
@@ -1,0 +1,100 @@
+{
+  "metadata": {
+    "module": "element-states",
+    "os": "macos",
+    "arch": "aarch64",
+    "date": "05-30-2026",
+    "timestamp_unix": 1780111760,
+    "entry_count": 8
+  },
+  "benchmarks": [
+    {
+      "name": "get_occupancy_8",
+      "operation_count": 8,
+      "total_time_ns": 50000007,
+      "iterations": 1737930,
+      "avg_time_ms": 0.000028769862422537154,
+      "time_per_op_ns": 3.5962328028171444,
+      "min_per_op_ns": 0,
+      "p50_per_op_ns": 5.25,
+      "p99_per_op_ns": 10.5
+    },
+    {
+      "name": "get_occupancy_64",
+      "operation_count": 64,
+      "total_time_ns": 50000401,
+      "iterations": 40335,
+      "avg_time_ms": 0.0012396281393330852,
+      "time_per_op_ns": 19.369189677079458,
+      "min_per_op_ns": 18.21875,
+      "p50_per_op_ns": 19.53125,
+      "p99_per_op_ns": 23.4375
+    },
+    {
+      "name": "get_occupancy_512",
+      "operation_count": 512,
+      "total_time_ns": 50026086,
+      "iterations": 793,
+      "avg_time_ms": 0.0630845977301387,
+      "time_per_op_ns": 123.21210494167717,
+      "min_per_op_ns": 121.337890625,
+      "p50_per_op_ns": 121.90625,
+      "p99_per_op_ns": 135.41796875
+    },
+    {
+      "name": "get_occupancy_4096",
+      "operation_count": 4096,
+      "total_time_ns": 52245498,
+      "iterations": 13,
+      "avg_time_ms": 4.018884461538462,
+      "time_per_op_ns": 981.1729642427885,
+      "min_per_op_ns": 966.30859375,
+      "p50_per_op_ns": 976.0537109375,
+      "p99_per_op_ns": 1010.17236328125
+    },
+    {
+      "name": "with_hit_64",
+      "operation_count": 64,
+      "total_time_ns": 50001158,
+      "iterations": 33660,
+      "avg_time_ms": 0.0014854770647653001,
+      "time_per_op_ns": 23.210579136957815,
+      "min_per_op_ns": 22.125,
+      "p50_per_op_ns": 22.78125,
+      "p99_per_op_ns": 28
+    },
+    {
+      "name": "with_hit_512",
+      "operation_count": 512,
+      "total_time_ns": 50071472,
+      "iterations": 633,
+      "avg_time_ms": 0.07910185150078988,
+      "time_per_op_ns": 154.49580371248024,
+      "min_per_op_ns": 152.017578125,
+      "p50_per_op_ns": 152.42578125,
+      "p99_per_op_ns": 186.19921875
+    },
+    {
+      "name": "insert_remove_64",
+      "operation_count": 64,
+      "total_time_ns": 50002772,
+      "iterations": 6612,
+      "avg_time_ms": 0.007562427707199032,
+      "time_per_op_ns": 118.16293292498487,
+      "min_per_op_ns": 104.828125,
+      "p50_per_op_ns": 110.03125,
+      "p99_per_op_ns": 257.15625
+    },
+    {
+      "name": "insert_remove_512",
+      "operation_count": 512,
+      "total_time_ns": 50143294,
+      "iterations": 307,
+      "avg_time_ms": 0.1633332052117264,
+      "time_per_op_ns": 319.0101664291531,
+      "min_per_op_ns": 307.6171875,
+      "p50_per_op_ns": 312.5,
+      "p99_per_op_ns": 402.181640625
+    }
+  ]
+}

--- a/docs/benchmarks/macos-aarch64-scene-benchmarks-05-30-2026.json
+++ b/docs/benchmarks/macos-aarch64-scene-benchmarks-05-30-2026.json
@@ -1,0 +1,265 @@
+{
+  "metadata": {
+    "module": "scene",
+    "os": "macos",
+    "arch": "aarch64",
+    "date": "05-30-2026",
+    "timestamp_unix": 1780110278,
+    "entry_count": 23
+  },
+  "benchmarks": [
+    {
+      "name": "build_quads_256",
+      "operation_count": 256,
+      "total_time_ns": 50000498,
+      "iterations": 49644,
+      "avg_time_ms": 0.0010071810893562162,
+      "time_per_op_ns": 3.9343011302977198,
+      "min_per_op_ns": 3.578125,
+      "p50_per_op_ns": 3.90625,
+      "p99_per_op_ns": 4.71875
+    },
+    {
+      "name": "build_quads_2k",
+      "operation_count": 2000,
+      "total_time_ns": 50005093,
+      "iterations": 5689,
+      "avg_time_ms": 0.008789786078396906,
+      "time_per_op_ns": 4.394893039198453,
+      "min_per_op_ns": 4.0835,
+      "p50_per_op_ns": 4.208,
+      "p99_per_op_ns": 7.146
+    },
+    {
+      "name": "build_quads_16k",
+      "operation_count": 16000,
+      "total_time_ns": 50035584,
+      "iterations": 735,
+      "avg_time_ms": 0.06807562448979591,
+      "time_per_op_ns": 4.254726530612245,
+      "min_per_op_ns": 4.190125,
+      "p50_per_op_ns": 4.2135625,
+      "p99_per_op_ns": 4.8828125
+    },
+    {
+      "name": "build_glyphs_2k",
+      "operation_count": 2000,
+      "total_time_ns": 50001871,
+      "iterations": 6388,
+      "avg_time_ms": 0.0078274688478397,
+      "time_per_op_ns": 3.9137344239198497,
+      "min_per_op_ns": 3.7705,
+      "p50_per_op_ns": 3.8335,
+      "p99_per_op_ns": 6.4375
+    },
+    {
+      "name": "build_glyphs_16k",
+      "operation_count": 16000,
+      "total_time_ns": 50012142,
+      "iterations": 809,
+      "avg_time_ms": 0.06181970580964154,
+      "time_per_op_ns": 3.863731613102596,
+      "min_per_op_ns": 3.765625,
+      "p50_per_op_ns": 3.796875,
+      "p99_per_op_ns": 4.7604375
+    },
+    {
+      "name": "build_interleaved_2k",
+      "operation_count": 4000,
+      "total_time_ns": 50034927,
+      "iterations": 1365,
+      "avg_time_ms": 0.03665562417582417,
+      "time_per_op_ns": 9.163906043956043,
+      "min_per_op_ns": 8.9165,
+      "p50_per_op_ns": 9.125,
+      "p99_per_op_ns": 11.25
+    },
+    {
+      "name": "build_dashboard_small",
+      "operation_count": 265,
+      "total_time_ns": 50000390,
+      "iterations": 52596,
+      "avg_time_ms": 0.0009506500494334169,
+      "time_per_op_ns": 3.587358677107234,
+      "min_per_op_ns": 3.30188679245283,
+      "p50_per_op_ns": 3.460377358490566,
+      "p99_per_op_ns": 4.245283018867925
+    },
+    {
+      "name": "build_dashboard_medium",
+      "operation_count": 1537,
+      "total_time_ns": 50000617,
+      "iterations": 9305,
+      "avg_time_ms": 0.005373521440085975,
+      "time_per_op_ns": 3.496110240784629,
+      "min_per_op_ns": 3.36174365647365,
+      "p50_per_op_ns": 3.443070917371503,
+      "p99_per_op_ns": 6.099544567338972
+    },
+    {
+      "name": "build_dashboard_large",
+      "operation_count": 5041,
+      "total_time_ns": 50004061,
+      "iterations": 2564,
+      "avg_time_ms": 0.019502363884555382,
+      "time_per_op_ns": 3.8687490348255076,
+      "min_per_op_ns": 3.661575084308669,
+      "p50_per_op_ns": 3.843483435826225,
+      "p99_per_op_ns": 4.703035112080936
+    },
+    {
+      "name": "batch_quads_16k",
+      "operation_count": 16000,
+      "total_time_ns": 50014724,
+      "iterations": 3172,
+      "avg_time_ms": 0.015767567465321562,
+      "time_per_op_ns": 0.9854729665825976,
+      "min_per_op_ns": 0.96875,
+      "p50_per_op_ns": 0.979125,
+      "p99_per_op_ns": 1.237
+    },
+    {
+      "name": "batch_glyphs_16k",
+      "operation_count": 16000,
+      "total_time_ns": 50001580,
+      "iterations": 3443,
+      "avg_time_ms": 0.01452267789718269,
+      "time_per_op_ns": 0.9076673685739182,
+      "min_per_op_ns": 0.890625,
+      "p50_per_op_ns": 0.8984375,
+      "p99_per_op_ns": 1.16925
+    },
+    {
+      "name": "batch_interleaved_2k",
+      "operation_count": 4000,
+      "total_time_ns": 50072034,
+      "iterations": 642,
+      "avg_time_ms": 0.07799382242990655,
+      "time_per_op_ns": 19.498455607476636,
+      "min_per_op_ns": 18.9375,
+      "p50_per_op_ns": 19.104,
+      "p99_per_op_ns": 25.38525
+    },
+    {
+      "name": "batch_dashboard_medium",
+      "operation_count": 1537,
+      "total_time_ns": 50004091,
+      "iterations": 14093,
+      "avg_time_ms": 0.003548150925991627,
+      "time_per_op_ns": 2.308491168504637,
+      "min_per_op_ns": 2.249837345478204,
+      "p50_per_op_ns": 2.3038386467143788,
+      "p99_per_op_ns": 2.5751463890696162
+    },
+    {
+      "name": "batch_dashboard_large",
+      "operation_count": 5041,
+      "total_time_ns": 50004146,
+      "iterations": 4848,
+      "avg_time_ms": 0.010314386551155116,
+      "time_per_op_ns": 2.046099296003792,
+      "min_per_op_ns": 1.967070025788534,
+      "p50_per_op_ns": 2.0416584011108907,
+      "p99_per_op_ns": 2.3556833961515573
+    },
+    {
+      "name": "sort_quads_1k",
+      "operation_count": 1000,
+      "total_time_ns": 50116285,
+      "iterations": 146,
+      "avg_time_ms": 0.34326222602739725,
+      "time_per_op_ns": 343.2622260273973,
+      "min_per_op_ns": 338.666,
+      "p50_per_op_ns": 340.042,
+      "p99_per_op_ns": 359.291
+    },
+    {
+      "name": "sort_quads_8k",
+      "operation_count": 8000,
+      "total_time_ns": 51138040,
+      "iterations": 16,
+      "avg_time_ms": 3.1961275,
+      "time_per_op_ns": 399.5159375,
+      "min_per_op_ns": 396.80725,
+      "p50_per_op_ns": 399.15625,
+      "p99_per_op_ns": 403.734375
+    },
+    {
+      "name": "sort_quads_32k",
+      "operation_count": 32000,
+      "total_time_ns": 70937126,
+      "iterations": 5,
+      "avg_time_ms": 14.1874252,
+      "time_per_op_ns": 443.3570375,
+      "min_per_op_ns": 442.5260625,
+      "p50_per_op_ns": 442.63021875,
+      "p99_per_op_ns": 444.19921875
+    },
+    {
+      "name": "clip_depth_8",
+      "operation_count": 8,
+      "total_time_ns": 50000032,
+      "iterations": 1288471,
+      "avg_time_ms": 0.00003880571002374132,
+      "time_per_op_ns": 4.850713752967665,
+      "min_per_op_ns": 0,
+      "p50_per_op_ns": 5.25,
+      "p99_per_op_ns": 10.5
+    },
+    {
+      "name": "clip_depth_16",
+      "operation_count": 16,
+      "total_time_ns": 50000005,
+      "iterations": 501039,
+      "avg_time_ms": 0.00009979264089222596,
+      "time_per_op_ns": 6.237040055764123,
+      "min_per_op_ns": 2.5625,
+      "p50_per_op_ns": 5.25,
+      "p99_per_op_ns": 7.8125
+    },
+    {
+      "name": "clip_depth_32",
+      "operation_count": 32,
+      "total_time_ns": 50000113,
+      "iterations": 163524,
+      "avg_time_ms": 0.00030576620557227075,
+      "time_per_op_ns": 9.55519392413346,
+      "min_per_op_ns": 3.90625,
+      "p50_per_op_ns": 9.125,
+      "p99_per_op_ns": 10.4375
+    },
+    {
+      "name": "frame_dashboard_small",
+      "operation_count": 265,
+      "total_time_ns": 50001597,
+      "iterations": 28212,
+      "avg_time_ms": 0.0017723520842194813,
+      "time_per_op_ns": 6.688121072526344,
+      "min_per_op_ns": 6.286792452830189,
+      "p50_per_op_ns": 6.60377358490566,
+      "p99_per_op_ns": 7.233962264150944
+    },
+    {
+      "name": "frame_dashboard_medium",
+      "operation_count": 1537,
+      "total_time_ns": 50005280,
+      "iterations": 5606,
+      "avg_time_ms": 0.008919957188726365,
+      "time_per_op_ns": 5.803485483881825,
+      "min_per_op_ns": 5.665582303188029,
+      "p50_per_op_ns": 5.77423552374756,
+      "p99_per_op_ns": 6.506180871828237
+    },
+    {
+      "name": "frame_dashboard_large",
+      "operation_count": 5041,
+      "total_time_ns": 50015533,
+      "iterations": 1658,
+      "avg_time_ms": 0.030166183956574187,
+      "time_per_op_ns": 5.98416662498992,
+      "min_per_op_ns": 5.785756794286848,
+      "p50_per_op_ns": 5.951200158698671,
+      "p99_per_op_ns": 7.223963499305693
+    }
+  ]
+}

--- a/docs/element-states-performance.md
+++ b/docs/element-states-performance.md
@@ -1,0 +1,179 @@
+# Element-State Pool Performance
+
+Benchmark notes and design analysis for `src/context/element_states.zig` — the
+keyed pool that backs `cx.with_element_state(...)` and holds every stateful
+widget's retained state under a `(id_hash, type_id) -> *S` key. Companion to
+`scene-data-plane-performance.md`; numbers are produced by
+`src/context/element_states_benchmarks.zig` (`zig build bench-element-states`).
+
+## Context
+
+`ElementStates` is the pool PR 8 introduced to collapse the per-type widget maps
+on the old `WidgetStore` (`text_inputs`, `text_areas`, `code_editors`,
+`scroll_containers`, `select_states`) into one table. Its lookup runs once per
+stateful widget per frame, so its hot path is a per-frame cost. `bench-context`
+covers the dispatch tree and entity map; this suite isolates the pool.
+
+The pool's lookup is an explicit linear scan, and `findIndex` says so:
+
+> Linear scan over the dense prefix. O(count). … at this size the
+> branch-predictor friendliness of the linear walk beats a hash map's
+> pointer-chasing for the small-N case (most elements touch < 64 distinct
+> states). **If a profile shows otherwise we can swap in an `AutoHashMap`** keyed
+> by `Key.hash()` without changing the public surface.
+
+`bench-element-states` *is* that profile. It measures lookup cost as a function
+of occupancy and pins down exactly where the linear scan stops being the right
+call — the same way the scene suite's sort measurement prescribed
+sort-keys-not-payloads.
+
+---
+
+## The suite
+
+Run: `zig build bench-element-states` (add `-Dbench-json-dir=<dir>` for JSON).
+Validate (Debug, assertions live): the `validate:` tests run under `zig build
+test` — lookup correctness, churn returning the pool to empty, and the
+**steady-state zero-allocation invariant** via a counting allocator.
+
+| Group | What it times | Reports |
+| --- | --- | --- |
+| Lookup vs occupancy | one `get` per present key at 8/64/512/4096 entries | ns / lookup |
+| Get-or-create hit | one `withElementState` per present key | ns / lookup |
+| Insert + remove | `count` `withElementState` misses + `remove`s | ns / (insert+remove) pair |
+
+The lookup groups walk every present key once, so the scanned position averages
+`occupancy/2` and the reported ns/op is the *average* lookup at that fill level.
+All groups collect p50/p99; the gate classifies on the best-of-N minimum.
+
+---
+
+## Results (macOS arm64, M-series, `ReleaseFast`)
+
+These are the shape of the curve, not acceptance criteria.
+
+### Lookup vs occupancy — a clean O(count) line
+
+| Test | Entries | ns/lookup | p99 | implied ns/comparison |
+| --- | --- | --- | --- | --- |
+| get_occupancy_8 | 8 | 3.60 | 10.50 | ~0.90 |
+| get_occupancy_64 | 64 | 19.37 | 23.44 | ~0.61 |
+| get_occupancy_512 | 512 | 123.21 | 135.42 | ~0.48 |
+| get_occupancy_4096 | 4096 | 981.17 | 1010.17 | ~0.48 |
+
+The average lookup scans `occupancy/2` entries, so dividing ns/lookup by that
+gives the per-comparison cost — and it converges to **~0.48 ns per `Key.eql`**
+(two `u64` compares) from 512 entries up. That is a textbook tight, cache-
+resident, branch-predictor-friendly linear scan; the per-comparison cost is
+*lower* at scale, not higher, because the loop amortizes its fixed overhead. The
+small-N rows (~0.9 ns/cmp at 8) are dominated by that fixed overhead, not the
+scan.
+
+The number that matters is the absolute lookup cost at the top: **a single
+lookup in a 4096-entry pool averages ~981 ns** because it walks ~2048 entries.
+
+### Get-or-create hit — the real call site matches `get`
+
+| Test | Entries | ns/lookup | p99 |
+| --- | --- | --- | --- |
+| with_hit_64 | 64 | 23.21 | 28.00 |
+| with_hit_512 | 512 | 154.50 | 186.20 |
+
+`withElementState` on a present key is `get` plus a capacity assert and the
+comptime-`default` plumbing — ~20% over the bare `get` at the same occupancy,
+same linear shape. This is the path `cx.with_element_state(...)` actually walks,
+and the validate test confirms it **allocates zero** on the hit path.
+
+### Insert + remove — the allocating control plane
+
+| Test | Pairs | ns/pair | p99 |
+| --- | --- | --- | --- |
+| insert_remove_64 | 64 | 118.16 | 257.16 |
+| insert_remove_512 | 512 | 319.01 | 402.18 |
+
+The miss path is `create(S)` + a full scan (the key isn't there yet); `remove`
+is a scan + swap-remove + `destroy`. This is the only group that touches the
+heap, and at ~118–319 ns/pair it is dominated by the allocator, not the scan.
+Widget mount/unmount churn, not steady-state polling, so this is a control-plane
+cost (CLAUDE.md §8) and is expected to allocate.
+
+---
+
+## The O(count) scan becomes O(count²) per frame at the top end
+
+The lookup is O(count). But a *frame* calls `withElementState` once per present
+state, so a frame that touches all `N` states costs `N × O(N) = O(N²)`. Folding
+the per-comparison constant (~0.48 ns) and the average scan length (`N/2`) in:
+
+```
+per-frame state lookup ≈ N × 0.24·N ns = 0.24·N² ns
+```
+
+| Distinct states in a frame | Full-frame state lookup | % of 60 Hz budget |
+| --- | --- | --- |
+| 64 | ~1.2 µs | 0.007% |
+| 512 | ~63 µs | 0.4% |
+| 4096 | ~4.0 ms | **24%** |
+
+For the **common case the `findIndex` comment names — under ~64 distinct states —
+the linear scan is the right answer**: ~1.2 µs/frame, and a hash map's hashing +
+pointer-chasing would only add overhead at that size. But a pathological frame —
+a 4096-row virtual list where every row is a distinct stateful widget — would
+spend **~4 ms, a quarter of the 60 Hz budget, in state lookup alone.**
+
+---
+
+## Recommended optimization: hash-map the lookup above a threshold
+
+`findIndex` already anticipates the fix and promises it costs nothing at the API
+surface. This benchmark sizes it:
+
+1. Add an `AutoHashMapUnmanaged(Key, u32)` (or `AutoArrayHashMapUnmanaged`) side
+   index mapping `Key.hash()` → slot, maintained alongside the existing dense
+   `entries` array (the array stays for dense iteration and swap-remove; the map
+   only accelerates `findIndex`).
+2. `get` / `withElementState` / `insert` / `remove` consult the map instead of
+   scanning. Swap-remove updates one map entry (the moved tail's slot).
+
+Expected win on the O(N²) frame: a hash lookup is ~O(1) at a fixed ~10–20 ns
+regardless of `N`, so the full-frame 4096-state cost drops from **~4 ms toward
+~60 µs (~65×)**. The map's memory is bounded by `MAX_ELEMENT_STATES` (4096), so
+it stays on the static-allocation path (CLAUDE.md §2/§4).
+
+**When to actually do it:** only if a real UI drives occupancy into the
+hundreds-to-thousands of *distinct* states per frame (large virtual/uniform
+lists where every row is independently stateful). Until then the linear scan
+wins on constant factors for the <64 case, exactly as the comment claims — the
+honest move is to keep the scan and let `bench-element-states` watch the curve.
+
+**Gating:** `get_occupancy_{8,64,512,4096}` already captures the line. If
+`findIndex` is hash-mapped, the high-occupancy entries should flatten from
+~981 ns toward a constant; `bench-compare` will show that as a large
+"improvement" and lock in the new shape.
+
+---
+
+## External validation
+
+- **Linear scan vs hash map at small N.** The result that a flat linear scan
+  beats a hash map below a few dozen elements — and that the crossover is in the
+  tens-to-low-hundreds — is a well-worn systems result (constant factors and
+  cache locality dominate at small N; this is why `std`-style flat maps and
+  small-vector optimizations exist). The ~0.48 ns/comparison measured here is
+  consistent with two L1-resident `u64` compares per step on M-series silicon.
+- **Same discipline as the sibling pools.** `Globals` and `SubscriberSet` use the
+  identical dense-prefix linear scan, deliberately (CLAUDE.md §1). A hash-map
+  retrofit here would be the template for those too if their occupancy ever
+  warrants it — but the same "measure first" rule applies; none is benched into
+  the danger zone today.
+
+---
+
+## References
+
+- Source: `src/context/element_states_benchmarks.zig`,
+  `src/context/element_states.zig`
+- Sibling pools sharing the linear-scan discipline:
+  `src/context/global.zig`, `src/context/subscriber_set.zig`
+- PR 8 rationale (unified element-state pool): `docs/cleanup-implementation-plan.md`
+- Baselines + regression workflow: `docs/benchmarks/README.md`

--- a/docs/scene-data-plane-performance.md
+++ b/docs/scene-data-plane-performance.md
@@ -1,0 +1,212 @@
+# Scene Data-Plane Performance
+
+Benchmark notes and design analysis for the scene → batch → frame pipeline
+(`src/scene/`), the data plane that feeds the GPU. Companion to
+`text-rendering-performance.md`; numbers are produced by
+`src/scene/benchmarks.zig` (`zig build bench-scene`).
+
+## Context
+
+The existing suites (`bench`, `bench-context`, `bench-core`, `bench-text`)
+thoroughly cover the **control plane** — layout, the dispatch tree, core
+geometry, text shaping/glyph caching. What was unbenched until now is the
+**data plane**: the scene assembly that turns those results into GPU
+instances, batches them in draw order, and drains them per frame.
+
+This is exactly the gap `CLAUDE.md` §7 ("how many vertices / texture uploads
+per frame?") and §8 ("batching is religion") call out. `bench-scene` measures
+it directly: the per-frame instance emission, how cleanly primitives batch,
+the draw-order sort, the clip stack, and the end-to-end frame against the
+frame budget.
+
+**Scope.** This measures the headless scene→batch portion of the frame. The
+platform/GPU submission in `runtime/frame.zig` needs a live window, a Metal
+device, and the CoreText stack, so it cannot run in a headless benchmark. The
+scene data plane is the part that is both measurable here and the
+GPU-bandwidth proxy.
+
+---
+
+## The suite
+
+Run: `zig build bench-scene` (add `-Dbench-json-dir=<dir>` to capture JSON).
+Validate (Debug, assertions live): the `validate:` tests in
+`src/scene/benchmarks.zig` run under `zig build test` — they check primitive
+counts, batch coalescing, sort correctness, clip balance, and the
+**steady-state zero-allocation invariant** via a counting allocator.
+
+| Group | What it times | Reports |
+| --- | --- | --- |
+| Scene build | `clear()` + `insertQuad`/`insertGlyph`/`insertShadow` | ns / primitive emitted |
+| Batch iteration | `BatchIterator.next()` drain of a finished scene | ns / primitive + **batch count** |
+| Draw-order sort | `finish()` pdq over a shuffled quad array | ns / quad sorted |
+| Clip stack | `pushClip` (with intersection) + `popClip` pairs | ns / nesting level |
+| Frame e2e | `clear → build → finish → drain` | whole-frame µs (avg + p99) vs budget |
+
+All groups collect p50/p99 percentiles; the regression gate
+(`bench-compare`) classifies on the best-of-N minimum.
+
+---
+
+## Results (macOS arm64, M-series, `ReleaseFast`)
+
+These are the shape of the curve, not acceptance criteria.
+
+### Scene build — flat ~4 ns/primitive, zero allocations
+
+| Test | Ops | ns/op | p99 |
+| --- | --- | --- | --- |
+| build_quads_256 | 256 | 3.98 | 4.72 |
+| build_quads_2k | 2000 | 4.37 | 8.40 |
+| build_quads_16k | 16000 | 4.32 | 5.59 |
+| build_glyphs_16k | 16000 | 4.06 | 5.33 |
+| build_interleaved_2k | 4000 | 9.45 | 13.35 |
+| build_dashboard_large | 5041 | 3.94 | 5.51 |
+
+Flat from 256 → 16k primitives with no super-linear creep; the passing
+zero-alloc test confirms the static-allocation policy (§2) holds in steady
+state — no per-insert growth jitter. Interleaved emission is ~2× because it
+bounces between two append targets (cache lines for the quad and glyph
+arrays).
+
+### Batch iteration — coalescing quantified
+
+| Test | Ops | ns/op | Batches |
+| --- | --- | --- | --- |
+| batch_quads_16k | 16000 | 1.00 | 1 |
+| batch_glyphs_16k | 16000 | 0.94 | 1 |
+| batch_interleaved_2k | 4000 | 19.89 | 4000 |
+| batch_dashboard_medium | 1537 | 2.39 | 145 |
+| batch_dashboard_large | 5041 | 2.08 | 361 |
+
+This is the §8 batching thesis made concrete: coalesced same-type primitives
+drain at ~1 ns each in a single batch; fully-interleaved primitives cost ~20×
+because each `next()` carries a fixed 9-primitive-type scan and emits one
+batch per primitive. Realistic mixed scenes land at ~2 ns/prim with healthy
+batch sizes (avg ~14).
+
+### Draw-order sort — the one hot spot
+
+| Test | Ops | ns/quad | per `finish()` |
+| --- | --- | --- | --- |
+| sort_quads_1k | 1000 | 354.6 | ~0.35 ms |
+| sort_quads_8k | 8000 | 410.5 | ~3.3 ms |
+| sort_quads_32k | 32000 | 457.2 | **~14.6 ms** |
+
+Per-quad cost scales sub-linearly (correct for a comparison sort), but the
+**constant is high**: `std.sort.pdq` moves whole 128-byte `Quad` structs
+(`QUAD_SIZE` in `core/limits.zig`). A large out-of-order scene can consume an
+entire 60 Hz frame in the sort alone. See the analysis and fix below.
+
+### Clip stack — negligible
+
+5–9.5 ns per push/pop pair (depths 8/16/32) — essentially at timer
+resolution. Not a concern.
+
+### Frame e2e — data plane is <0.4% of budget
+
+| Test | Prims | Batches | Avg/frame | p99/frame | % 60 Hz | % 120 Hz |
+| --- | --- | --- | --- | --- | --- | --- |
+| frame_dashboard_small | 265 | 37 | 1.83 µs | 2.17 µs | 0.01% | 0.02% |
+| frame_dashboard_medium | 1537 | 145 | 9.21 µs | 17.71 µs | 0.06% | 0.11% |
+| frame_dashboard_large | 5041 | 361 | 30.73 µs | 44.46 µs | 0.18% | 0.37% |
+
+The frame group uses in-order builds (no overlays), so it exercises the
+no-sort happy path. The takeaway: scene assembly is not where the frame
+budget goes — layout, text shaping, and GPU submission are. Tails are tight
+(build/batch p99 ≈ 1.2–1.5× p50), which is what frame pacing needs.
+
+---
+
+## External validation
+
+The numbers were cross-checked against published claims. gooey's scene
+primitives are directly modeled on GPUI, so it is the primary reference.
+
+### Frame budget (GPUI / Zed)
+
+The GPUI rendering blog opens with *"an application only has **8.33 ms** per
+frame to push pixels to screen"* — exactly our 120 Hz budget. Our 5041-prim
+frame at 30.7 µs (**0.37%** of 8.33 ms) is consistent with GPUI's thesis that
+scene assembly is cheap and the budget is spent elsewhere.
+
+### Draw order (GPUI)
+
+GPUI: *"starts by drawing all shadows, followed by all rectangles, then all
+glyphs… a rectangle could never be rendered on top of a glyph."* That is
+exactly gooey's `BatchIterator` tie-break (`shadow < quad < glyph < svg <
+image < …`), and GPUI's `Layer { shadows, rectangles, glyphs, … }` mirrors
+gooey's per-type arrays. The lineage is faithful.
+
+**The divergence that explains our sort cost:** GPUI avoids per-primitive
+order-sorting entirely — it uses fixed type order plus coarse
+layers/stacking contexts for z-ordering. gooey generalized that into a
+per-primitive `order` field plus an interleaving iterator. More flexible, but
+it is what introduces the sort (and the interleaved worst case).
+
+### Sorting (Christer Ericson, "Order your graphics draw calls around!", 2008)
+
+The canonical draw-call-sorting reference says to sort an array of
+**`(key, value)` pairs where the value is a pointer/offset** to the draw-call
+data — never the payload. His claim: *"there really is no problem sorting
+**5,000 or even 10,000 draw calls** each frame this way"* on **2008-era PS3**
+hardware.
+
+We sort 8k on a modern M-series and it costs 3.3 ms — the gap is almost
+entirely because we move 128-byte structs where he moves tiny keys. This both
+corroborates the hot-spot finding and prescribes the fix.
+
+### Rebuild-every-frame (Dear ImGui)
+
+The IMGUI paradigm builds draw data fresh each frame (*"most is built up every
+frame"*). Our `clear() + rebuild` at flat ~4 ns/prim with zero allocations is
+the cheap rebuild that model assumes — and the zero-alloc test proves we avoid
+the GC/allocation jitter the GPUI blog blames for Electron's missed frames.
+
+> Caveat: Ericson's numbers are 2008 PS3 SPUs; GPUI's are modern Macs. Treat
+> absolute cross-era figures as order-of-magnitude sanity checks. The
+> structural claims (same draw order as GPUI, sort keys not payloads, 8.33 ms
+> budget) are the robust takeaways.
+
+---
+
+## Recommended optimization: sort keys, not payloads
+
+`Scene.finish()` currently calls `std.sort.pdq` directly over the
+`ArrayListUnmanaged(Quad)` (and the other per-type arrays), so every swap
+moves a 128-byte `Quad`. The textbook fix (Ericson's `(key, value)` scheme)
+is to sort a compact key array and gather:
+
+1. Build a scratch `[]struct { order: u32, index: u32 }` (8 bytes/entry vs
+   128) — or pack `order` and `index` into a single `u64` key.
+2. `pdq` the key array (8× fewer bytes moved per swap, cache-resident).
+3. Gather the payload array into sorted position once, in a single linear
+   pass.
+
+Expected win: ~10× on the sort path (sorting 8-byte keys instead of 128-byte
+structs), which would bring an 8k-quad sort from ~3.3 ms toward the
+sub-millisecond range Ericson describes. The key array is fixed-capacity
+(bounded by `MAX_QUADS_PER_FRAME`), so it stays on the static-allocation path.
+
+This only affects scenes that trigger the sort (`insertQuadWithOrder`,
+overlays, canvas z-ordering); the common in-order frame never sorts. But it
+removes a latent tail-latency spike that scales straight into the frame budget
+for overlay-heavy scenes.
+
+**Gating:** `bench-scene` already measures `sort_quads_{1k,8k,32k}`. Add an
+index-sort-vs-struct-sort comparison entry on the same shuffled inputs to size
+the win on our hardware and let `bench-compare` lock it in.
+
+---
+
+## References
+
+- Scandurra, A. *Leveraging Rust and the GPU to render user interfaces at
+  120 FPS* (GPUI), Zed, 2023 — <https://zed.dev/blog/videogame>
+- Ericson, C. *Order your graphics draw calls around!*, 2008 —
+  <https://realtimecollisiondetection.net/blog/?p=86>
+- Dear ImGui — *About the IMGUI paradigm* —
+  <https://github.com/ocornut/imgui/wiki/About-the-IMGUI-paradigm>
+- Source: `src/scene/benchmarks.zig`, `src/scene/scene.zig`,
+  `src/scene/batch_iterator.zig`, `src/core/limits.zig`
+- Baselines + regression workflow: `docs/benchmarks/README.md`

--- a/src/accessibility/benchmarks.zig
+++ b/src/accessibility/benchmarks.zig
@@ -1,0 +1,591 @@
+//! Accessibility Module Benchmarks
+//!
+//! Benchmark suite for the per-frame accessibility diff (`accessibility/tree.zig`
+//! + `fingerprint.zig`). Immediate mode rebuilds the a11y tree every frame, then
+//! diffs it against the previous frame to compute the dirty/removed sets the
+//! platform bridge syncs. This suite measures that whole cycle against the frame
+//! budget, plus the fingerprint hash underneath it.
+//!
+//! Run as executable: zig build bench-accessibility
+//! Quick tests only:  zig test src/accessibility/benchmarks.zig (validates the
+//!                    diff produces the expected dirty/removed counts)
+//!
+//! Groups:
+//!   - Fingerprint    — `fingerprint.compute` micro-bench (the pure hot fn that
+//!                      runs once per element per frame). Reports ns / call.
+//!   - Frame diff     — `beginFrame → pushElement×N (+popElement) → endFrame`,
+//!                      the full snapshot + rebuild + dirty/removed diff, reported
+//!                      against the 16.6 ms (60 Hz) / 8.3 ms (120 Hz) budget.
+//!                      Two variants: a stable tree (steady state, no churn) and
+//!                      a churn tree (a fraction of elements change content each
+//!                      frame, driving the dirty + auto-announce path).
+//!
+//! Why this shape: it mirrors the scene suite's frame-e2e group directly — a
+//! whole-frame µs number against the budget is the only thing that answers "does
+//! the a11y diff fit the frame?". The fingerprint micro-bench sits underneath as
+//! the per-element primitive. The tree uses static arrays end to end, so there is
+//! no allocator churn to gate (CLAUDE.md §2); the only heap touch is the one-time
+//! `Tree` allocation (it is ~350 KiB, so it is heap-allocated per §14).
+
+const std = @import("std");
+const gooey = @import("gooey");
+const bench = @import("bench");
+
+const Allocator = std.mem.Allocator;
+
+/// Minimal `Instant.now()` / `.since()` shim over `std.Io.Clock.awake`, kept
+/// local to the benchmark module so every sample site reads as a two-line
+/// capture-then-diff. `.awake` is the monotonic clock — deltas here can never
+/// go negative regardless of NTP or sysadmin clock edits.
+const time = struct {
+    inline fn benchIo() std.Io {
+        return std.Io.Threaded.global_single_threaded.io();
+    }
+
+    const Instant = struct {
+        ts: std.Io.Timestamp,
+
+        inline fn now() Instant {
+            return .{ .ts = std.Io.Timestamp.now(benchIo(), .awake) };
+        }
+
+        inline fn since(self: Instant, earlier: Instant) u64 {
+            const ns: i96 = earlier.ts.durationTo(self.ts).toNanoseconds();
+            std.debug.assert(ns >= 0);
+            return @intCast(ns);
+        }
+    };
+};
+
+const a11y = gooey.accessibility;
+const Tree = a11y.Tree;
+const fingerprint = a11y.fingerprint;
+const Fingerprint = fingerprint.Fingerprint;
+const constants = a11y.constants;
+const LayoutId = gooey.layout.LayoutId;
+
+const MAX_ELEMENTS = constants.MAX_ELEMENTS;
+
+// =============================================================================
+// Benchmark Configuration
+// =============================================================================
+
+/// Adaptive warmup iterations based on operation count.
+fn getWarmupIterations(operation_count: u32) u32 {
+    std.debug.assert(operation_count > 0);
+    if (operation_count >= 10000) return 2;
+    if (operation_count >= 5000) return 3;
+    return 5;
+}
+
+/// Adaptive minimum sample iterations based on operation count.
+fn getMinSampleIterations(operation_count: u32) u32 {
+    std.debug.assert(operation_count > 0);
+    if (operation_count >= 10000) return 5;
+    if (operation_count >= 5000) return 8;
+    return 10;
+}
+
+/// Minimum wall-clock time to sample before concluding a benchmark.
+const MIN_SAMPLE_TIME_NS: u64 = 50 * std.time.ns_per_ms;
+
+/// Maximum per-iteration samples collected for percentile computation.
+const MAX_SAMPLE_COUNT: u32 = 4096;
+
+/// Per-frame budgets in nanoseconds for the frame-budget summary.
+const FRAME_BUDGET_60HZ_NS: f64 = 16_666_667.0;
+const FRAME_BUDGET_120HZ_NS: f64 = 8_333_333.0;
+
+/// Fixed name length for generated element names. Wide enough to hold
+/// "a11y_elem_" plus a multi-digit index without truncation.
+const NAME_STRIDE: u32 = 20;
+
+/// Table width for benchmark output formatting (characters per row).
+const TABLE_WIDTH = 99;
+
+// =============================================================================
+// Iteration Sample Collection and Percentile Computation
+// =============================================================================
+
+/// Per-iteration timing data for percentile analysis. Fixed capacity avoids
+/// dynamic allocation during benchmark runs. Mirrors the scene/animation suites.
+const IterationSamples = struct {
+    times_ns: [MAX_SAMPLE_COUNT]u64,
+    count: u32,
+
+    fn init() IterationSamples {
+        return .{ .times_ns = undefined, .count = 0 };
+    }
+
+    fn record(self: *IterationSamples, elapsed_ns: u64) void {
+        if (self.count < MAX_SAMPLE_COUNT) {
+            self.times_ns[self.count] = elapsed_ns;
+            self.count += 1;
+        }
+    }
+
+    /// Sort collected samples and extract min/p50/p99 percentiles as ns/op.
+    fn computePercentiles(self: *IterationSamples, operation_count: u32) PercentileResult {
+        std.debug.assert(self.count > 0);
+        std.debug.assert(operation_count > 0);
+
+        const slice = self.times_ns[0..self.count];
+        std.mem.sort(u64, slice, {}, struct {
+            fn lessThan(_: void, a: u64, b: u64) bool {
+                return a < b;
+            }
+        }.lessThan);
+
+        const last_index = self.count - 1;
+        const last_f: f64 = @floatFromInt(last_index);
+        const p50_index: u32 = @intFromFloat(0.50 * last_f);
+        const p99_index: u32 = @intFromFloat(@min(0.99 * last_f, last_f));
+        const ops_f: f64 = @floatFromInt(operation_count);
+
+        return .{
+            .min_per_op_ns = @as(f64, @floatFromInt(slice[0])) / ops_f,
+            .p50_per_op_ns = @as(f64, @floatFromInt(slice[p50_index])) / ops_f,
+            .p99_per_op_ns = @as(f64, @floatFromInt(slice[p99_index])) / ops_f,
+        };
+    }
+};
+
+/// Percentile statistics computed from iteration samples.
+const PercentileResult = struct {
+    min_per_op_ns: f64,
+    p50_per_op_ns: f64,
+    p99_per_op_ns: f64,
+};
+
+// =============================================================================
+// Benchmark Results
+// =============================================================================
+
+const BenchmarkResult = struct {
+    name: []const u8,
+    operation_count: u32,
+    total_time_ns: u64,
+    iterations: u32,
+    min_per_op_ns: f64,
+    p50_per_op_ns: f64,
+    p99_per_op_ns: f64,
+
+    pub fn timePerOpNs(self: BenchmarkResult) f64 {
+        std.debug.assert(self.iterations > 0);
+        std.debug.assert(self.operation_count > 0);
+        const avg_ns = @as(f64, @floatFromInt(self.total_time_ns)) /
+            @as(f64, @floatFromInt(self.operation_count * self.iterations));
+        return avg_ns;
+    }
+
+    pub fn print(self: BenchmarkResult) void {
+        std.debug.assert(self.iterations > 0);
+        std.debug.assert(self.operation_count > 0);
+        std.debug.print(
+            "| {s:<40} | {d:>7} | {d:>9.2} | {d:>9.2} | {d:>9.2} | {d:>6} |\n",
+            .{ self.name, self.operation_count, self.timePerOpNs(), self.p50_per_op_ns, self.p99_per_op_ns, self.iterations },
+        );
+    }
+
+    /// Frame-budget summary line: whole-frame time (avg + p99) in microseconds
+    /// and avg as a percentage of the 60 Hz and 120 Hz budgets.
+    pub fn printFrameBudget(self: BenchmarkResult) void {
+        std.debug.assert(self.iterations > 0);
+        std.debug.assert(self.operation_count > 0);
+        const avg_ns: f64 = @as(f64, @floatFromInt(self.total_time_ns)) /
+            @as(f64, @floatFromInt(self.iterations));
+        const p99_ns: f64 = self.p99_per_op_ns * @as(f64, @floatFromInt(self.operation_count));
+        std.debug.print(
+            "| {s:<28} | {d:>6} | {d:>10.2} us | {d:>10.2} us | {d:>6.2}% | {d:>6.2}% |\n",
+            .{
+                self.name,
+                self.operation_count,
+                avg_ns / 1000.0,
+                p99_ns / 1000.0,
+                100.0 * avg_ns / FRAME_BUDGET_60HZ_NS,
+                100.0 * avg_ns / FRAME_BUDGET_120HZ_NS,
+            },
+        );
+    }
+};
+
+/// Assemble a result from the common runner outputs.
+fn makeResult(
+    name: []const u8,
+    operation_count: u32,
+    total_time_ns: u64,
+    iterations: u32,
+    percentiles: PercentileResult,
+) BenchmarkResult {
+    std.debug.assert(operation_count > 0);
+    std.debug.assert(iterations > 0);
+    return .{
+        .name = name,
+        .operation_count = operation_count,
+        .total_time_ns = total_time_ns,
+        .iterations = iterations,
+        .min_per_op_ns = percentiles.min_per_op_ns,
+        .p50_per_op_ns = percentiles.p50_per_op_ns,
+        .p99_per_op_ns = percentiles.p99_per_op_ns,
+    };
+}
+
+// =============================================================================
+// Element Name Table
+//
+// Fingerprints fold in the element name hash, so giving every child a unique,
+// frame-stable name keeps fingerprints distinct even when sibling positions
+// saturate (`child_positions` is a saturating u8). Names are generated once and
+// reused across frames so the diff sees a stable structure.
+// =============================================================================
+
+const NameTable = struct {
+    backing: []u8,
+    names: [][]const u8,
+};
+
+/// Allocate `count` unique, stable element names ("a11y_elem_<i>").
+fn allocNames(allocator: Allocator, count: u32) !NameTable {
+    std.debug.assert(count > 0);
+
+    const backing = try allocator.alloc(u8, count * NAME_STRIDE);
+    errdefer allocator.free(backing);
+
+    const names = try allocator.alloc([]const u8, count);
+
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        const slot = backing[i * NAME_STRIDE ..][0..NAME_STRIDE];
+        const written = std.fmt.bufPrint(slot, "a11y_elem_{d}", .{i}) catch unreachable;
+        names[i] = written;
+    }
+    return .{ .backing = backing, .names = names };
+}
+
+fn freeNames(allocator: Allocator, table: NameTable) void {
+    allocator.free(table.names);
+    allocator.free(table.backing);
+}
+
+// =============================================================================
+// Tree Building
+// =============================================================================
+
+/// Build one frame's tree: a root group containing `names.len` children. The
+/// first `churn_count` children are live `.status` regions whose `value` toggles
+/// each frame (driving the dirty-detection + auto-announce path); the rest are
+/// stable `.button`s whose content never changes (the no-churn steady state).
+///
+/// Fingerprints stay stable frame-to-frame because role/name/position are
+/// fixed; only the non-fingerprinted `value` changes, so churn elements take the
+/// "existed, content changed" branch rather than being seen as removed + new.
+fn buildTree(tree: *Tree, names: [][]const u8, churn_count: u32, toggle: bool) void {
+    std.debug.assert(names.len >= 1);
+    std.debug.assert(churn_count <= names.len);
+
+    _ = tree.pushElement(.{ .layout_id = LayoutId.none, .role = .group, .name = "a11y_root" });
+
+    const child_count: u32 = @intCast(names.len);
+    var i: u32 = 0;
+    while (i < child_count) : (i += 1) {
+        if (i < churn_count) {
+            const value: []const u8 = if (toggle) "on" else "off";
+            _ = tree.pushElement(.{ .layout_id = LayoutId.none, .role = .status, .name = names[i], .value = value });
+        } else {
+            _ = tree.pushElement(.{ .layout_id = LayoutId.none, .role = .button, .name = names[i] });
+        }
+        tree.popElement();
+    }
+
+    tree.popElement();
+}
+
+/// Run one full diff frame and return the observed dirty + removed counts so the
+/// timed caller can keep the work from being optimized away.
+fn runDiffFrame(tree: *Tree, names: [][]const u8, churn_count: u32, toggle: bool) u32 {
+    std.debug.assert(names.len >= 1);
+    tree.beginFrame();
+    buildTree(tree, names, churn_count, toggle);
+    tree.endFrame();
+    const dirty: u32 = @intCast(tree.getDirtyElements().len);
+    const removed: u32 = @intCast(tree.getRemovedFingerprints().len);
+    return dirty + removed;
+}
+
+// =============================================================================
+// Hot Loop (CLAUDE.md §20 — primitive args, no struct receiver)
+// =============================================================================
+
+/// Compute `count` fingerprints, varying the position so the call is not folded
+/// to a constant, and sum the results so the work is observable. `position` is
+/// kept in `[0, 254]` because `fingerprint.compute` asserts `position < 255`.
+fn fingerprintSum(count: u32, name: []const u8, parent: ?Fingerprint) u64 {
+    std.debug.assert(count > 0);
+    var sum: u64 = 0;
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        const position: u8 = @intCast(i % 255);
+        const fp = fingerprint.compute(.button, name, parent, position);
+        sum +%= fp.toU64();
+    }
+    return sum;
+}
+
+// =============================================================================
+// Benchmark Runners
+// =============================================================================
+
+/// Fingerprint micro-bench: time `count` `fingerprint.compute` calls. Reports
+/// ns per fingerprint — the per-element primitive under the frame diff.
+fn benchFingerprint(comptime name: []const u8, count: u32, with_parent: bool) BenchmarkResult {
+    std.debug.assert(count > 0);
+
+    const parent: ?Fingerprint = if (with_parent)
+        fingerprint.compute(.group, "a11y_parent", null, 0)
+    else
+        null;
+    const sample_name = "a11y_fingerprint_bench";
+
+    const warmup_iters = getWarmupIterations(count);
+    const min_sample_iters = getMinSampleIterations(count);
+
+    for (0..warmup_iters) |_| std.mem.doNotOptimizeAway(fingerprintSum(count, sample_name, parent));
+
+    var total_time_ns: u64 = 0;
+    var iterations: u32 = 0;
+    var samples = IterationSamples.init();
+
+    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_sample_iters) {
+        const start = time.Instant.now();
+        const sum = fingerprintSum(count, sample_name, parent);
+        const end = time.Instant.now();
+        std.mem.doNotOptimizeAway(sum);
+
+        const elapsed = end.since(start);
+        total_time_ns += elapsed;
+        samples.record(elapsed);
+        iterations += 1;
+    }
+
+    const percentiles = samples.computePercentiles(count);
+    return makeResult(name, count, total_time_ns, iterations, percentiles);
+}
+
+/// Frame diff: time the full `beginFrame → build → endFrame` cycle over a tree
+/// of `child_count` children (`churn_count` of them changing content each
+/// frame). Reports against the frame budget; operation_count = total elements.
+fn benchFrameDiff(allocator: Allocator, comptime name: []const u8, child_count: u32, churn_count: u32) !BenchmarkResult {
+    std.debug.assert(child_count > 0);
+    std.debug.assert(churn_count <= child_count);
+    std.debug.assert(child_count + 1 <= MAX_ELEMENTS);
+
+    const table = try allocNames(allocator, child_count);
+    defer freeNames(allocator, table);
+
+    const tree = try allocator.create(Tree);
+    defer allocator.destroy(tree);
+    tree.initInPlace();
+
+    const operation_count = child_count + 1; // children + the root group
+    const warmup_iters = getWarmupIterations(operation_count);
+    const min_sample_iters = getMinSampleIterations(operation_count);
+
+    var toggle = false;
+    for (0..warmup_iters) |_| {
+        std.mem.doNotOptimizeAway(runDiffFrame(tree, table.names, churn_count, toggle));
+        toggle = !toggle;
+    }
+
+    var total_time_ns: u64 = 0;
+    var iterations: u32 = 0;
+    var samples = IterationSamples.init();
+
+    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_sample_iters) {
+        const start = time.Instant.now();
+        const changed = runDiffFrame(tree, table.names, churn_count, toggle);
+        const end = time.Instant.now();
+        toggle = !toggle;
+        std.mem.doNotOptimizeAway(changed);
+
+        const elapsed = end.since(start);
+        total_time_ns += elapsed;
+        samples.record(elapsed);
+        iterations += 1;
+    }
+
+    const percentiles = samples.computePercentiles(operation_count);
+    return makeResult(name, operation_count, total_time_ns, iterations, percentiles);
+}
+
+// =============================================================================
+// Validation Tests (run with `zig test src/accessibility/benchmarks.zig`)
+//
+// These do not time anything — they assert the diff produces the dirty/removed
+// counts the timed runners assume, so a structural regression fails the build.
+// =============================================================================
+
+test "validate: a stable rebuild reports zero dirty after the first frame" {
+    const allocator = std.testing.allocator;
+
+    const table = try allocNames(allocator, 64);
+    defer freeNames(allocator, table);
+
+    const tree = try allocator.create(Tree);
+    defer allocator.destroy(tree);
+    tree.initInPlace();
+
+    // First frame: everything is new, so every element is dirty.
+    _ = runDiffFrame(tree, table.names, 0, false);
+    try std.testing.expectEqual(@as(usize, 65), tree.getDirtyElements().len);
+
+    // Second identical frame: fingerprints + content hashes match → nothing
+    // dirty, nothing removed. This is the steady-state diff the bench measures.
+    _ = runDiffFrame(tree, table.names, 0, false);
+    try std.testing.expectEqual(@as(usize, 0), tree.getDirtyElements().len);
+    try std.testing.expectEqual(@as(usize, 0), tree.getRemovedFingerprints().len);
+}
+
+test "validate: churn marks exactly the changed elements dirty" {
+    const allocator = std.testing.allocator;
+
+    const table = try allocNames(allocator, 64);
+    defer freeNames(allocator, table);
+
+    const tree = try allocator.create(Tree);
+    defer allocator.destroy(tree);
+    tree.initInPlace();
+
+    const churn_count: u32 = 8;
+
+    // Settle the structure first (toggle=false), then flip the churn subset.
+    _ = runDiffFrame(tree, table.names, churn_count, false);
+    _ = runDiffFrame(tree, table.names, churn_count, false);
+    const changed = runDiffFrame(tree, table.names, churn_count, true);
+
+    // Only the churn elements changed content; fingerprints are stable, so
+    // they are dirty (not removed). Nothing should be reported as removed.
+    try std.testing.expectEqual(@as(u32, churn_count), changed);
+    try std.testing.expectEqual(@as(usize, 0), tree.getRemovedFingerprints().len);
+}
+
+// =============================================================================
+// Main Entry Point (for benchmark executable)
+// =============================================================================
+
+/// Print a per-op benchmark result and record it in the JSON reporter.
+fn collect(reporter: *bench.Reporter, result: BenchmarkResult) void {
+    result.print();
+    reporter.addEntry(bench.entryWithPercentiles(
+        result.name,
+        result.operation_count,
+        result.total_time_ns,
+        result.iterations,
+        result.min_per_op_ns,
+        result.p50_per_op_ns,
+        result.p99_per_op_ns,
+    ));
+}
+
+/// Record a frame result (frame groups print their own whole-frame budget line).
+fn collectFrame(reporter: *bench.Reporter, result: BenchmarkResult) void {
+    result.printFrameBudget();
+    reporter.addEntry(bench.entryWithPercentiles(
+        result.name,
+        result.operation_count,
+        result.total_time_ns,
+        result.iterations,
+        result.min_per_op_ns,
+        result.p50_per_op_ns,
+        result.p99_per_op_ns,
+    ));
+}
+
+pub fn main(init: std.process.Init) !void {
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    var reporter = bench.Reporter.init("accessibility", init.io, init.minimal.args.vector);
+
+    // =========================================================================
+    // Fingerprint (the per-element hash primitive)
+    // =========================================================================
+
+    printSectionHeader("Gooey Accessibility Benchmarks — Fingerprint (fingerprint.compute)");
+    collect(&reporter, benchFingerprint("fingerprint_flat_4k", 4000, false));
+    collect(&reporter, benchFingerprint("fingerprint_parented_4k", 4000, true));
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+
+    // =========================================================================
+    // Frame Diff (the full per-frame snapshot + rebuild + dirty/removed diff)
+    // =========================================================================
+
+    printFrameHeader();
+    collectFrame(&reporter, try benchFrameDiff(allocator, "frame_stable_64", 64, 0));
+    collectFrame(&reporter, try benchFrameDiff(allocator, "frame_stable_256", 256, 0));
+    collectFrame(&reporter, try benchFrameDiff(allocator, "frame_stable_1000", 1000, 0));
+    collectFrame(&reporter, try benchFrameDiff(allocator, "frame_churn_256", 256, 32));
+    collectFrame(&reporter, try benchFrameDiff(allocator, "frame_churn_1000", 1000, 125));
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+
+    std.debug.print(
+        \\
+        \\Notes:
+        \\  - Fingerprint = fingerprint.compute over N calls; the per-element hash
+        \\    that beginFrame (snapshot) and endFrame (diff) both walk. ns/op = per call.
+        \\  - Frame Diff  = beginFrame -> pushElement x N (+popElement) -> endFrame,
+        \\    the full snapshot + rebuild + computeDirty/computeRemoved cycle. Reported
+        \\    whole-frame; 60Hz budget = 16.67 ms, 120Hz = 8.33 ms.
+        \\  - stable = identical content each frame (steady state, ~0 dirty after frame 1).
+        \\    churn  = a fraction of live .status elements change value each frame, driving
+        \\    the dirty-detection + auto-announce path.
+        \\  - The tree is fully static-allocation; the only heap touch is the one-time
+        \\    Tree allocation, so there is no per-frame zero-alloc gate to run here.
+        \\  - operation_count = total elements (children + root); iterations are adaptive.
+        \\
+    , .{});
+
+    reporter.finish();
+}
+
+// =============================================================================
+// Section Printers
+// =============================================================================
+
+fn printSectionHeader(comptime title: []const u8) void {
+    comptime std.debug.assert(title.len > 0);
+    comptime std.debug.assert(title.len < TABLE_WIDTH);
+    std.debug.print("\n", .{});
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+    std.debug.print("{s}\n", .{title});
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+    printHeader();
+    std.debug.print("-" ** TABLE_WIDTH ++ "\n", .{});
+}
+
+fn printHeader() void {
+    std.debug.print("| {s:<40} | {s:>7} | {s:>9} | {s:>9} | {s:>9} | {s:>6} |\n", .{
+        "Test",
+        "Ops",
+        "ns/op",
+        "p50",
+        "p99",
+        "Iters",
+    });
+}
+
+fn printFrameHeader() void {
+    std.debug.print("\n", .{});
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+    std.debug.print("Gooey Accessibility Benchmarks — Frame Diff (beginFrame -> build N -> endFrame)\n", .{});
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+    std.debug.print("| {s:<28} | {s:>6} | {s:>13} | {s:>13} | {s:>6} | {s:>6} |\n", .{
+        "Test",
+        "Elems",
+        "Avg/frame",
+        "p99/frame",
+        "60Hz",
+        "120Hz",
+    });
+    std.debug.print("-" ** TABLE_WIDTH ++ "\n", .{});
+}

--- a/src/animation/benchmarks.zig
+++ b/src/animation/benchmarks.zig
@@ -1,0 +1,778 @@
+//! Animation Module Benchmarks
+//!
+//! Benchmark suite for the per-frame animation tick — the spring physics and
+//! the `AnimationStore` dispatch that run on every animating window each frame.
+//! The control-plane suites (`bench`, `bench-context`, `bench-core`,
+//! `bench-text`) and the scene data-plane suite (`bench-scene`) leave the
+//! animation engine unbenched; this suite fills that gap.
+//!
+//! Run as executable: zig build bench-animation
+//! Quick tests only:  zig test src/animation/benchmarks.zig (validates physics
+//!                    sanity + the steady-state zero-allocation invariant)
+//!
+//! Groups:
+//!   - Spring step    — `stepSpring` RK4 integration at a fixed dt (the §20 pure
+//!                      hot loop; the in-flight physics cost per spring)
+//!   - Spring tick    — `tickSpring` on settled springs (the at-rest fast path:
+//!                      one branch, zero physics — the "at-rest ≈ free" claim)
+//!   - Store frame    — `beginFrame → springById×N → endFrame`, reported against
+//!                      the 16.6 ms (60 Hz) / 8.3 ms (120 Hz) frame budget
+//!   - Motion frame   — the same per-frame cycle through `springMotionById`
+//!
+//! Why this split: `spring.zig`'s own back-of-envelope claims (a) an in-flight
+//! step is ~20 multiply-adds and (b) an at-rest spring costs one branch. The
+//! step vs at-rest-tick groups quantify both halves of that claim directly. The
+//! store-frame groups measure the realistic per-frame *dispatch* cost (the
+//! hash-map lookup + tick funnel that `cx.animations.spring(...)` walks) and
+//! gate the steady-state zero-allocation invariant: the pools grow during warmup
+//! and must never touch the heap again once every spring is registered.
+//!
+//! Scope note: the store ticks via `tickSpring`, whose dt comes from the
+//! monotonic clock. A benchmark frame completes well under one millisecond, so
+//! the clock-derived dt rounds toward zero and the store path measures the
+//! lookup + dispatch overhead rather than RK4 work. That separation is on
+//! purpose (CLAUDE.md §8, control plane vs data plane): the RK4 cost lives in
+//! the Spring-step group, the dispatch cost in the Store-frame group.
+
+const std = @import("std");
+const gooey = @import("gooey");
+const bench = @import("bench");
+
+const Allocator = std.mem.Allocator;
+const Alignment = std.mem.Alignment;
+
+/// Minimal `Instant.now()` / `.since()` shim over `std.Io.Clock.awake`, kept
+/// local to the benchmark module so every sample site reads as a two-line
+/// capture-then-diff instead of threading `io` through every benchmark
+/// helper signature. `.awake` is the monotonic clock — deltas here can never
+/// go negative regardless of NTP or sysadmin clock edits.
+///
+/// `std.Io` is a pair of pointers into a process-lifetime vtable, so the
+/// per-call `global_single_threaded.io()` lookup compiles down to a pair of
+/// constant pointer loads — effectively free.
+const time = struct {
+    inline fn benchIo() std.Io {
+        return std.Io.Threaded.global_single_threaded.io();
+    }
+
+    const Instant = struct {
+        ts: std.Io.Timestamp,
+
+        inline fn now() Instant {
+            return .{ .ts = std.Io.Timestamp.now(benchIo(), .awake) };
+        }
+
+        inline fn since(self: Instant, earlier: Instant) u64 {
+            const ns: i96 = earlier.ts.durationTo(self.ts).toNanoseconds();
+            std.debug.assert(ns >= 0);
+            return @intCast(ns);
+        }
+    };
+};
+
+const anim = gooey.animation;
+const spring_mod = anim.spring;
+const SpringState = anim.SpringState;
+const SpringConfig = anim.SpringConfig;
+const AnimationStore = anim.AnimationStore;
+const SpringMotionConfig = anim.SpringMotionConfig;
+
+const MAX_SPRINGS = spring_mod.MAX_SPRINGS;
+
+// =============================================================================
+// Benchmark Configuration
+// =============================================================================
+
+/// Adaptive warmup iterations based on operation count.
+fn getWarmupIterations(operation_count: u32) u32 {
+    std.debug.assert(operation_count > 0);
+    if (operation_count >= 10000) return 2;
+    if (operation_count >= 5000) return 3;
+    return 5;
+}
+
+/// Adaptive minimum sample iterations based on operation count.
+fn getMinSampleIterations(operation_count: u32) u32 {
+    std.debug.assert(operation_count > 0);
+    if (operation_count >= 10000) return 5;
+    if (operation_count >= 5000) return 8;
+    return 10;
+}
+
+/// Minimum wall-clock time to sample before concluding a benchmark.
+const MIN_SAMPLE_TIME_NS: u64 = 50 * std.time.ns_per_ms;
+
+/// Maximum per-iteration samples collected for percentile computation.
+/// 4096 samples * 8 bytes = 32 KB — fits comfortably on the stack.
+const MAX_SAMPLE_COUNT: u32 = 4096;
+
+/// Fixed integration step for the Spring-step group: one 60 Hz frame. Using a
+/// fixed dt (rather than the wall clock) makes the RK4 cost deterministic and
+/// independent of how fast the benchmark loop happens to run.
+const FIXED_DT_SECONDS: f32 = 1.0 / 60.0;
+
+/// Per-frame budgets in nanoseconds for the frame-budget summary.
+const FRAME_BUDGET_60HZ_NS: f64 = 16_666_667.0;
+const FRAME_BUDGET_120HZ_NS: f64 = 8_333_333.0;
+
+/// Table width for benchmark output formatting (characters per row).
+const TABLE_WIDTH = 99;
+
+// =============================================================================
+// Iteration Sample Collection and Percentile Computation
+// =============================================================================
+
+/// Per-iteration timing data for percentile analysis. Fixed capacity avoids
+/// dynamic allocation during benchmark runs. Mirrors the scene/text suites so
+/// every percentile-reporting suite shares one shape.
+const IterationSamples = struct {
+    times_ns: [MAX_SAMPLE_COUNT]u64,
+    count: u32,
+
+    fn init() IterationSamples {
+        return .{ .times_ns = undefined, .count = 0 };
+    }
+
+    /// Record one iteration's elapsed time. Drops samples beyond capacity
+    /// (the first MAX_SAMPLE_COUNT samples are sufficient for percentiles).
+    fn record(self: *IterationSamples, elapsed_ns: u64) void {
+        if (self.count < MAX_SAMPLE_COUNT) {
+            self.times_ns[self.count] = elapsed_ns;
+            self.count += 1;
+        }
+    }
+
+    /// Sort collected samples and extract min/p50/p99 percentiles as ns/op.
+    /// Mutates the internal array (sort is idempotent on subsequent calls).
+    fn computePercentiles(self: *IterationSamples, operation_count: u32) PercentileResult {
+        std.debug.assert(self.count > 0);
+        std.debug.assert(operation_count > 0);
+
+        const slice = self.times_ns[0..self.count];
+        std.mem.sort(u64, slice, {}, struct {
+            fn lessThan(_: void, a: u64, b: u64) bool {
+                return a < b;
+            }
+        }.lessThan);
+
+        const last_index = self.count - 1;
+        const last_f: f64 = @floatFromInt(last_index);
+        const p50_index: u32 = @intFromFloat(0.50 * last_f);
+        const p99_index: u32 = @intFromFloat(@min(0.99 * last_f, last_f));
+        const ops_f: f64 = @floatFromInt(operation_count);
+
+        return .{
+            // The slice is sorted ascending, so slice[0] is the fastest sample (the min).
+            .min_per_op_ns = @as(f64, @floatFromInt(slice[0])) / ops_f,
+            .p50_per_op_ns = @as(f64, @floatFromInt(slice[p50_index])) / ops_f,
+            .p99_per_op_ns = @as(f64, @floatFromInt(slice[p99_index])) / ops_f,
+        };
+    }
+};
+
+/// Percentile statistics computed from iteration samples.
+const PercentileResult = struct {
+    min_per_op_ns: f64,
+    p50_per_op_ns: f64,
+    p99_per_op_ns: f64,
+};
+
+// =============================================================================
+// Benchmark Results
+// =============================================================================
+
+const BenchmarkResult = struct {
+    name: []const u8,
+    operation_count: u32,
+    total_time_ns: u64,
+    iterations: u32,
+    min_per_op_ns: f64,
+    p50_per_op_ns: f64,
+    p99_per_op_ns: f64,
+
+    pub fn avgTimeMs(self: BenchmarkResult) f64 {
+        std.debug.assert(self.iterations > 0);
+        const avg_ns: f64 = @as(f64, @floatFromInt(self.total_time_ns)) /
+            @as(f64, @floatFromInt(self.iterations));
+        return avg_ns / std.time.ns_per_ms;
+    }
+
+    pub fn timePerOpNs(self: BenchmarkResult) f64 {
+        std.debug.assert(self.iterations > 0);
+        std.debug.assert(self.operation_count > 0);
+        const avg_ns = @as(f64, @floatFromInt(self.total_time_ns)) /
+            @as(f64, @floatFromInt(self.operation_count * self.iterations));
+        return avg_ns;
+    }
+
+    pub fn print(self: BenchmarkResult) void {
+        std.debug.assert(self.iterations > 0);
+        std.debug.assert(self.operation_count > 0);
+        std.debug.print(
+            "| {s:<40} | {d:>7} | {d:>9.2} | {d:>9.2} | {d:>9.2} | {d:>6} |\n",
+            .{ self.name, self.operation_count, self.timePerOpNs(), self.p50_per_op_ns, self.p99_per_op_ns, self.iterations },
+        );
+    }
+
+    /// Frame-budget summary line: whole-frame time (avg + p99) in microseconds
+    /// and avg as a percentage of the 60 Hz and 120 Hz budgets. This is the
+    /// "do we fit the budget?" number, so it is reported in whole-frame units.
+    pub fn printFrameBudget(self: BenchmarkResult) void {
+        std.debug.assert(self.iterations > 0);
+        std.debug.assert(self.operation_count > 0);
+        const avg_ns: f64 = @as(f64, @floatFromInt(self.total_time_ns)) /
+            @as(f64, @floatFromInt(self.iterations));
+        const p99_ns: f64 = self.p99_per_op_ns * @as(f64, @floatFromInt(self.operation_count));
+        std.debug.print(
+            "| {s:<28} | {d:>6} | {d:>10.2} us | {d:>10.2} us | {d:>6.2}% | {d:>6.2}% |\n",
+            .{
+                self.name,
+                self.operation_count,
+                avg_ns / 1000.0,
+                p99_ns / 1000.0,
+                100.0 * avg_ns / FRAME_BUDGET_60HZ_NS,
+                100.0 * avg_ns / FRAME_BUDGET_120HZ_NS,
+            },
+        );
+    }
+};
+
+/// Assemble a result from the common runner outputs. Centralizes the invariant
+/// checks so each runner ends with a single tail call.
+fn makeResult(
+    name: []const u8,
+    operation_count: u32,
+    total_time_ns: u64,
+    iterations: u32,
+    percentiles: PercentileResult,
+) BenchmarkResult {
+    std.debug.assert(operation_count > 0);
+    std.debug.assert(iterations > 0);
+    return .{
+        .name = name,
+        .operation_count = operation_count,
+        .total_time_ns = total_time_ns,
+        .iterations = iterations,
+        .min_per_op_ns = percentiles.min_per_op_ns,
+        .p50_per_op_ns = percentiles.p50_per_op_ns,
+        .p99_per_op_ns = percentiles.p99_per_op_ns,
+    };
+}
+
+// =============================================================================
+// Spring State Seeding
+// =============================================================================
+
+/// Seed every spring in the array to an in-flight state (position 0, target 1).
+/// `stepSpring` does a full RK4 evaluation on these regardless of how far they
+/// have converged, so the Spring-step group needs no per-iteration reset — the
+/// arithmetic cost is constant even after a spring settles.
+fn initInFlightSprings(states: []SpringState, io: std.Io) void {
+    std.debug.assert(states.len > 0);
+    const config: SpringConfig = .{
+        .target = 1.0,
+        .initial_position = 0.0,
+        .stiffness = 170.0,
+        .damping = 26.0,
+    };
+    for (states) |*state| state.* = SpringState.init(io, config);
+    // The seed must actually be in flight, else the step group would measure
+    // a degenerate fixed point instead of real RK4 work.
+    std.debug.assert(!states[0].at_rest);
+}
+
+/// Seed every spring to a settled (at-rest) state at its target. `tickSpring`
+/// early-returns on these without reading the clock or stepping physics, which
+/// is exactly the fast path the Spring-tick group measures.
+fn initAtRestSprings(states: []SpringState, io: std.Io) void {
+    std.debug.assert(states.len > 0);
+    const config: SpringConfig = .{ .target = 1.0 };
+    for (states) |*state| state.* = SpringState.initSettled(io, config);
+    std.debug.assert(states[0].at_rest);
+}
+
+// =============================================================================
+// Hot Loops (CLAUDE.md §20 — primitive args, no struct receiver)
+// =============================================================================
+
+/// Advance N springs by one fixed RK4 step. The pure in-flight physics cost.
+fn stepSpringBatch(states: []SpringState, dt_seconds: f32) void {
+    std.debug.assert(states.len > 0);
+    std.debug.assert(dt_seconds > 0.0);
+    for (states) |*state| spring_mod.stepSpring(state, dt_seconds);
+}
+
+/// Tick N springs, summing the returned positions so the work is observable.
+/// For at-rest springs this exercises only the early-return fast path.
+fn tickSpringSum(io: std.Io, states: []SpringState) f32 {
+    std.debug.assert(states.len > 0);
+    var sum: f32 = 0.0;
+    for (states) |*state| {
+        const handle = spring_mod.tickSpring(io, state);
+        sum += handle.value;
+    }
+    return sum;
+}
+
+/// One store frame over N pre-registered springs: reset the per-frame active
+/// counters, poll every spring (hash-map lookup + tick), close the frame. The
+/// summed value keeps the polls from being optimized away.
+fn runSpringFrame(store: *AnimationStore, count: u32, config: SpringConfig) f32 {
+    std.debug.assert(count > 0);
+    store.beginFrame();
+    var sum: f32 = 0.0;
+    var i: u32 = 0;
+    while (i < count) : (i += 1) sum += store.springById(i, config).value;
+    store.endFrame();
+    return sum;
+}
+
+/// One store frame over N pre-registered spring-motions (covers `motion.zig`'s
+/// `tickSpringMotion` + the store dispatch). `show` is held true so settled
+/// motions stay in the `entered` phase — the idle steady state.
+fn runSpringMotionFrame(store: *AnimationStore, count: u32, config: SpringMotionConfig) f32 {
+    std.debug.assert(count > 0);
+    store.beginFrame();
+    var sum: f32 = 0.0;
+    var i: u32 = 0;
+    while (i < count) : (i += 1) sum += store.springMotionById(i, true, config).progress;
+    store.endFrame();
+    return sum;
+}
+
+// =============================================================================
+// Benchmark Runners
+// =============================================================================
+
+/// Spring step: time one RK4 step across N in-flight springs. Reports ns per
+/// spring stepped — the §7 back-of-envelope physics cost made concrete.
+fn benchSpringStep(allocator: Allocator, comptime name: []const u8, count: u32) !BenchmarkResult {
+    std.debug.assert(count > 0);
+
+    const states = try allocator.alloc(SpringState, count);
+    defer allocator.free(states);
+
+    initInFlightSprings(states, time.benchIo());
+
+    const warmup_iters = getWarmupIterations(count);
+    const min_sample_iters = getMinSampleIterations(count);
+
+    for (0..warmup_iters) |_| stepSpringBatch(states, FIXED_DT_SECONDS);
+
+    var total_time_ns: u64 = 0;
+    var iterations: u32 = 0;
+    var samples = IterationSamples.init();
+
+    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_sample_iters) {
+        const start = time.Instant.now();
+        stepSpringBatch(states, FIXED_DT_SECONDS);
+        const end = time.Instant.now();
+        std.mem.doNotOptimizeAway(states[count - 1].position);
+
+        const elapsed = end.since(start);
+        total_time_ns += elapsed;
+        samples.record(elapsed);
+        iterations += 1;
+    }
+
+    const percentiles = samples.computePercentiles(count);
+    return makeResult(name, count, total_time_ns, iterations, percentiles);
+}
+
+/// Spring tick (at rest): time `tickSpring` across N settled springs. Reports
+/// ns per spring — the at-rest fast path that should be far below the RK4 cost.
+fn benchSpringTickAtRest(allocator: Allocator, comptime name: []const u8, count: u32) !BenchmarkResult {
+    std.debug.assert(count > 0);
+
+    const states = try allocator.alloc(SpringState, count);
+    defer allocator.free(states);
+
+    const io = time.benchIo();
+    initAtRestSprings(states, io);
+
+    const warmup_iters = getWarmupIterations(count);
+    const min_sample_iters = getMinSampleIterations(count);
+
+    for (0..warmup_iters) |_| std.mem.doNotOptimizeAway(tickSpringSum(io, states));
+
+    var total_time_ns: u64 = 0;
+    var iterations: u32 = 0;
+    var samples = IterationSamples.init();
+
+    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_sample_iters) {
+        const start = time.Instant.now();
+        const sum = tickSpringSum(io, states);
+        const end = time.Instant.now();
+        std.mem.doNotOptimizeAway(sum);
+
+        const elapsed = end.since(start);
+        total_time_ns += elapsed;
+        samples.record(elapsed);
+        iterations += 1;
+    }
+
+    const percentiles = samples.computePercentiles(count);
+    return makeResult(name, count, total_time_ns, iterations, percentiles);
+}
+
+/// Store frame (springs): pre-register N idle springs, then time the per-frame
+/// `beginFrame → springById×N → endFrame` cycle. Reports against frame budget.
+fn benchStoreSpringFrame(allocator: Allocator, comptime name: []const u8, count: u32) !BenchmarkResult {
+    std.debug.assert(count > 0);
+    std.debug.assert(count <= MAX_SPRINGS);
+
+    var store = AnimationStore.init(allocator, time.benchIo());
+    defer store.deinit();
+
+    // target == default initial_position (0) → springs are created settled, so
+    // the steady-state poll exercises the at-rest tick + lookup, not physics.
+    const config: SpringConfig = .{ .target = 0.0 };
+    var i: u32 = 0;
+    while (i < count) : (i += 1) std.mem.doNotOptimizeAway(store.springById(i, config).value);
+    std.debug.assert(store.springs.count() == count);
+
+    const warmup_iters = getWarmupIterations(count);
+    const min_sample_iters = getMinSampleIterations(count);
+
+    for (0..warmup_iters) |_| std.mem.doNotOptimizeAway(runSpringFrame(&store, count, config));
+
+    var total_time_ns: u64 = 0;
+    var iterations: u32 = 0;
+    var samples = IterationSamples.init();
+
+    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_sample_iters) {
+        const start = time.Instant.now();
+        const sum = runSpringFrame(&store, count, config);
+        const end = time.Instant.now();
+        std.mem.doNotOptimizeAway(sum);
+
+        const elapsed = end.since(start);
+        total_time_ns += elapsed;
+        samples.record(elapsed);
+        iterations += 1;
+    }
+
+    const percentiles = samples.computePercentiles(count);
+    return makeResult(name, count, total_time_ns, iterations, percentiles);
+}
+
+/// Store frame (spring-motions): pre-register N visible spring-motions, then
+/// time the per-frame poll cycle. Covers `motion.zig` + store dispatch.
+fn benchStoreSpringMotionFrame(allocator: Allocator, comptime name: []const u8, count: u32) !BenchmarkResult {
+    std.debug.assert(count > 0);
+    std.debug.assert(count <= MAX_SPRINGS);
+
+    var store = AnimationStore.init(allocator, time.benchIo());
+    defer store.deinit();
+
+    // start_visible → created settled in the entered phase; holding show=true
+    // keeps them idle, so the poll measures lookup + at-rest dispatch.
+    const config: SpringMotionConfig = .{ .start_visible = true };
+    var i: u32 = 0;
+    while (i < count) : (i += 1) std.mem.doNotOptimizeAway(store.springMotionById(i, true, config).progress);
+    std.debug.assert(store.spring_motions.count() == count);
+
+    const warmup_iters = getWarmupIterations(count);
+    const min_sample_iters = getMinSampleIterations(count);
+
+    for (0..warmup_iters) |_| std.mem.doNotOptimizeAway(runSpringMotionFrame(&store, count, config));
+
+    var total_time_ns: u64 = 0;
+    var iterations: u32 = 0;
+    var samples = IterationSamples.init();
+
+    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_sample_iters) {
+        const start = time.Instant.now();
+        const sum = runSpringMotionFrame(&store, count, config);
+        const end = time.Instant.now();
+        std.mem.doNotOptimizeAway(sum);
+
+        const elapsed = end.since(start);
+        total_time_ns += elapsed;
+        samples.record(elapsed);
+        iterations += 1;
+    }
+
+    const percentiles = samples.computePercentiles(count);
+    return makeResult(name, count, total_time_ns, iterations, percentiles);
+}
+
+// =============================================================================
+// Counting Allocator (zero-allocation invariant check)
+// =============================================================================
+
+/// Wraps a backing allocator and counts every vtable call. After the spring
+/// pools grow to hold every registered spring, a steady-state frame must touch
+/// the heap zero times (CLAUDE.md §2). This turns that belief into a checkable
+/// fact in the validate tests below. Mirrors the scene suite's counter.
+const CountingAllocator = struct {
+    backing: Allocator,
+    calls: u64 = 0,
+
+    fn allocator(self: *CountingAllocator) Allocator {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    const vtable = Allocator.VTable{
+        .alloc = alloc,
+        .resize = resize,
+        .remap = remap,
+        .free = free,
+    };
+
+    fn alloc(ctx: *anyopaque, len: usize, alignment: Alignment, ret_addr: usize) ?[*]u8 {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.calls += 1;
+        return self.backing.rawAlloc(len, alignment, ret_addr);
+    }
+
+    fn resize(ctx: *anyopaque, memory: []u8, alignment: Alignment, new_len: usize, ret_addr: usize) bool {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.calls += 1;
+        return self.backing.rawResize(memory, alignment, new_len, ret_addr);
+    }
+
+    fn remap(ctx: *anyopaque, memory: []u8, alignment: Alignment, new_len: usize, ret_addr: usize) ?[*]u8 {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.calls += 1;
+        return self.backing.rawRemap(memory, alignment, new_len, ret_addr);
+    }
+
+    fn free(ctx: *anyopaque, memory: []u8, alignment: Alignment, ret_addr: usize) void {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.calls += 1;
+        self.backing.rawFree(memory, alignment, ret_addr);
+    }
+};
+
+// =============================================================================
+// Validation Tests (run with `zig test src/animation/benchmarks.zig`)
+//
+// These do not time anything — they assert the physics moves in the right
+// direction, the at-rest tick is a genuine no-op on state, and the
+// steady-state store frame allocates nothing.
+// =============================================================================
+
+test "validate: in-flight spring advances toward its target under stepping" {
+    const io = time.benchIo();
+    var states: [4]SpringState = undefined;
+    initInFlightSprings(&states, io);
+
+    // 120 fixed steps ≈ 2 s of simulated time; the spring must reach rest.
+    var i: u32 = 0;
+    while (i < 120) : (i += 1) stepSpringBatch(&states, FIXED_DT_SECONDS);
+
+    try std.testing.expect(states[0].at_rest);
+    try std.testing.expectApproxEqAbs(@as(f32, 1.0), states[0].position, 0.001);
+}
+
+test "validate: at-rest tick leaves spring state untouched" {
+    const io = time.benchIo();
+    var states: [4]SpringState = undefined;
+    initAtRestSprings(&states, io);
+
+    const value_before = states[0].position;
+    const sum = tickSpringSum(io, &states);
+
+    // Settled springs early-return: position is unchanged and the summed
+    // value is exactly N × target (here 4 × 1.0).
+    try std.testing.expect(states[0].at_rest);
+    try std.testing.expectEqual(value_before, states[0].position);
+    try std.testing.expectApproxEqAbs(@as(f32, 4.0), sum, 0.0001);
+}
+
+test "validate: steady-state spring frame performs zero heap allocations" {
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = gpa.deinit();
+
+    var counter = CountingAllocator{ .backing = gpa.allocator() };
+    const allocator = counter.allocator();
+
+    var store = AnimationStore.init(allocator, time.benchIo());
+    defer store.deinit();
+
+    const config: SpringConfig = .{ .target = 0.0 };
+    const count: u32 = 64;
+
+    // Registration grows the pool — those allocations happen before we measure.
+    var i: u32 = 0;
+    while (i < count) : (i += 1) std.mem.doNotOptimizeAway(store.springById(i, config).value);
+    std.debug.assert(store.springs.count() == count);
+
+    // Warm once more so any lazy first-use growth is paid before the gate.
+    std.mem.doNotOptimizeAway(runSpringFrame(&store, count, config));
+
+    const calls_before = counter.calls;
+
+    // Steady state: every key already exists, so getOrPut returns the cached
+    // slot and ticks early-return on the settled springs. Net heap: zero.
+    var frame: u32 = 0;
+    while (frame < 16) : (frame += 1) {
+        std.mem.doNotOptimizeAway(runSpringFrame(&store, count, config));
+    }
+
+    try std.testing.expectEqual(calls_before, counter.calls);
+}
+
+test "validate: steady-state spring-motion frame performs zero heap allocations" {
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = gpa.deinit();
+
+    var counter = CountingAllocator{ .backing = gpa.allocator() };
+    const allocator = counter.allocator();
+
+    var store = AnimationStore.init(allocator, time.benchIo());
+    defer store.deinit();
+
+    const config: SpringMotionConfig = .{ .start_visible = true };
+    const count: u32 = 64;
+
+    var i: u32 = 0;
+    while (i < count) : (i += 1) std.mem.doNotOptimizeAway(store.springMotionById(i, true, config).progress);
+    std.debug.assert(store.spring_motions.count() == count);
+
+    std.mem.doNotOptimizeAway(runSpringMotionFrame(&store, count, config));
+
+    const calls_before = counter.calls;
+
+    var frame: u32 = 0;
+    while (frame < 16) : (frame += 1) {
+        std.mem.doNotOptimizeAway(runSpringMotionFrame(&store, count, config));
+    }
+
+    try std.testing.expectEqual(calls_before, counter.calls);
+}
+
+// =============================================================================
+// Main Entry Point (for benchmark executable)
+// =============================================================================
+
+/// Print a benchmark result and record it in the JSON reporter. Animation
+/// benchmarks carry p50/p99 percentiles, so the entry uses the percentile
+/// constructor; the regression gate still classifies on the min (best-of-N).
+fn collect(reporter: *bench.Reporter, result: BenchmarkResult) void {
+    result.print();
+    reporter.addEntry(bench.entryWithPercentiles(
+        result.name,
+        result.operation_count,
+        result.total_time_ns,
+        result.iterations,
+        result.min_per_op_ns,
+        result.p50_per_op_ns,
+        result.p99_per_op_ns,
+    ));
+}
+
+/// Record a frame result (no per-op table print — the frame groups print their
+/// own whole-frame budget line via printFrameBudget).
+fn collectFrame(reporter: *bench.Reporter, result: BenchmarkResult) void {
+    result.printFrameBudget();
+    reporter.addEntry(bench.entryWithPercentiles(
+        result.name,
+        result.operation_count,
+        result.total_time_ns,
+        result.iterations,
+        result.min_per_op_ns,
+        result.p50_per_op_ns,
+        result.p99_per_op_ns,
+    ));
+}
+
+pub fn main(init: std.process.Init) !void {
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    var reporter = bench.Reporter.init("animation", init.io, init.minimal.args.vector);
+
+    // =========================================================================
+    // Spring Step (RK4 physics — the in-flight cost per spring)
+    // =========================================================================
+
+    printSectionHeader("Gooey Animation Benchmarks — Spring Step (stepSpring RK4, fixed dt)");
+    collect(&reporter, try benchSpringStep(allocator, "spring_step_256", 256));
+    collect(&reporter, try benchSpringStep(allocator, "spring_step_1k", 1024));
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+
+    // =========================================================================
+    // Spring Tick (at-rest fast path — the "≈ free" claim)
+    // =========================================================================
+
+    printSectionHeader("Gooey Animation Benchmarks — Spring Tick (tickSpring on settled springs)");
+    collect(&reporter, try benchSpringTickAtRest(allocator, "spring_tick_atrest_256", 256));
+    collect(&reporter, try benchSpringTickAtRest(allocator, "spring_tick_atrest_1k", 1024));
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+
+    // =========================================================================
+    // Store Frame (per-frame dispatch over N pre-registered springs/motions)
+    // =========================================================================
+
+    printFrameHeader();
+    collectFrame(&reporter, try benchStoreSpringFrame(allocator, "frame_springs_16", 16));
+    collectFrame(&reporter, try benchStoreSpringFrame(allocator, "frame_springs_64", 64));
+    collectFrame(&reporter, try benchStoreSpringFrame(allocator, "frame_springs_256", 256));
+    collectFrame(&reporter, try benchStoreSpringMotionFrame(allocator, "frame_spring_motions_64", 64));
+    collectFrame(&reporter, try benchStoreSpringMotionFrame(allocator, "frame_spring_motions_256", 256));
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+
+    std.debug.print(
+        \\
+        \\Notes:
+        \\  - Spring Step  = stepSpring RK4 integration at a fixed 1/60 s dt; the pure
+        \\                   in-flight physics cost per spring (CLAUDE.md §20 hot loop).
+        \\  - Spring Tick  = tickSpring on settled springs — the at-rest early return.
+        \\                   Compare against Spring Step to size "at-rest ≈ free".
+        \\  - Store Frame  = beginFrame -> springById/springMotionById x N -> endFrame,
+        \\                   the per-frame dispatch (hash-map lookup + tick) over idle
+        \\                   springs. 60Hz budget = 16.67 ms, 120Hz = 8.33 ms.
+        \\  - Store ticks via the monotonic clock; a sub-ms benchmark frame rounds dt
+        \\    toward zero, so Store Frame measures dispatch overhead, not RK4. The RK4
+        \\    cost is the Spring Step group; active per-frame cost ≈ frame + N x step.
+        \\  - ns/op and percentiles are per spring/motion; iterations are adaptive.
+        \\
+    , .{});
+
+    reporter.finish();
+}
+
+// =============================================================================
+// Section Printers
+// =============================================================================
+
+fn printSectionHeader(comptime title: []const u8) void {
+    comptime std.debug.assert(title.len > 0);
+    comptime std.debug.assert(title.len < TABLE_WIDTH);
+    std.debug.print("\n", .{});
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+    std.debug.print("{s}\n", .{title});
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+    printHeader();
+    std.debug.print("-" ** TABLE_WIDTH ++ "\n", .{});
+}
+
+fn printHeader() void {
+    std.debug.print("| {s:<40} | {s:>7} | {s:>9} | {s:>9} | {s:>9} | {s:>6} |\n", .{
+        "Test",
+        "Ops",
+        "ns/op",
+        "p50",
+        "p99",
+        "Iters",
+    });
+}
+
+fn printFrameHeader() void {
+    std.debug.print("\n", .{});
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+    std.debug.print("Gooey Animation Benchmarks — Store Frame (beginFrame -> poll N -> endFrame)\n", .{});
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+    std.debug.print("| {s:<28} | {s:>6} | {s:>13} | {s:>13} | {s:>6} | {s:>6} |\n", .{
+        "Test",
+        "Count",
+        "Avg/frame",
+        "p99/frame",
+        "60Hz",
+        "120Hz",
+    });
+    std.debug.print("-" ** TABLE_WIDTH ++ "\n", .{});
+}

--- a/src/context/element_states_benchmarks.zig
+++ b/src/context/element_states_benchmarks.zig
@@ -1,0 +1,614 @@
+//! Element-State Pool Benchmarks
+//!
+//! Benchmark suite for `context/element_states.zig` — the keyed pool that backs
+//! `cx.with_element_state(...)` and holds every stateful widget's retained
+//! state (`(id_hash, type_id) -> *S`). `bench-context` covers the dispatch
+//! tree and entity map; this suite isolates the element-state pool, whose hot
+//! path runs once per stateful widget per frame.
+//!
+//! Run as executable: zig build bench-element-states
+//! Quick tests only:  zig test src/context/element_states_benchmarks.zig
+//!                    (validates lookup correctness + the zero-alloc invariant)
+//!
+//! Groups:
+//!   - Lookup vs occupancy — `get` hit cost at 8 / 64 / 512 / 4096 entries.
+//!                           This is the headline number: `findIndex` is an
+//!                           explicit O(count) linear scan, and this curve says
+//!                           whether the scan stays cheap or needs a hash map.
+//!   - Get-or-create hit   — `withElementState` on already-present keys; the
+//!                           real per-frame call site, gated zero-allocation.
+//!   - Insert + remove     — the miss path (`create(S)`) + teardown (`destroy`);
+//!                           the control-plane churn cost, which *does* allocate.
+//!
+//! Why this split (CLAUDE.md §8, control vs data plane): the steady-state hot
+//! path is a lookup on a present key and must be allocation-free; the miss path
+//! is one `create(S)`. The lookup-vs-occupancy curve directly answers the
+//! standing question in `findIndex`'s own comment — *"if a profile shows
+//! otherwise we can swap in an AutoHashMap"* — the same way the scene suite's
+//! sort measurement prescribed sort-keys-not-payloads.
+
+const std = @import("std");
+const gooey = @import("gooey");
+const bench = @import("bench");
+
+const Allocator = std.mem.Allocator;
+const Alignment = std.mem.Alignment;
+
+/// Minimal `Instant.now()` / `.since()` shim over `std.Io.Clock.awake`, kept
+/// local to the benchmark module so every sample site reads as a two-line
+/// capture-then-diff. `.awake` is the monotonic clock — deltas here can never
+/// go negative regardless of NTP or sysadmin clock edits.
+const time = struct {
+    inline fn benchIo() std.Io {
+        return std.Io.Threaded.global_single_threaded.io();
+    }
+
+    const Instant = struct {
+        ts: std.Io.Timestamp,
+
+        inline fn now() Instant {
+            return .{ .ts = std.Io.Timestamp.now(benchIo(), .awake) };
+        }
+
+        inline fn since(self: Instant, earlier: Instant) u64 {
+            const ns: i96 = earlier.ts.durationTo(self.ts).toNanoseconds();
+            std.debug.assert(ns >= 0);
+            return @intCast(ns);
+        }
+    };
+};
+
+const context = gooey.context;
+const ElementStates = context.ElementStates;
+const MAX_ELEMENT_STATES = context.MAX_ELEMENT_STATES;
+
+/// Payload stored in the pool for every benchmark. A bare `u64` keeps the
+/// per-entry allocation tiny so the measurement reflects the pool's lookup and
+/// slot bookkeeping, not the cost of constructing a fat widget state.
+const BenchState = struct {
+    value: u64,
+
+    /// Comptime factory required by `withElementState`.
+    pub fn defaultInit() BenchState {
+        return .{ .value = 0 };
+    }
+};
+
+// =============================================================================
+// Benchmark Configuration
+// =============================================================================
+
+/// Adaptive warmup iterations based on operation count.
+fn getWarmupIterations(operation_count: u32) u32 {
+    std.debug.assert(operation_count > 0);
+    if (operation_count >= 10000) return 2;
+    if (operation_count >= 5000) return 3;
+    return 5;
+}
+
+/// Adaptive minimum sample iterations based on operation count.
+fn getMinSampleIterations(operation_count: u32) u32 {
+    std.debug.assert(operation_count > 0);
+    if (operation_count >= 10000) return 5;
+    if (operation_count >= 5000) return 8;
+    return 10;
+}
+
+/// Minimum wall-clock time to sample before concluding a benchmark.
+const MIN_SAMPLE_TIME_NS: u64 = 50 * std.time.ns_per_ms;
+
+/// Maximum per-iteration samples collected for percentile computation.
+const MAX_SAMPLE_COUNT: u32 = 4096;
+
+/// Table width for benchmark output formatting (characters per row).
+const TABLE_WIDTH = 99;
+
+// =============================================================================
+// Iteration Sample Collection and Percentile Computation
+// =============================================================================
+
+/// Per-iteration timing data for percentile analysis. Fixed capacity avoids
+/// dynamic allocation during benchmark runs. Mirrors the scene/animation suites.
+const IterationSamples = struct {
+    times_ns: [MAX_SAMPLE_COUNT]u64,
+    count: u32,
+
+    fn init() IterationSamples {
+        return .{ .times_ns = undefined, .count = 0 };
+    }
+
+    fn record(self: *IterationSamples, elapsed_ns: u64) void {
+        if (self.count < MAX_SAMPLE_COUNT) {
+            self.times_ns[self.count] = elapsed_ns;
+            self.count += 1;
+        }
+    }
+
+    /// Sort collected samples and extract min/p50/p99 percentiles as ns/op.
+    fn computePercentiles(self: *IterationSamples, operation_count: u32) PercentileResult {
+        std.debug.assert(self.count > 0);
+        std.debug.assert(operation_count > 0);
+
+        const slice = self.times_ns[0..self.count];
+        std.mem.sort(u64, slice, {}, struct {
+            fn lessThan(_: void, a: u64, b: u64) bool {
+                return a < b;
+            }
+        }.lessThan);
+
+        const last_index = self.count - 1;
+        const last_f: f64 = @floatFromInt(last_index);
+        const p50_index: u32 = @intFromFloat(0.50 * last_f);
+        const p99_index: u32 = @intFromFloat(@min(0.99 * last_f, last_f));
+        const ops_f: f64 = @floatFromInt(operation_count);
+
+        return .{
+            .min_per_op_ns = @as(f64, @floatFromInt(slice[0])) / ops_f,
+            .p50_per_op_ns = @as(f64, @floatFromInt(slice[p50_index])) / ops_f,
+            .p99_per_op_ns = @as(f64, @floatFromInt(slice[p99_index])) / ops_f,
+        };
+    }
+};
+
+/// Percentile statistics computed from iteration samples.
+const PercentileResult = struct {
+    min_per_op_ns: f64,
+    p50_per_op_ns: f64,
+    p99_per_op_ns: f64,
+};
+
+// =============================================================================
+// Benchmark Results
+// =============================================================================
+
+const BenchmarkResult = struct {
+    name: []const u8,
+    operation_count: u32,
+    total_time_ns: u64,
+    iterations: u32,
+    min_per_op_ns: f64,
+    p50_per_op_ns: f64,
+    p99_per_op_ns: f64,
+
+    pub fn timePerOpNs(self: BenchmarkResult) f64 {
+        std.debug.assert(self.iterations > 0);
+        std.debug.assert(self.operation_count > 0);
+        const avg_ns = @as(f64, @floatFromInt(self.total_time_ns)) /
+            @as(f64, @floatFromInt(self.operation_count * self.iterations));
+        return avg_ns;
+    }
+
+    pub fn print(self: BenchmarkResult) void {
+        std.debug.assert(self.iterations > 0);
+        std.debug.assert(self.operation_count > 0);
+        std.debug.print(
+            "| {s:<40} | {d:>7} | {d:>9.2} | {d:>9.2} | {d:>9.2} | {d:>6} |\n",
+            .{ self.name, self.operation_count, self.timePerOpNs(), self.p50_per_op_ns, self.p99_per_op_ns, self.iterations },
+        );
+    }
+};
+
+/// Assemble a result from the common runner outputs.
+fn makeResult(
+    name: []const u8,
+    operation_count: u32,
+    total_time_ns: u64,
+    iterations: u32,
+    percentiles: PercentileResult,
+) BenchmarkResult {
+    std.debug.assert(operation_count > 0);
+    std.debug.assert(iterations > 0);
+    return .{
+        .name = name,
+        .operation_count = operation_count,
+        .total_time_ns = total_time_ns,
+        .iterations = iterations,
+        .min_per_op_ns = percentiles.min_per_op_ns,
+        .p50_per_op_ns = percentiles.p50_per_op_ns,
+        .p99_per_op_ns = percentiles.p99_per_op_ns,
+    };
+}
+
+// =============================================================================
+// Pool Lifecycle Helpers
+//
+// `ElementStates` embeds a 128 KiB entries array, so it is heap-allocated and
+// initialised in place (CLAUDE.md §14) rather than returned by value.
+// =============================================================================
+
+/// Allocate + in-place-init an empty pool. Caller owns it via `destroyPool`.
+fn createPool(allocator: Allocator) !*ElementStates {
+    const pool = try allocator.create(ElementStates);
+    pool.initInPlace(allocator);
+    std.debug.assert(pool.len() == 0);
+    return pool;
+}
+
+/// Tear down a pool's payloads and free the container.
+fn destroyPool(allocator: Allocator, pool: *ElementStates) void {
+    pool.deinit();
+    allocator.destroy(pool);
+}
+
+/// Fill the pool with `occupancy` distinct keys (id_hash = 0..occupancy-1).
+/// Keys are inserted in ascending order, so key `i` lands at slot `i`.
+fn fillPool(pool: *ElementStates, occupancy: u32) !void {
+    std.debug.assert(occupancy > 0);
+    std.debug.assert(occupancy <= MAX_ELEMENT_STATES);
+    var i: u32 = 0;
+    while (i < occupancy) : (i += 1) {
+        _ = try pool.withElementState(BenchState, i, BenchState.defaultInit);
+    }
+    std.debug.assert(pool.len() == occupancy);
+}
+
+// =============================================================================
+// Hot Loops (CLAUDE.md §20 — primitive args, no struct receiver beyond *pool)
+// =============================================================================
+
+/// Look up every key once via `get`, summing payload values so the scan is not
+/// optimized away. Average scanned position is occupancy/2, so ns/op tracks the
+/// O(count) cost of `findIndex` directly.
+fn getScanSum(pool: *ElementStates, occupancy: u32) u64 {
+    std.debug.assert(occupancy > 0);
+    var sum: u64 = 0;
+    var i: u32 = 0;
+    while (i < occupancy) : (i += 1) {
+        // Keys 0..occupancy-1 are all present, so the lookup never misses.
+        const ptr = pool.get(BenchState, i) orelse unreachable;
+        sum +%= ptr.value;
+    }
+    return sum;
+}
+
+/// Look up every key once via `withElementState` (the real per-frame call site).
+/// Every key is present, so this is pure get-on-hit — no allocation.
+fn withHitSum(pool: *ElementStates, occupancy: u32) u64 {
+    std.debug.assert(occupancy > 0);
+    var sum: u64 = 0;
+    var i: u32 = 0;
+    while (i < occupancy) : (i += 1) {
+        // Present keys never hit the miss path, so the error set is unreachable.
+        const ptr = pool.withElementState(BenchState, i, BenchState.defaultInit) catch unreachable;
+        sum +%= ptr.value;
+    }
+    return sum;
+}
+
+/// Insert `count` fresh keys (miss path: `create(S)`) then remove them all
+/// (teardown: `destroy`). Leaves the pool empty for the next iteration.
+fn churnInsertRemove(pool: *ElementStates, count: u32) void {
+    std.debug.assert(count > 0);
+    std.debug.assert(pool.len() == 0);
+
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        // The pool was empty and count <= capacity, so neither error can fire.
+        _ = pool.withElementState(BenchState, i, BenchState.defaultInit) catch unreachable;
+    }
+    std.debug.assert(pool.len() == count);
+
+    i = 0;
+    while (i < count) : (i += 1) {
+        const removed = pool.remove(BenchState, i);
+        std.debug.assert(removed);
+    }
+    std.debug.assert(pool.len() == 0);
+}
+
+// =============================================================================
+// Benchmark Runners
+// =============================================================================
+
+/// Lookup vs occupancy: fill to `occupancy`, then time one `get` per key.
+/// Reports ns per lookup — the linear-scan cost at this fill level.
+fn benchGetByOccupancy(allocator: Allocator, comptime name: []const u8, occupancy: u32) !BenchmarkResult {
+    std.debug.assert(occupancy > 0);
+    std.debug.assert(occupancy <= MAX_ELEMENT_STATES);
+
+    const pool = try createPool(allocator);
+    defer destroyPool(allocator, pool);
+
+    try fillPool(pool, occupancy);
+
+    const warmup_iters = getWarmupIterations(occupancy);
+    const min_sample_iters = getMinSampleIterations(occupancy);
+
+    for (0..warmup_iters) |_| std.mem.doNotOptimizeAway(getScanSum(pool, occupancy));
+
+    var total_time_ns: u64 = 0;
+    var iterations: u32 = 0;
+    var samples = IterationSamples.init();
+
+    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_sample_iters) {
+        const start = time.Instant.now();
+        const sum = getScanSum(pool, occupancy);
+        const end = time.Instant.now();
+        std.mem.doNotOptimizeAway(sum);
+
+        const elapsed = end.since(start);
+        total_time_ns += elapsed;
+        samples.record(elapsed);
+        iterations += 1;
+    }
+
+    const percentiles = samples.computePercentiles(occupancy);
+    return makeResult(name, occupancy, total_time_ns, iterations, percentiles);
+}
+
+/// Get-or-create hit: fill to `occupancy`, then time one `withElementState`
+/// per present key. Reports ns per hit — the allocation-free steady-state path.
+fn benchWithHit(allocator: Allocator, comptime name: []const u8, occupancy: u32) !BenchmarkResult {
+    std.debug.assert(occupancy > 0);
+    std.debug.assert(occupancy <= MAX_ELEMENT_STATES);
+
+    const pool = try createPool(allocator);
+    defer destroyPool(allocator, pool);
+
+    try fillPool(pool, occupancy);
+
+    const warmup_iters = getWarmupIterations(occupancy);
+    const min_sample_iters = getMinSampleIterations(occupancy);
+
+    for (0..warmup_iters) |_| std.mem.doNotOptimizeAway(withHitSum(pool, occupancy));
+
+    var total_time_ns: u64 = 0;
+    var iterations: u32 = 0;
+    var samples = IterationSamples.init();
+
+    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_sample_iters) {
+        const start = time.Instant.now();
+        const sum = withHitSum(pool, occupancy);
+        const end = time.Instant.now();
+        std.mem.doNotOptimizeAway(sum);
+
+        const elapsed = end.since(start);
+        total_time_ns += elapsed;
+        samples.record(elapsed);
+        iterations += 1;
+    }
+
+    const percentiles = samples.computePercentiles(occupancy);
+    return makeResult(name, occupancy, total_time_ns, iterations, percentiles);
+}
+
+/// Insert + remove churn: time a full `count`-key insert-then-remove cycle.
+/// Reports ns per (insert+remove) pair — the control-plane allocate/free cost.
+fn benchInsertRemove(allocator: Allocator, comptime name: []const u8, count: u32) !BenchmarkResult {
+    std.debug.assert(count > 0);
+    std.debug.assert(count <= MAX_ELEMENT_STATES);
+
+    const pool = try createPool(allocator);
+    defer destroyPool(allocator, pool);
+
+    const warmup_iters = getWarmupIterations(count);
+    const min_sample_iters = getMinSampleIterations(count);
+
+    for (0..warmup_iters) |_| churnInsertRemove(pool, count);
+
+    var total_time_ns: u64 = 0;
+    var iterations: u32 = 0;
+    var samples = IterationSamples.init();
+
+    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_sample_iters) {
+        const start = time.Instant.now();
+        churnInsertRemove(pool, count);
+        const end = time.Instant.now();
+
+        const elapsed = end.since(start);
+        total_time_ns += elapsed;
+        samples.record(elapsed);
+        iterations += 1;
+    }
+
+    const percentiles = samples.computePercentiles(count);
+    return makeResult(name, count, total_time_ns, iterations, percentiles);
+}
+
+// =============================================================================
+// Counting Allocator (zero-allocation invariant check)
+// =============================================================================
+
+/// Wraps a backing allocator and counts every vtable call. After the pool is
+/// filled, a steady-state lookup loop must touch the heap zero times — the get
+/// path never allocates (CLAUDE.md §2). Mirrors the scene/animation suites.
+const CountingAllocator = struct {
+    backing: Allocator,
+    calls: u64 = 0,
+
+    fn allocator(self: *CountingAllocator) Allocator {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    const vtable = Allocator.VTable{
+        .alloc = alloc,
+        .resize = resize,
+        .remap = remap,
+        .free = free,
+    };
+
+    fn alloc(ctx: *anyopaque, len: usize, alignment: Alignment, ret_addr: usize) ?[*]u8 {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.calls += 1;
+        return self.backing.rawAlloc(len, alignment, ret_addr);
+    }
+
+    fn resize(ctx: *anyopaque, memory: []u8, alignment: Alignment, new_len: usize, ret_addr: usize) bool {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.calls += 1;
+        return self.backing.rawResize(memory, alignment, new_len, ret_addr);
+    }
+
+    fn remap(ctx: *anyopaque, memory: []u8, alignment: Alignment, new_len: usize, ret_addr: usize) ?[*]u8 {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.calls += 1;
+        return self.backing.rawRemap(memory, alignment, new_len, ret_addr);
+    }
+
+    fn free(ctx: *anyopaque, memory: []u8, alignment: Alignment, ret_addr: usize) void {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.calls += 1;
+        self.backing.rawFree(memory, alignment, ret_addr);
+    }
+};
+
+// =============================================================================
+// Validation Tests (run with `zig test src/context/element_states_benchmarks.zig`)
+// =============================================================================
+
+test "validate: filled pool returns every key and stays dense" {
+    const allocator = std.testing.allocator;
+
+    const pool = try createPool(allocator);
+    defer destroyPool(allocator, pool);
+
+    const occupancy: u32 = 512;
+    try fillPool(pool, occupancy);
+    try std.testing.expectEqual(occupancy, pool.len());
+
+    // Every inserted key resolves to a live slot.
+    var i: u32 = 0;
+    while (i < occupancy) : (i += 1) {
+        try std.testing.expect(pool.get(BenchState, i) != null);
+    }
+    // A key past the fill level is genuinely absent.
+    try std.testing.expect(pool.get(BenchState, occupancy) == null);
+}
+
+test "validate: insert + remove churn returns the pool to empty" {
+    const allocator = std.testing.allocator;
+
+    const pool = try createPool(allocator);
+    defer destroyPool(allocator, pool);
+
+    churnInsertRemove(pool, 256);
+    try std.testing.expectEqual(@as(u32, 0), pool.len());
+}
+
+test "validate: steady-state lookup performs zero heap allocations" {
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = gpa.deinit();
+
+    var counter = CountingAllocator{ .backing = gpa.allocator() };
+    const allocator = counter.allocator();
+
+    const pool = try createPool(allocator);
+    defer destroyPool(allocator, pool);
+
+    const occupancy: u32 = 256;
+    try fillPool(pool, occupancy);
+
+    // Warm once so any lazy first-use cost is paid before the gate.
+    std.mem.doNotOptimizeAway(getScanSum(pool, occupancy));
+    std.mem.doNotOptimizeAway(withHitSum(pool, occupancy));
+
+    const calls_before = counter.calls;
+
+    // Steady state: get and withElementState on present keys are pure lookups.
+    var iter: u32 = 0;
+    while (iter < 16) : (iter += 1) {
+        std.mem.doNotOptimizeAway(getScanSum(pool, occupancy));
+        std.mem.doNotOptimizeAway(withHitSum(pool, occupancy));
+    }
+
+    try std.testing.expectEqual(calls_before, counter.calls);
+}
+
+// =============================================================================
+// Main Entry Point (for benchmark executable)
+// =============================================================================
+
+/// Print a benchmark result and record it in the JSON reporter. Entries carry
+/// p50/p99; the regression gate still classifies on the min (best-of-N).
+fn collect(reporter: *bench.Reporter, result: BenchmarkResult) void {
+    result.print();
+    reporter.addEntry(bench.entryWithPercentiles(
+        result.name,
+        result.operation_count,
+        result.total_time_ns,
+        result.iterations,
+        result.min_per_op_ns,
+        result.p50_per_op_ns,
+        result.p99_per_op_ns,
+    ));
+}
+
+pub fn main(init: std.process.Init) !void {
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    var reporter = bench.Reporter.init("element-states", init.io, init.minimal.args.vector);
+
+    // =========================================================================
+    // Lookup vs Occupancy (the linear-scan cost curve)
+    // =========================================================================
+
+    printSectionHeader("Gooey Element-State Benchmarks — Lookup vs Occupancy (get hit, O(count) scan)");
+    collect(&reporter, try benchGetByOccupancy(allocator, "get_occupancy_8", 8));
+    collect(&reporter, try benchGetByOccupancy(allocator, "get_occupancy_64", 64));
+    collect(&reporter, try benchGetByOccupancy(allocator, "get_occupancy_512", 512));
+    collect(&reporter, try benchGetByOccupancy(allocator, "get_occupancy_4096", 4096));
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+
+    // =========================================================================
+    // Get-or-create Hit (the real per-frame call site, zero-alloc)
+    // =========================================================================
+
+    printSectionHeader("Gooey Element-State Benchmarks — Get-or-create Hit (withElementState on present keys)");
+    collect(&reporter, try benchWithHit(allocator, "with_hit_64", 64));
+    collect(&reporter, try benchWithHit(allocator, "with_hit_512", 512));
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+
+    // =========================================================================
+    // Insert + Remove (the allocating control-plane churn)
+    // =========================================================================
+
+    printSectionHeader("Gooey Element-State Benchmarks — Insert + Remove (create/destroy churn)");
+    collect(&reporter, try benchInsertRemove(allocator, "insert_remove_64", 64));
+    collect(&reporter, try benchInsertRemove(allocator, "insert_remove_512", 512));
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+
+    std.debug.print(
+        \\
+        \\Notes:
+        \\  - Lookup vs Occupancy = one get() per present key, averaged over scan
+        \\    positions (mean position = occupancy/2). A flat ns/op means the linear
+        \\    scan stays cheap; a rising curve is the signal to swap findIndex for a
+        \\    hash map (see element_states.zig findIndex comment).
+        \\  - Get-or-create Hit   = withElementState on present keys — the real frame
+        \\    call site. Must match get() and allocate zero (gated in the tests).
+        \\  - Insert + Remove     = create(S) miss path + remove() teardown; the only
+        \\    group that touches the heap, reported per insert+remove pair.
+        \\  - ns/op and percentiles are per lookup / per pair; iterations are adaptive.
+        \\
+    , .{});
+
+    reporter.finish();
+}
+
+// =============================================================================
+// Section Printers
+// =============================================================================
+
+fn printSectionHeader(comptime title: []const u8) void {
+    comptime std.debug.assert(title.len > 0);
+    comptime std.debug.assert(title.len < TABLE_WIDTH);
+    std.debug.print("\n", .{});
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+    std.debug.print("{s}\n", .{title});
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+    printHeader();
+    std.debug.print("-" ** TABLE_WIDTH ++ "\n", .{});
+}
+
+fn printHeader() void {
+    std.debug.print("| {s:<40} | {s:>7} | {s:>9} | {s:>9} | {s:>9} | {s:>6} |\n", .{
+        "Test",
+        "Ops",
+        "ns/op",
+        "p50",
+        "p99",
+        "Iters",
+    });
+}

--- a/src/scene/benchmarks.zig
+++ b/src/scene/benchmarks.zig
@@ -1,0 +1,1038 @@
+//! Scene Module Benchmarks
+//!
+//! Benchmark suite for the data-plane pipeline: the scene → batch → frame path
+//! that actually feeds the GPU. The control-plane suites (`bench`, `bench-context`,
+//! `bench-core`, `bench-text`) cover layout, the dispatch tree, geometry, and text
+//! shaping; this suite measures what those produce per frame — the instances/vertices
+//! emitted, how cleanly they batch, the draw-order sort, and the clip stack.
+//!
+//! Run as executable: zig build bench-scene
+//! Quick tests only:  zig test src/scene/benchmarks.zig (validates counts + zero-alloc)
+//!
+//! Groups:
+//!   - Scene build      — clear() + insertQuad/insertGlyph/insertShadow emission
+//!   - Batch iteration  — BatchIterator.next() drain cost + batch count (coalescing)
+//!   - Draw-order sort  — finish() pdq sort over an out-of-order quad array
+//!   - Clip stack       — pushClip/popClip pairs at increasing nesting depth
+//!   - Frame e2e        — clear → build → finish → drain, reported against the
+//!                        16.6 ms (60 Hz) / 8.3 ms (120 Hz) frame budget with p99
+//!
+//! Why these: CLAUDE.md §7 ("how many vertices/texture uploads per frame?") and §8
+//! ("batching is religion") call for measuring the data plane directly. The frame
+//! group is the only number that answers "do we fit the frame budget?"; it reports
+//! tail latency (p99), since GUI quality is frame-budget consistency, not throughput.
+//!
+//! Scope note: this measures the headless scene→batch portion of the frame. The
+//! platform/GPU submission in `runtime/frame.zig` needs a live window, Metal device,
+//! and CoreText stack, so it cannot run in a headless benchmark; the scene data plane
+//! is the part that is both measurable here and the GPU-bandwidth proxy.
+
+const std = @import("std");
+const gooey = @import("gooey");
+const bench = @import("bench");
+
+const Allocator = std.mem.Allocator;
+const Alignment = std.mem.Alignment;
+
+/// Minimal `Instant.now()` / `.since()` shim over `std.Io.Clock.awake`, kept
+/// local to the benchmark module so every sample site reads as a two-line
+/// capture-then-diff instead of threading `io` through every benchmark
+/// helper signature. `.awake` is the monotonic clock — deltas here can
+/// never go negative regardless of NTP or sysadmin clock edits.
+///
+/// `std.Io` is a pair of pointers into a process-lifetime vtable, so the
+/// per-call `global_single_threaded.io()` lookup compiles down to a pair
+/// of constant pointer loads — effectively free.
+const time = struct {
+    inline fn benchIo() std.Io {
+        return std.Io.Threaded.global_single_threaded.io();
+    }
+
+    const Instant = struct {
+        ts: std.Io.Timestamp,
+
+        inline fn now() Instant {
+            return .{ .ts = std.Io.Timestamp.now(benchIo(), .awake) };
+        }
+
+        inline fn since(self: Instant, earlier: Instant) u64 {
+            const ns: i96 = earlier.ts.durationTo(self.ts).toNanoseconds();
+            std.debug.assert(ns >= 0);
+            return @intCast(ns);
+        }
+    };
+};
+
+const scene_mod = gooey.scene;
+const Scene = scene_mod.Scene;
+const Quad = scene_mod.Quad;
+const GlyphInstance = scene_mod.GlyphInstance;
+const Shadow = scene_mod.Shadow;
+const Hsla = scene_mod.Hsla;
+const BatchIterator = scene_mod.BatchIterator;
+
+const MAX_QUADS_PER_FRAME = scene_mod.MAX_QUADS_PER_FRAME;
+const MAX_GLYPHS_PER_FRAME = scene_mod.MAX_GLYPHS_PER_FRAME;
+const MAX_SHADOWS_PER_FRAME = scene_mod.MAX_SHADOWS_PER_FRAME;
+const MAX_CLIP_STACK_DEPTH = scene_mod.MAX_CLIP_STACK_DEPTH;
+
+// =============================================================================
+// Benchmark Configuration
+// =============================================================================
+
+/// Adaptive warmup iterations based on operation count.
+fn getWarmupIterations(operation_count: u32) u32 {
+    std.debug.assert(operation_count > 0);
+    if (operation_count >= 10000) return 2;
+    if (operation_count >= 5000) return 3;
+    return 5;
+}
+
+/// Adaptive minimum sample iterations based on operation count.
+fn getMinSampleIterations(operation_count: u32) u32 {
+    std.debug.assert(operation_count > 0);
+    if (operation_count >= 10000) return 5;
+    if (operation_count >= 5000) return 8;
+    return 10;
+}
+
+/// Minimum wall-clock time to sample before concluding a benchmark.
+const MIN_SAMPLE_TIME_NS: u64 = 50 * std.time.ns_per_ms;
+
+/// Maximum per-iteration samples collected for percentile computation.
+/// 4096 samples * 8 bytes = 32 KB — fits comfortably on the stack.
+const MAX_SAMPLE_COUNT: u32 = 4096;
+
+/// Hard cap on batches drained from a single scene (CLAUDE.md §4: limit
+/// everything). A scene can never produce more batches than primitives, and
+/// the per-frame primitive caps sum to well under this; exceeding it means a
+/// BatchIterator bug, so we fail fast rather than spin.
+const MAX_DRAIN_BATCHES: u32 = 262_144;
+
+/// Per-frame budgets in nanoseconds for the frame e2e summary.
+const FRAME_BUDGET_60HZ_NS: f64 = 16_666_667.0;
+const FRAME_BUDGET_120HZ_NS: f64 = 8_333_333.0;
+
+/// Table width for benchmark output formatting (characters per row).
+const TABLE_WIDTH = 104;
+
+// =============================================================================
+// Iteration Sample Collection and Percentile Computation
+// =============================================================================
+
+/// Per-iteration timing data for percentile analysis. Fixed capacity avoids
+/// dynamic allocation during benchmark runs. Mirrors the text suite so both
+/// percentile-reporting suites share one shape.
+const IterationSamples = struct {
+    times_ns: [MAX_SAMPLE_COUNT]u64,
+    count: u32,
+
+    fn init() IterationSamples {
+        return .{ .times_ns = undefined, .count = 0 };
+    }
+
+    /// Record one iteration's elapsed time. Drops samples beyond capacity
+    /// (the first MAX_SAMPLE_COUNT samples are sufficient for percentiles).
+    fn record(self: *IterationSamples, elapsed_ns: u64) void {
+        if (self.count < MAX_SAMPLE_COUNT) {
+            self.times_ns[self.count] = elapsed_ns;
+            self.count += 1;
+        }
+    }
+
+    /// Sort collected samples and extract min/p50/p99 percentiles as ns/op.
+    /// Mutates the internal array (sort is idempotent on subsequent calls).
+    fn computePercentiles(self: *IterationSamples, operation_count: u32) PercentileResult {
+        std.debug.assert(self.count > 0);
+        std.debug.assert(operation_count > 0);
+
+        const slice = self.times_ns[0..self.count];
+        std.mem.sort(u64, slice, {}, struct {
+            fn lessThan(_: void, a: u64, b: u64) bool {
+                return a < b;
+            }
+        }.lessThan);
+
+        const last_index = self.count - 1;
+        const last_f: f64 = @floatFromInt(last_index);
+        const p50_index: u32 = @intFromFloat(0.50 * last_f);
+        const p99_index: u32 = @intFromFloat(@min(0.99 * last_f, last_f));
+        const ops_f: f64 = @floatFromInt(operation_count);
+
+        return .{
+            // The slice is sorted ascending, so slice[0] is the fastest sample (the min).
+            .min_per_op_ns = @as(f64, @floatFromInt(slice[0])) / ops_f,
+            .p50_per_op_ns = @as(f64, @floatFromInt(slice[p50_index])) / ops_f,
+            .p99_per_op_ns = @as(f64, @floatFromInt(slice[p99_index])) / ops_f,
+        };
+    }
+};
+
+/// Percentile statistics computed from iteration samples.
+const PercentileResult = struct {
+    min_per_op_ns: f64,
+    p50_per_op_ns: f64,
+    p99_per_op_ns: f64,
+};
+
+// =============================================================================
+// Benchmark Results
+// =============================================================================
+
+const BenchmarkResult = struct {
+    name: []const u8,
+    operation_count: u32,
+    total_time_ns: u64,
+    iterations: u32,
+    min_per_op_ns: f64,
+    p50_per_op_ns: f64,
+    p99_per_op_ns: f64,
+    /// Number of draw-order batches the BatchIterator emitted for the scene.
+    /// Zero for groups where batching is not exercised (build/sort/clip).
+    batch_count: u32 = 0,
+
+    pub fn avgTimeMs(self: BenchmarkResult) f64 {
+        std.debug.assert(self.iterations > 0);
+        const avg_ns: f64 = @as(f64, @floatFromInt(self.total_time_ns)) /
+            @as(f64, @floatFromInt(self.iterations));
+        return avg_ns / std.time.ns_per_ms;
+    }
+
+    pub fn timePerOpNs(self: BenchmarkResult) f64 {
+        std.debug.assert(self.iterations > 0);
+        std.debug.assert(self.operation_count > 0);
+        const avg_ns = @as(f64, @floatFromInt(self.total_time_ns)) /
+            @as(f64, @floatFromInt(self.operation_count * self.iterations));
+        return avg_ns;
+    }
+
+    pub fn print(self: BenchmarkResult) void {
+        std.debug.assert(self.iterations > 0);
+        std.debug.assert(self.operation_count > 0);
+        // Batched groups show the batch count; non-batched groups show "-".
+        if (self.batch_count > 0) {
+            std.debug.print(
+                "| {s:<40} | {d:>7} | {d:>9.2} | {d:>9.2} | {d:>9.2} | {d:>7} | {d:>6} |\n",
+                .{ self.name, self.operation_count, self.timePerOpNs(), self.p50_per_op_ns, self.p99_per_op_ns, self.batch_count, self.iterations },
+            );
+        } else {
+            std.debug.print(
+                "| {s:<40} | {d:>7} | {d:>9.2} | {d:>9.2} | {d:>9.2} | {s:>7} | {d:>6} |\n",
+                .{ self.name, self.operation_count, self.timePerOpNs(), self.p50_per_op_ns, self.p99_per_op_ns, "-", self.iterations },
+            );
+        }
+    }
+
+    /// Frame e2e summary line: total per-frame time (avg + p99) in microseconds
+    /// and avg as a percentage of the 60 Hz and 120 Hz budgets. This is the
+    /// "do we fit the budget?" number, so it is reported in whole-frame units.
+    pub fn printFrameBudget(self: BenchmarkResult) void {
+        std.debug.assert(self.iterations > 0);
+        std.debug.assert(self.operation_count > 0);
+        const avg_ns: f64 = @as(f64, @floatFromInt(self.total_time_ns)) /
+            @as(f64, @floatFromInt(self.iterations));
+        const p99_ns: f64 = self.p99_per_op_ns * @as(f64, @floatFromInt(self.operation_count));
+        std.debug.print(
+            "| {s:<28} | {d:>6} | {d:>5} | {d:>9.2} us | {d:>9.2} us | {d:>6.2}% | {d:>6.2}% |\n",
+            .{
+                self.name,
+                self.operation_count,
+                self.batch_count,
+                avg_ns / 1000.0,
+                p99_ns / 1000.0,
+                100.0 * avg_ns / FRAME_BUDGET_60HZ_NS,
+                100.0 * avg_ns / FRAME_BUDGET_120HZ_NS,
+            },
+        );
+    }
+};
+
+/// Assemble a result from the common runner outputs. Centralizes the invariant
+/// checks so each runner ends with a single tail call.
+fn makeResult(
+    name: []const u8,
+    operation_count: u32,
+    total_time_ns: u64,
+    iterations: u32,
+    percentiles: PercentileResult,
+    batch_count: u32,
+) BenchmarkResult {
+    std.debug.assert(operation_count > 0);
+    std.debug.assert(iterations > 0);
+    std.debug.assert(batch_count <= operation_count);
+    return .{
+        .name = name,
+        .operation_count = operation_count,
+        .total_time_ns = total_time_ns,
+        .iterations = iterations,
+        .min_per_op_ns = percentiles.min_per_op_ns,
+        .p50_per_op_ns = percentiles.p50_per_op_ns,
+        .p99_per_op_ns = percentiles.p99_per_op_ns,
+        .batch_count = batch_count,
+    };
+}
+
+// =============================================================================
+// Scene Builders
+//
+// Each builder populates a freshly-cleared scene and returns the primitive
+// count it emitted. They use only quads/glyphs/shadows (no paths/meshes) so the
+// data plane is exercised without pulling in mesh-pool allocation — keeping the
+// frame group on the static-allocation fast path (CLAUDE.md §2).
+// =============================================================================
+
+/// N filled quads in insertion order (auto-assigned ascending draw orders).
+/// Coalesces into a single batch — the best case for the BatchIterator.
+fn buildQuads(scene: *Scene, count: u32) Allocator.Error!u32 {
+    std.debug.assert(count > 0);
+    std.debug.assert(count <= MAX_QUADS_PER_FRAME);
+
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        const fi: f32 = @floatFromInt(i);
+        try scene.insertQuad(Quad.filled(fi * 2.0, fi * 1.5, 40.0, 24.0, Hsla.blue));
+    }
+    return count;
+}
+
+/// N glyphs in insertion order. Also a single coalesced batch.
+fn buildGlyphs(scene: *Scene, count: u32) Allocator.Error!u32 {
+    std.debug.assert(count > 0);
+    std.debug.assert(count <= MAX_GLYPHS_PER_FRAME);
+
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        const fi: f32 = @floatFromInt(i);
+        try scene.insertGlyph(GlyphInstance.init(fi * 7.0, 100.0, 6.0, 12.0, 0.0, 0.0, 0.5, 0.5, Hsla.black));
+    }
+    return count;
+}
+
+/// Alternating quad/glyph emission — the worst case for batching: every
+/// primitive sits between two of another type, so the iterator emits one batch
+/// per primitive. Returns `pairs * 2` primitives.
+fn buildInterleaved(scene: *Scene, pairs: u32) Allocator.Error!u32 {
+    std.debug.assert(pairs > 0);
+    std.debug.assert(pairs <= MAX_GLYPHS_PER_FRAME);
+    std.debug.assert(pairs <= MAX_QUADS_PER_FRAME);
+
+    var i: u32 = 0;
+    while (i < pairs) : (i += 1) {
+        const fi: f32 = @floatFromInt(i);
+        try scene.insertQuad(Quad.filled(fi, fi, 10.0, 10.0, Hsla.red));
+        try scene.insertGlyph(GlyphInstance.init(fi, fi, 6.0, 12.0, 0.0, 0.0, 0.5, 0.5, Hsla.black));
+    }
+    return pairs * 2;
+}
+
+/// A realistic "dashboard": a background, then a grid of cards, each a shadow +
+/// rounded quad + a run of label glyphs. The per-panel glyph run coalesces into
+/// one batch, so batch count grows with panels (mixed scene), not glyphs.
+fn buildDashboard(scene: *Scene, panel_count: u32, glyphs_per_panel: u32) Allocator.Error!u32 {
+    std.debug.assert(panel_count > 0);
+    std.debug.assert(panel_count <= MAX_SHADOWS_PER_FRAME);
+    std.debug.assert(glyphs_per_panel > 0);
+
+    try scene.insertQuad(Quad.filled(0.0, 0.0, 1280.0, 800.0, Hsla.white));
+    var count: u32 = 1;
+
+    var p: u32 = 0;
+    while (p < panel_count) : (p += 1) {
+        const col: f32 = @floatFromInt(p % 4);
+        const row: f32 = @floatFromInt(p / 4);
+        const x = 16.0 + col * 312.0;
+        const y = 16.0 + row * 120.0;
+
+        const card = Quad.rounded(x, y, 296.0, 104.0, Hsla.blue, 8.0);
+        try scene.insertShadow(Shadow.forQuad(card, 8.0));
+        try scene.insertQuad(card);
+        count += 2;
+
+        var g: u32 = 0;
+        while (g < glyphs_per_panel) : (g += 1) {
+            const fg: f32 = @floatFromInt(g);
+            try scene.insertGlyph(GlyphInstance.init(x + 12.0 + fg * 7.0, y + 16.0, 6.0, 12.0, 0.0, 0.0, 0.5, 0.5, Hsla.black));
+            count += 1;
+        }
+    }
+
+    std.debug.assert(count == 1 + panel_count * (2 + glyphs_per_panel));
+    return count;
+}
+
+// Zero-argument wrappers so the runners can take a `comptime build_fn`.
+fn buildQuads256(scene: *Scene) Allocator.Error!u32 {
+    return buildQuads(scene, 256);
+}
+fn buildQuads2k(scene: *Scene) Allocator.Error!u32 {
+    return buildQuads(scene, 2000);
+}
+fn buildQuads16k(scene: *Scene) Allocator.Error!u32 {
+    return buildQuads(scene, 16000);
+}
+fn buildGlyphs2k(scene: *Scene) Allocator.Error!u32 {
+    return buildGlyphs(scene, 2000);
+}
+fn buildGlyphs16k(scene: *Scene) Allocator.Error!u32 {
+    return buildGlyphs(scene, 16000);
+}
+fn buildInterleaved2k(scene: *Scene) Allocator.Error!u32 {
+    return buildInterleaved(scene, 2000);
+}
+fn buildDashboardSmall(scene: *Scene) Allocator.Error!u32 {
+    return buildDashboard(scene, 12, 20);
+}
+fn buildDashboardMedium(scene: *Scene) Allocator.Error!u32 {
+    return buildDashboard(scene, 48, 30);
+}
+fn buildDashboardLarge(scene: *Scene) Allocator.Error!u32 {
+    return buildDashboard(scene, 120, 40);
+}
+
+// =============================================================================
+// Batch Drain Helper
+// =============================================================================
+
+const DrainResult = struct {
+    primitives: u64,
+    batches: u32,
+};
+
+/// Drain a finished scene through the BatchIterator, returning the total
+/// primitives and batch count. The returned `primitives` total is fed to
+/// `doNotOptimizeAway` by timed callers so the drain is not elided.
+fn drainScene(scene: *const Scene) DrainResult {
+    var iterator = BatchIterator.init(scene);
+    var primitives: u64 = 0;
+    var batches: u32 = 0;
+
+    while (iterator.next()) |batch| {
+        primitives += batch.len();
+        batches += 1;
+        // Fail fast on a runaway iterator rather than spinning unbounded.
+        if (batches >= MAX_DRAIN_BATCHES) unreachable;
+    }
+
+    std.debug.assert(iterator.done());
+    return .{ .primitives = primitives, .batches = batches };
+}
+
+// =============================================================================
+// Benchmark Runners
+// =============================================================================
+
+/// Scene build: time clear() + primitive emission together (both are per-frame
+/// data-plane costs). Reports nanoseconds per emitted primitive.
+fn benchSceneBuild(
+    allocator: Allocator,
+    comptime name: []const u8,
+    comptime build_fn: fn (*Scene) Allocator.Error!u32,
+) !BenchmarkResult {
+    var scene = try Scene.initCapacity(allocator);
+    defer scene.deinit();
+
+    scene.clear();
+    const operation_count = try build_fn(&scene);
+    std.debug.assert(operation_count > 0);
+
+    const warmup_iters = getWarmupIterations(operation_count);
+    const min_sample_iters = getMinSampleIterations(operation_count);
+
+    for (0..warmup_iters) |_| {
+        scene.clear();
+        _ = try build_fn(&scene);
+    }
+
+    var total_time_ns: u64 = 0;
+    var iterations: u32 = 0;
+    var samples = IterationSamples.init();
+
+    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_sample_iters) {
+        const start = time.Instant.now();
+        scene.clear();
+        const emitted = try build_fn(&scene);
+        const end = time.Instant.now();
+        std.debug.assert(emitted == operation_count);
+
+        const elapsed = end.since(start);
+        total_time_ns += elapsed;
+        samples.record(elapsed);
+        iterations += 1;
+    }
+
+    const percentiles = samples.computePercentiles(operation_count);
+    return makeResult(name, operation_count, total_time_ns, iterations, percentiles, 0);
+}
+
+/// Batch iteration: build + finish once, then time draining the finished scene
+/// through the BatchIterator. Reports ns per primitive drained and the batch
+/// count (the coalescing measure from CLAUDE.md §8).
+fn benchBatchIterate(
+    allocator: Allocator,
+    comptime name: []const u8,
+    comptime build_fn: fn (*Scene) Allocator.Error!u32,
+) !BenchmarkResult {
+    var scene = try Scene.initCapacity(allocator);
+    defer scene.deinit();
+
+    scene.clear();
+    const operation_count = try build_fn(&scene);
+    scene.finish();
+    std.debug.assert(operation_count > 0);
+
+    // Batch count is a structural property of the scene — measure it once.
+    const structure = drainScene(&scene);
+    std.debug.assert(structure.primitives == operation_count);
+    std.debug.assert(structure.batches > 0);
+    const batch_count = structure.batches;
+
+    const warmup_iters = getWarmupIterations(operation_count);
+    const min_sample_iters = getMinSampleIterations(operation_count);
+
+    for (0..warmup_iters) |_| {
+        std.mem.doNotOptimizeAway(drainScene(&scene).primitives);
+    }
+
+    var total_time_ns: u64 = 0;
+    var iterations: u32 = 0;
+    var samples = IterationSamples.init();
+
+    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_sample_iters) {
+        const start = time.Instant.now();
+        const drained = drainScene(&scene);
+        const end = time.Instant.now();
+        std.mem.doNotOptimizeAway(drained.primitives);
+
+        const elapsed = end.since(start);
+        total_time_ns += elapsed;
+        samples.record(elapsed);
+        iterations += 1;
+    }
+
+    const percentiles = samples.computePercentiles(operation_count);
+    return makeResult(name, operation_count, total_time_ns, iterations, percentiles, batch_count);
+}
+
+/// Seed a scene with `count` quads whose draw orders are a deterministic
+/// pseudo-random permutation, and snapshot that unsorted state into `out`. The
+/// scene's quad array is left dirty so `finish()` must re-sort it.
+///
+/// We reach into `scene.quads.items` / `scene.needs_sort_quads` directly: there
+/// is no public API to overwrite a quad's order in place, and the sort
+/// microbench needs to restore the unsorted permutation each iteration without
+/// paying the insertion cost. Acceptable coupling for a benchmark.
+fn seedShuffledQuads(scene: *Scene, count: u32, out: []Quad) Allocator.Error!void {
+    std.debug.assert(count > 1);
+    std.debug.assert(out.len == count);
+
+    scene.clear();
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        try scene.insertQuad(Quad.filled(0.0, 0.0, 1.0, 1.0, Hsla.white));
+    }
+    std.debug.assert(scene.quads.items.len == count);
+
+    // xorshift32 gives a cheap, deterministic order permutation so pdq does
+    // real O(n log n) work each iteration (not a reverse-sorted fast path).
+    var rng: u32 = 0x9E3779B9;
+    i = 0;
+    while (i < count) : (i += 1) {
+        rng ^= rng << 13;
+        rng ^= rng >> 17;
+        rng ^= rng << 5;
+        out[i] = scene.quads.items[i];
+        out[i].order = rng % count;
+    }
+    scene.needs_sort_quads = true;
+}
+
+/// Draw-order sort: time `finish()` over a quad array re-shuffled to the same
+/// unsorted permutation each iteration. The memcpy restore is outside the timed
+/// region, so only the pdq sort is measured. Reports ns per quad sorted.
+fn benchDrawOrderSort(
+    allocator: Allocator,
+    comptime name: []const u8,
+    count: u32,
+) !BenchmarkResult {
+    std.debug.assert(count > 1);
+    std.debug.assert(count <= MAX_QUADS_PER_FRAME);
+
+    var scene = try Scene.initCapacity(allocator);
+    defer scene.deinit();
+
+    const unsorted = try allocator.alloc(Quad, count);
+    defer allocator.free(unsorted);
+
+    try seedShuffledQuads(&scene, count, unsorted);
+    const items = scene.quads.items;
+    std.debug.assert(items.len == count);
+
+    const warmup_iters = getWarmupIterations(count);
+    const min_sample_iters = getMinSampleIterations(count);
+
+    for (0..warmup_iters) |_| {
+        @memcpy(items, unsorted);
+        scene.needs_sort_quads = true;
+        scene.finish();
+    }
+
+    var total_time_ns: u64 = 0;
+    var iterations: u32 = 0;
+    var samples = IterationSamples.init();
+
+    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_sample_iters) {
+        @memcpy(items, unsorted); // restore unsorted permutation (untimed)
+        scene.needs_sort_quads = true;
+
+        const start = time.Instant.now();
+        scene.finish();
+        const end = time.Instant.now();
+        std.debug.assert(scene.quads.items[0].order <= scene.quads.items[count - 1].order);
+
+        const elapsed = end.since(start);
+        total_time_ns += elapsed;
+        samples.record(elapsed);
+        iterations += 1;
+    }
+
+    const percentiles = samples.computePercentiles(count);
+    return makeResult(name, count, total_time_ns, iterations, percentiles, 0);
+}
+
+/// Clip stack: time `depth` pushClip calls (each intersecting the current clip)
+/// followed by `depth` popClip calls. Reports ns per push/pop pair — the cost
+/// of one nested clip level.
+fn benchClipStack(
+    allocator: Allocator,
+    comptime name: []const u8,
+    depth: u32,
+) !BenchmarkResult {
+    std.debug.assert(depth > 0);
+    std.debug.assert(depth <= MAX_CLIP_STACK_DEPTH);
+
+    var scene = try Scene.initCapacity(allocator);
+    defer scene.deinit();
+
+    const warmup_iters = getWarmupIterations(depth);
+    const min_sample_iters = getMinSampleIterations(depth);
+
+    for (0..warmup_iters) |_| {
+        try pushPopClips(&scene, depth);
+    }
+
+    var total_time_ns: u64 = 0;
+    var iterations: u32 = 0;
+    var samples = IterationSamples.init();
+
+    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_sample_iters) {
+        const start = time.Instant.now();
+        try pushPopClips(&scene, depth);
+        const end = time.Instant.now();
+        std.debug.assert(!scene.hasActiveClip());
+
+        const elapsed = end.since(start);
+        total_time_ns += elapsed;
+        samples.record(elapsed);
+        iterations += 1;
+    }
+
+    const percentiles = samples.computePercentiles(depth);
+    return makeResult(name, depth, total_time_ns, iterations, percentiles, 0);
+}
+
+/// Push `depth` nested clips (each shrinking inward so intersection does real
+/// work) then pop them all. Leaves the clip stack empty.
+fn pushPopClips(scene: *Scene, depth: u32) Allocator.Error!void {
+    std.debug.assert(depth > 0);
+    std.debug.assert(depth <= MAX_CLIP_STACK_DEPTH);
+
+    var i: u32 = 0;
+    while (i < depth) : (i += 1) {
+        const fi: f32 = @floatFromInt(i);
+        try scene.pushClip(.{ .x = fi, .y = fi, .width = 1000.0 - fi * 2.0, .height = 1000.0 - fi * 2.0 });
+    }
+    i = 0;
+    while (i < depth) : (i += 1) {
+        scene.popClip();
+    }
+}
+
+/// Frame e2e: the full data-plane cycle — clear → build → finish → drain — the
+/// only number that answers "do we fit the frame budget?". Reports ns per
+/// primitive (gated) plus, via printFrameBudget, whole-frame avg/p99.
+fn benchFrame(
+    allocator: Allocator,
+    comptime name: []const u8,
+    comptime build_fn: fn (*Scene) Allocator.Error!u32,
+) !BenchmarkResult {
+    var scene = try Scene.initCapacity(allocator);
+    defer scene.deinit();
+
+    scene.clear();
+    const operation_count = try build_fn(&scene);
+    scene.finish();
+    const batch_count = drainScene(&scene).batches;
+    std.debug.assert(batch_count > 0);
+
+    const warmup_iters = getWarmupIterations(operation_count);
+    const min_sample_iters = getMinSampleIterations(operation_count);
+
+    for (0..warmup_iters) |_| {
+        scene.clear();
+        _ = try build_fn(&scene);
+        scene.finish();
+        std.mem.doNotOptimizeAway(drainScene(&scene).primitives);
+    }
+
+    var total_time_ns: u64 = 0;
+    var iterations: u32 = 0;
+    var samples = IterationSamples.init();
+
+    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_sample_iters) {
+        const start = time.Instant.now();
+        scene.clear();
+        const emitted = try build_fn(&scene);
+        scene.finish();
+        const drained = drainScene(&scene);
+        const end = time.Instant.now();
+        std.debug.assert(emitted == operation_count);
+        std.mem.doNotOptimizeAway(drained.primitives);
+
+        const elapsed = end.since(start);
+        total_time_ns += elapsed;
+        samples.record(elapsed);
+        iterations += 1;
+    }
+
+    const percentiles = samples.computePercentiles(operation_count);
+    return makeResult(name, operation_count, total_time_ns, iterations, percentiles, batch_count);
+}
+
+// =============================================================================
+// Counting Allocator (zero-allocation invariant check)
+// =============================================================================
+
+/// Wraps a backing allocator and counts every vtable call. After `initCapacity`
+/// pre-allocates the scene's arrays, a steady-state frame must touch the heap
+/// zero times (CLAUDE.md §2: zero dynamic allocation after init). This turns
+/// that belief into a checkable fact in the validate tests below.
+const CountingAllocator = struct {
+    backing: Allocator,
+    calls: u64 = 0,
+
+    fn allocator(self: *CountingAllocator) Allocator {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    const vtable = Allocator.VTable{
+        .alloc = alloc,
+        .resize = resize,
+        .remap = remap,
+        .free = free,
+    };
+
+    fn alloc(ctx: *anyopaque, len: usize, alignment: Alignment, ret_addr: usize) ?[*]u8 {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.calls += 1;
+        return self.backing.rawAlloc(len, alignment, ret_addr);
+    }
+
+    fn resize(ctx: *anyopaque, memory: []u8, alignment: Alignment, new_len: usize, ret_addr: usize) bool {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.calls += 1;
+        return self.backing.rawResize(memory, alignment, new_len, ret_addr);
+    }
+
+    fn remap(ctx: *anyopaque, memory: []u8, alignment: Alignment, new_len: usize, ret_addr: usize) ?[*]u8 {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.calls += 1;
+        return self.backing.rawRemap(memory, alignment, new_len, ret_addr);
+    }
+
+    fn free(ctx: *anyopaque, memory: []u8, alignment: Alignment, ret_addr: usize) void {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.calls += 1;
+        self.backing.rawFree(memory, alignment, ret_addr);
+    }
+};
+
+// =============================================================================
+// Validation Tests (run with `zig test src/scene/benchmarks.zig`)
+//
+// These do not time anything — they assert the builders emit the expected
+// primitive counts, the BatchIterator drains exactly what was built, and the
+// steady-state frame allocates nothing.
+// =============================================================================
+
+fn validateBuild(comptime build_fn: fn (*Scene) Allocator.Error!u32, expected: u32) !void {
+    const allocator = std.testing.allocator;
+    var scene = try Scene.initCapacity(allocator);
+    defer scene.deinit();
+
+    scene.clear();
+    const emitted = try build_fn(&scene);
+    try std.testing.expectEqual(expected, emitted);
+
+    scene.finish();
+    const drained = drainScene(&scene);
+    try std.testing.expectEqual(@as(u64, expected), drained.primitives);
+    try std.testing.expect(drained.batches > 0);
+    try std.testing.expect(drained.batches <= emitted);
+}
+
+test "validate: build quads emits and drains expected count" {
+    try validateBuild(buildQuads256, 256);
+}
+
+test "validate: build glyphs emits and drains expected count" {
+    try validateBuild(buildGlyphs2k, 2000);
+}
+
+test "validate: interleaved build is the worst case for batching" {
+    const allocator = std.testing.allocator;
+    var scene = try Scene.initCapacity(allocator);
+    defer scene.deinit();
+
+    scene.clear();
+    const emitted = try buildInterleaved(&scene, 100);
+    try std.testing.expectEqual(@as(u32, 200), emitted);
+
+    scene.finish();
+    const drained = drainScene(&scene);
+    // Alternating quad/glyph means every primitive is its own batch.
+    try std.testing.expectEqual(@as(u32, 200), drained.batches);
+}
+
+test "validate: dashboard emits 1 + panels*(2 + glyphs)" {
+    const allocator = std.testing.allocator;
+    var scene = try Scene.initCapacity(allocator);
+    defer scene.deinit();
+
+    scene.clear();
+    const emitted = try buildDashboard(&scene, 12, 20);
+    try std.testing.expectEqual(@as(u32, 1 + 12 * (2 + 20)), emitted);
+}
+
+test "validate: finish sorts an out-of-order quad array ascending" {
+    const allocator = std.testing.allocator;
+    var scene = try Scene.initCapacity(allocator);
+    defer scene.deinit();
+
+    const count: u32 = 512;
+    const unsorted = try allocator.alloc(Quad, count);
+    defer allocator.free(unsorted);
+
+    try seedShuffledQuads(&scene, count, unsorted);
+    @memcpy(scene.quads.items, unsorted);
+    scene.needs_sort_quads = true;
+    scene.finish();
+
+    // After finish, draw orders are non-decreasing.
+    var i: u32 = 1;
+    while (i < count) : (i += 1) {
+        try std.testing.expect(scene.quads.items[i - 1].order <= scene.quads.items[i].order);
+    }
+}
+
+test "validate: clip stack is balanced after push/pop" {
+    const allocator = std.testing.allocator;
+    var scene = try Scene.initCapacity(allocator);
+    defer scene.deinit();
+
+    try pushPopClips(&scene, MAX_CLIP_STACK_DEPTH);
+    try std.testing.expect(!scene.hasActiveClip());
+}
+
+test "validate: steady-state frame performs zero heap allocations" {
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = gpa.deinit();
+
+    var counter = CountingAllocator{ .backing = gpa.allocator() };
+    const allocator = counter.allocator();
+
+    var scene = try Scene.initCapacity(allocator);
+    defer scene.deinit();
+
+    // Warm once so any lazy first-use allocation happens before we measure.
+    scene.clear();
+    _ = try buildDashboardSmall(&scene);
+    scene.finish();
+    _ = drainScene(&scene);
+
+    const calls_before = counter.calls;
+
+    // Steady state: clear retains capacity, inserts stay under the pre-allocated
+    // caps, finish sorts in place, the iterator never allocates. Net heap: zero.
+    var frame: u32 = 0;
+    while (frame < 16) : (frame += 1) {
+        scene.clear();
+        _ = try buildDashboardSmall(&scene);
+        scene.finish();
+        std.mem.doNotOptimizeAway(drainScene(&scene).primitives);
+    }
+
+    try std.testing.expectEqual(calls_before, counter.calls);
+}
+
+// =============================================================================
+// Main Entry Point (for benchmark executable)
+// =============================================================================
+
+/// Print a benchmark result and record it in the JSON reporter. Scene benchmarks
+/// carry p50/p99 percentiles, so the entry uses the percentile constructor; the
+/// regression gate still classifies on the min (best-of-N).
+fn collect(reporter: *bench.Reporter, result: BenchmarkResult) void {
+    result.print();
+    reporter.addEntry(bench.entryWithPercentiles(
+        result.name,
+        result.operation_count,
+        result.total_time_ns,
+        result.iterations,
+        result.min_per_op_ns,
+        result.p50_per_op_ns,
+        result.p99_per_op_ns,
+    ));
+}
+
+/// Record a frame result in the reporter (no per-op table print — the frame
+/// group prints its own whole-frame budget line via printFrameBudget).
+fn collectFrame(reporter: *bench.Reporter, result: BenchmarkResult) void {
+    result.printFrameBudget();
+    reporter.addEntry(bench.entryWithPercentiles(
+        result.name,
+        result.operation_count,
+        result.total_time_ns,
+        result.iterations,
+        result.min_per_op_ns,
+        result.p50_per_op_ns,
+        result.p99_per_op_ns,
+    ));
+}
+
+pub fn main(init: std.process.Init) !void {
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    var reporter = bench.Reporter.init("scene", init.io, init.minimal.args.vector);
+
+    // =========================================================================
+    // Scene Build
+    // =========================================================================
+
+    printSectionHeader("Gooey Scene Benchmarks — Scene Build (clear + primitive emission)");
+    collect(&reporter, try benchSceneBuild(allocator, "build_quads_256", buildQuads256));
+    collect(&reporter, try benchSceneBuild(allocator, "build_quads_2k", buildQuads2k));
+    collect(&reporter, try benchSceneBuild(allocator, "build_quads_16k", buildQuads16k));
+    collect(&reporter, try benchSceneBuild(allocator, "build_glyphs_2k", buildGlyphs2k));
+    collect(&reporter, try benchSceneBuild(allocator, "build_glyphs_16k", buildGlyphs16k));
+    collect(&reporter, try benchSceneBuild(allocator, "build_interleaved_2k", buildInterleaved2k));
+    collect(&reporter, try benchSceneBuild(allocator, "build_dashboard_small", buildDashboardSmall));
+    collect(&reporter, try benchSceneBuild(allocator, "build_dashboard_medium", buildDashboardMedium));
+    collect(&reporter, try benchSceneBuild(allocator, "build_dashboard_large", buildDashboardLarge));
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+
+    // =========================================================================
+    // Batch Iteration
+    // =========================================================================
+
+    printSectionHeader("Gooey Scene Benchmarks — Batch Iteration (BatchIterator drain + coalescing)");
+    collect(&reporter, try benchBatchIterate(allocator, "batch_quads_16k", buildQuads16k));
+    collect(&reporter, try benchBatchIterate(allocator, "batch_glyphs_16k", buildGlyphs16k));
+    collect(&reporter, try benchBatchIterate(allocator, "batch_interleaved_2k", buildInterleaved2k));
+    collect(&reporter, try benchBatchIterate(allocator, "batch_dashboard_medium", buildDashboardMedium));
+    collect(&reporter, try benchBatchIterate(allocator, "batch_dashboard_large", buildDashboardLarge));
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+
+    // =========================================================================
+    // Draw-Order Sort
+    // =========================================================================
+
+    printSectionHeader("Gooey Scene Benchmarks — Draw-Order Sort (finish() pdq over shuffled quads)");
+    collect(&reporter, try benchDrawOrderSort(allocator, "sort_quads_1k", 1000));
+    collect(&reporter, try benchDrawOrderSort(allocator, "sort_quads_8k", 8000));
+    collect(&reporter, try benchDrawOrderSort(allocator, "sort_quads_32k", 32000));
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+
+    // =========================================================================
+    // Clip Stack
+    // =========================================================================
+
+    printSectionHeader("Gooey Scene Benchmarks — Clip Stack (pushClip/popClip pairs)");
+    collect(&reporter, try benchClipStack(allocator, "clip_depth_8", 8));
+    collect(&reporter, try benchClipStack(allocator, "clip_depth_16", 16));
+    collect(&reporter, try benchClipStack(allocator, "clip_depth_32", 32));
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+
+    // =========================================================================
+    // Frame e2e (data plane)
+    // =========================================================================
+
+    printFrameHeader();
+    collectFrame(&reporter, try benchFrame(allocator, "frame_dashboard_small", buildDashboardSmall));
+    collectFrame(&reporter, try benchFrame(allocator, "frame_dashboard_medium", buildDashboardMedium));
+    collectFrame(&reporter, try benchFrame(allocator, "frame_dashboard_large", buildDashboardLarge));
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+
+    std.debug.print(
+        \\
+        \\Notes:
+        \\  - Scene Build  = clear() + insertQuad/insertGlyph/insertShadow (per-frame emit).
+        \\  - Batch Iter   = BatchIterator drain of a finished scene; Batches column is the
+        \\                   coalescing measure (fewer = better; interleaved is worst case).
+        \\  - Draw Sort    = finish() pdq sort over a shuffled quad array (overlay/z-order cost).
+        \\  - Clip Stack   = pushClip (with intersection) + popClip pairs per nesting level.
+        \\  - Frame e2e    = clear -> build -> finish -> drain; the data-plane frame budget.
+        \\                   60Hz budget = 16.67 ms, 120Hz = 8.33 ms (avg % shown per frame).
+        \\  - Frame e2e excludes platform/GPU submission (runtime/frame.zig needs a live
+        \\    window + Metal + CoreText, so it cannot run headless).
+        \\  - ns/op and percentiles are per primitive; iterations are adaptive.
+        \\
+    , .{});
+
+    reporter.finish();
+}
+
+// =============================================================================
+// Section Printers
+// =============================================================================
+
+fn printSectionHeader(comptime title: []const u8) void {
+    comptime std.debug.assert(title.len > 0);
+    comptime std.debug.assert(title.len < TABLE_WIDTH);
+    std.debug.print("\n", .{});
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+    std.debug.print("{s}\n", .{title});
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+    printHeader();
+    std.debug.print("-" ** TABLE_WIDTH ++ "\n", .{});
+}
+
+fn printHeader() void {
+    std.debug.print("| {s:<40} | {s:>7} | {s:>9} | {s:>9} | {s:>9} | {s:>7} | {s:>6} |\n", .{
+        "Test",
+        "Ops",
+        "ns/op",
+        "p50",
+        "p99",
+        "Batches",
+        "Iters",
+    });
+}
+
+fn printFrameHeader() void {
+    std.debug.print("\n", .{});
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+    std.debug.print("Gooey Scene Benchmarks — Frame e2e (clear -> build -> finish -> drain)\n", .{});
+    std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
+    std.debug.print("| {s:<28} | {s:>6} | {s:>5} | {s:>12} | {s:>12} | {s:>6} | {s:>6} |\n", .{
+        "Test",
+        "Prims",
+        "Batch",
+        "Avg/frame",
+        "p99/frame",
+        "60Hz",
+        "120Hz",
+    });
+    std.debug.print("-" ** TABLE_WIDTH ++ "\n", .{});
+}


### PR DESCRIPTION
## Summary

Builds on `integration/v0.2.0` (now merged to `main`) by adding four new benchmark suites plus their docs and build/CI wiring. Changes are purely additive — no production source paths are modified.

New benchmark coverage:
- **Scene** (data plane): scene build, batch iteration, frame e2e — `src/scene/benchmarks.zig`
- **Animation**: per-frame spring physics + store dispatch — `src/animation/benchmarks.zig`
- **Element-states**: keyed per-element retained-state pool — `src/context/element_states_benchmarks.zig`
- **Accessibility**: diff performance — `src/accessibility/benchmarks.zig`

Supporting changes:
- `build.zig`: new `bench-scene`, `bench-animation`, `bench-element-states`, `bench-accessibility` steps. Each suite's `validate:` tests are wired into `zig build test` so assertions run in Debug.
- `.github/workflows/ci.yml`: bench comparison loop extended to the four new modules.
- New perf docs under `docs/` and recorded baselines under `docs/benchmarks/`.

## Diff stat
15 files changed, +4665 / -10 (benchmarks, docs, build/CI only).

## Validation
- `zig build` — clean (Zig 0.16.0).
- `zig build test` — **1175/1175 tests passed, 21/21 steps succeeded**.
- The two `failed command` lines `zig build test` emits under the `--listen=-` runner come from pre-existing charts/context tests writing to stdout/stderr; the binaries themselves exit 0, and the identical failures (same cache hashes) reproduce on `main`. Not a regression in this branch.

## Notes
This branch already contains all of `main` (it merged `main` in at `4e15d27`), so it fast-forwards / merges cleanly.