### PR TITLE
examples: add todo app and make it the README headline example

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -143,6 +143,7 @@ pub fn build(b: *std.Build) void {
         addNativeExample(b, mod, objc_dep.module("objc"), target, optimize, "glass", "src/examples/glass.zig", false);
         addNativeExample(b, mod, objc_dep.module("objc"), target, optimize, "window-features", "src/examples/window_features.zig", false);
         addNativeExample(b, mod, objc_dep.module("objc"), target, optimize, "counter", "src/examples/counter.zig", false);
+        addNativeExample(b, mod, objc_dep.module("objc"), target, optimize, "todo", "src/examples/todo.zig", false);
         addNativeExample(b, mod, objc_dep.module("objc"), target, optimize, "layout", "src/examples/layout.zig", false);
         addNativeExample(b, mod, objc_dep.module("objc"), target, optimize, "select", "src/examples/select.zig", false);
         addNativeExample(b, mod, objc_dep.module("objc"), target, optimize, "dynamic-counters", "src/examples/dynamic_counters.zig", false);
@@ -190,6 +191,23 @@ pub fn build(b: *std.Build) void {
         });
         const run_exe_tests = b.addRunArtifact(exe_tests);
 
+        // Example tests — keep the README's headline example honest by running
+        // its pure-state unit tests in CI. The example also builds as an
+        // executable via `addNativeExample`/`installArtifact` above, so both
+        // its render paths and its state model are exercised.
+        const todo_example_tests = b.addTest(.{
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/examples/todo.zig"),
+                .target = target,
+                .optimize = optimize,
+                .imports = &.{
+                    .{ .name = "gooey", .module = mod },
+                    .{ .name = "objc", .module = objc_dep.module("objc") },
+                },
+            }),
+        });
+        const run_todo_example_tests = b.addRunArtifact(todo_example_tests);
+
         // Charts tests
         const charts_tests = b.addTest(.{
             .root_module = charts_mod,
@@ -199,6 +217,7 @@ pub fn build(b: *std.Build) void {
         const test_step = b.step("test", "Run tests");
         test_step.dependOn(&run_mod_tests.step);
         test_step.dependOn(&run_exe_tests.step);
+        test_step.dependOn(&run_todo_example_tests.step);
         test_step.dependOn(&run_charts_tests.step);
         test_step.dependOn(&run_compare_tests.step);
         test_step.dependOn(&run_bench_tests.step);
@@ -491,6 +510,7 @@ pub fn build(b: *std.Build) void {
         addLinuxExample(b, mod, target, optimize, compile_shaders_step, skip_shader_compile, "lucide-demo", "src/examples/lucide_demo.zig");
         addLinuxExample(b, mod, target, optimize, compile_shaders_step, skip_shader_compile, "animation", "src/examples/animation.zig");
         addLinuxExample(b, mod, target, optimize, compile_shaders_step, skip_shader_compile, "counter", "src/examples/counter.zig");
+        addLinuxExample(b, mod, target, optimize, compile_shaders_step, skip_shader_compile, "todo", "src/examples/todo.zig");
         addLinuxExample(b, mod, target, optimize, compile_shaders_step, skip_shader_compile, "code-editor", "src/examples/code_editor.zig");
         addLinuxExample(b, mod, target, optimize, compile_shaders_step, skip_shader_compile, "pomodoro", "src/examples/pomodoro.zig");
         addLinuxExample(b, mod, target, optimize, compile_shaders_step, skip_shader_compile, "spaceship", "src/examples/spaceship.zig");

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,7 @@ Example app built with Gooey — [**chat-zig**](https://github.com/duanebester/c
 ```bash
 zig build run              # Showcase demo
 zig build run-counter      # Counter example
+zig build run-todo         # Todo app (state, handlers, TextInput, lists)
 zig build run-animation    # Animation demo
 zig build run-pomodoro     # Pomodoro timer
 zig build run-glass        # Liquid glass effect
@@ -69,38 +70,131 @@ zig build test             # Run tests
 
 ## Example
 
+A small todo app that touches a representative slice of the API: a pure,
+UI-free state model; `cx.update` / `cx.updateWith` / `cx.command` handlers; a
+bound `TextInput`; `Checkbox` and `Button`; list iteration; and unit tests that
+exercise the state with no UI in play.
+
+The full, runnable source lives in [`src/examples/todo.zig`](src/examples/todo.zig)
+(`zig build run-todo`). Its state model is covered by the tests shown at the
+bottom, which run as part of `zig build test`.
+
 ```zig
 const std = @import("std");
 const gooey = @import("gooey");
+
 const ui = gooey.ui;
 const Cx = gooey.Cx;
-const Button = gooey.Button;
+const Button = gooey.components.Button;
+const Checkbox = gooey.components.Checkbox;
+const TextInput = gooey.components.TextInput;
 
-// State is pure - no UI knowledge, fully testable!
+const MAX_TODOS = 64;
+const TEXT_CAP = 128;
+const draft_input_id = "new-todo";
+
+// State is pure — no UI knowledge, fully testable.
+const Todo = struct {
+    buf: [TEXT_CAP]u8 = [_]u8{0} ** TEXT_CAP,
+    len: usize = 0,
+    done: bool = false,
+
+    fn text(self: *const Todo) []const u8 {
+        return self.buf[0..self.len];
+    }
+};
+
+const Filter = enum { all, active, done };
+
 const AppState = struct {
-    count: i32 = 0,
+    todos: [MAX_TODOS]Todo = [_]Todo{.{}} ** MAX_TODOS,
+    count: usize = 0,
+    draft: []const u8 = "", // two-way bound to the TextInput
+    filter: Filter = .all,
 
-    pub fn increment(self: *AppState) void {
+    // Pure logic — what the tests below drive.
+    fn pushTodo(self: *AppState, value: []const u8) void {
+        const trimmed = std.mem.trim(u8, value, " \t\r\n");
+        if (trimmed.len == 0) return;
+        if (self.count >= MAX_TODOS) return;
+        const slot = &self.todos[self.count];
+        const n = @min(trimmed.len, TEXT_CAP);
+        @memcpy(slot.buf[0..n], trimmed[0..n]);
+        slot.len = n;
+        slot.done = false;
         self.count += 1;
     }
 
-    pub fn decrement(self: *AppState) void {
+    pub fn toggle(self: *AppState, index: usize) void {
+        if (index >= self.count) return;
+        self.todos[index].done = !self.todos[index].done;
+    }
+
+    pub fn remove(self: *AppState, index: usize) void {
+        if (index >= self.count) return;
+        var i = index;
+        while (i + 1 < self.count) : (i += 1) self.todos[i] = self.todos[i + 1];
         self.count -= 1;
     }
 
-    pub fn reset(self: *AppState) void {
-        self.count = 0;
+    pub fn setFilter(self: *AppState, filter: Filter) void {
+        self.filter = filter;
+    }
+
+    pub fn clearCompleted(self: *AppState) void {
+        var write: usize = 0;
+        var read: usize = 0;
+        while (read < self.count) : (read += 1) {
+            if (!self.todos[read].done) {
+                self.todos[write] = self.todos[read];
+                write += 1;
+            }
+        }
+        self.count = write;
+    }
+
+    fn remaining(self: *const AppState) u32 {
+        var n: u32 = 0;
+        for (self.todos[0..self.count]) |*t| {
+            if (!t.done) n += 1;
+        }
+        return n;
+    }
+
+    fn visible(self: *const AppState, t: *const Todo) bool {
+        return switch (self.filter) {
+            .all => true,
+            .active => !t.done,
+            .done => t.done,
+        };
+    }
+
+    // Command — needs framework access (the binding only flows widget -> state,
+    // so we reach the retained input widget to clear it after adding).
+    pub fn addTodo(self: *AppState, g: *gooey.Window) void {
+        self.pushTodo(self.draft);
+        self.draft = "";
+        const id_hash: u64 = gooey.layout.LayoutId.fromString(draft_input_id).id;
+        if (g.element_states.get(gooey.widgets.TextInputState, id_hash)) |input| {
+            input.clear();
+        }
     }
 };
 
 var state = AppState{};
 
-pub fn main() !void {
-    try gooey.runCx(AppState, &state, render, .{
-        .title = "Counter",
-        .width = 400,
-        .height = 300,
-    });
+const App = gooey.App(AppState, &state, render, .{
+    .title = "Todos",
+    .width = 480,
+    .height = 560,
+});
+
+comptime {
+    _ = App; // Force analysis (also wires @export on WASM).
+}
+
+pub fn main(init: std.process.Init) !void {
+    return App.main(init);
 }
 
 fn render(cx: *Cx) void {
@@ -110,28 +204,113 @@ fn render(cx: *Cx) void {
     cx.render(ui.box(.{
         .width = size.width,
         .height = size.height,
-        .alignment = .{ .main = .center, .cross = .center },
-        .gap = 16,
         .direction = .column,
+        .padding = .{ .all = 24 },
+        .gap = 16,
+        .background = ui.Color.rgb(0.96, 0.96, 0.97),
     }, .{
-        ui.textFmt("{d}", .{s.count}, .{ .size = 48 }),
-        ui.hstack(.{ .gap = 12 }, .{
-            // Pure handlers - framework auto-renders after mutation!
-            Button{ .label = "-", .on_click_handler = cx.update(AppState.decrement) },
-            Button{ .label = "+", .on_click_handler = cx.update(AppState.increment) },
+        ui.text("Todos", .{ .size = 28 }),
+
+        // Input row: TextInput binds to state.draft; Add is a command.
+        ui.hstack(.{ .gap = 8, .alignment = .center }, .{
+            TextInput{ .id = draft_input_id, .placeholder = "What needs doing?", .bind = &s.draft, .fill_width = true },
+            Button{ .label = "Add", .on_click_handler = cx.command(AppState.addTodo) },
         }),
-        Button{ .label = "Reset", .variant = .secondary, .on_click_handler = cx.update(AppState.reset) },
+
+        // Filters: each button packs its enum value into the handler arg.
+        ui.hstack(.{ .gap = 8 }, .{
+            FilterButton{ .label = "All", .filter = .all, .active = s.filter == .all },
+            FilterButton{ .label = "Active", .filter = .active, .active = s.filter == .active },
+            FilterButton{ .label = "Done", .filter = .done, .active = s.filter == .done },
+        }),
+
+        // The list, or an empty-state hint.
+        ui.when(s.count == 0, .{
+            ui.text("Nothing yet — add your first todo above.", .{ .size = 14 }),
+        }),
+        TodoItems{},
+
+        ui.spacer(),
+        ui.hstack(.{ .gap = 12, .alignment = .center }, .{
+            ui.textFmt("{d} left", .{s.remaining()}, .{ .size = 14 }),
+            ui.spacer(),
+            Button{ .label = "Clear completed", .variant = .secondary, .size = .small, .on_click_handler = cx.update(AppState.clearCompleted) },
+        }),
     }));
 }
 
-// State is testable without UI!
-test "counter logic" {
+// Iteration lives in a component because each row needs `cx` for its handlers.
+const TodoItems = struct {
+    pub fn render(_: @This(), cx: *Cx) void {
+        const s = cx.state(AppState);
+        for (s.todos[0..s.count], 0..) |*todo, index| {
+            if (!s.visible(todo)) continue;
+            cx.render(TodoRow{ .index = index, .done = todo.done, .label = todo.text() });
+        }
+    }
+};
+
+const TodoRow = struct {
+    index: usize,
+    done: bool,
+    label: []const u8,
+
+    pub fn render(self: @This(), cx: *Cx) void {
+        // A background + cross-axis centering means this is a `box` (with
+        // `.direction = .row`), not an `hstack` — stacks carry only gap/
+        // alignment/padding.
+        cx.render(ui.box(.{
+            .direction = .row,
+            .gap = 12,
+            .alignment = .{ .cross = .center },
+            .padding = .{ .all = 10 },
+            .background = ui.Color.white,
+            .corner_radius = 8,
+        }, .{
+            Checkbox{ .checked = self.done, .on_click_handler = cx.updateWith(self.index, AppState.toggle) },
+            ui.text(self.label, .{ .size = 16 }),
+            ui.spacer(),
+            Button{ .label = "Delete", .variant = .danger, .size = .small, .on_click_handler = cx.updateWith(self.index, AppState.remove) },
+        }));
+    }
+};
+
+const FilterButton = struct {
+    label: []const u8,
+    filter: Filter,
+    active: bool,
+
+    pub fn render(self: @This(), cx: *Cx) void {
+        cx.render(Button{
+            .label = self.label,
+            .size = .small,
+            .variant = if (self.active) .primary else .secondary,
+            .on_click_handler = cx.updateWith(self.filter, AppState.setFilter),
+        });
+    }
+};
+
+// State is testable without UI.
+test "remove keeps the list contiguous" {
     var s = AppState{};
-    s.increment();
-    s.increment();
-    try std.testing.expectEqual(2, s.count);
-    s.reset();
-    try std.testing.expectEqual(0, s.count);
+    s.pushTodo("a");
+    s.pushTodo("b");
+    s.pushTodo("c");
+    s.remove(1); // drop "b"
+    try std.testing.expectEqual(@as(usize, 2), s.count);
+    try std.testing.expectEqualStrings("a", s.todos[0].text());
+    try std.testing.expectEqualStrings("c", s.todos[1].text());
+}
+
+test "remaining and clearCompleted" {
+    var s = AppState{};
+    s.pushTodo("a");
+    s.pushTodo("b");
+    s.toggle(0);
+    try std.testing.expectEqual(@as(u32, 1), s.remaining());
+    s.clearCompleted();
+    try std.testing.expectEqual(@as(usize, 1), s.count);
+    try std.testing.expectEqualStrings("b", s.todos[0].text());
 }
 ```
 

--- a/src/examples/todo.zig
+++ b/src/examples/todo.zig
@@ -1,0 +1,423 @@
+//! Todo Example (Cx API)
+//!
+//! A compact, end-to-end app that exercises a broad slice of the public
+//! surface in one place. It is the example the README's "Quick Start"
+//! mirrors, so keep the two in sync.
+//!
+//! Demonstrates:
+//! - Pure state methods + `cx.update` (toggle-free mutations like clearCompleted)
+//! - `cx.updateWith` with a packed index argument (toggle / remove a row)
+//! - `cx.updateWith` with a packed enum argument (filter switch)
+//! - `cx.command` for framework access (clearing the input widget's buffer)
+//! - `TextInput` two-way binding via `.bind`
+//! - `Checkbox`, `Button` variants/sizes
+//! - Layout with `ui.box` (backgrounds, `{ .main, .cross }` alignment) vs
+//!   `ui.hstack` / `ui.vstack` (gap + simple alignment only)
+//! - `ui.text` / `ui.textFmt`, `ui.spacer`, conditional rendering by hand
+//! - Pure, UI-free unit tests over the state model
+
+const std = @import("std");
+
+const gooey = @import("gooey");
+const platform = gooey.platform;
+
+/// Route std.log through the console on WASM, default logFn on native.
+pub const std_options = gooey.std_options;
+
+const ui = gooey.ui;
+const Cx = gooey.Cx;
+const Button = gooey.components.Button;
+const Checkbox = gooey.components.Checkbox;
+const TextInput = gooey.components.TextInput;
+
+// =============================================================================
+// Limits (CLAUDE.md §4 — a hard cap on everything)
+// =============================================================================
+
+const MAX_TODOS = 64;
+const TEXT_CAP = 128;
+
+/// Stable layout id for the draft input. Used both to render the field and to
+/// reach its retained widget buffer from `addTodo` so we can clear it.
+const draft_input_id = "new-todo";
+
+// =============================================================================
+// Models
+// =============================================================================
+
+/// One todo. The text is copied into a fixed inline buffer so the model owns
+/// its bytes outright — no allocator, no lifetime coupling to the input widget.
+const Todo = struct {
+    buf: [TEXT_CAP]u8 = [_]u8{0} ** TEXT_CAP,
+    len: usize = 0,
+    done: bool = false,
+
+    fn text(self: *const Todo) []const u8 {
+        return self.buf[0..self.len];
+    }
+};
+
+const Filter = enum { all, active, done };
+
+// =============================================================================
+// Application State — pure, fully testable without any UI
+// =============================================================================
+
+const AppState = struct {
+    todos: [MAX_TODOS]Todo = [_]Todo{.{}} ** MAX_TODOS,
+    count: usize = 0,
+    /// Bound to the TextInput; the widget writes the live text back here each
+    /// frame (widget -> state only — see `addTodo` for why clearing is manual).
+    draft: []const u8 = "",
+    filter: Filter = .all,
+
+    // -------------------------------------------------------------------------
+    // Pure logic (no Cx, no Window) — these are what the tests below drive.
+    // -------------------------------------------------------------------------
+
+    /// Append `value` as a new todo. No-op when blank or at capacity, so the
+    /// caller never has to pre-check. Split out from `addTodo` so the append
+    /// path is testable without a live widget.
+    fn pushTodo(self: *AppState, value: []const u8) void {
+        const trimmed = std.mem.trim(u8, value, " \t\r\n");
+        if (trimmed.len == 0) return;
+        if (self.count >= MAX_TODOS) return;
+
+        const slot = &self.todos[self.count];
+        const n = @min(trimmed.len, TEXT_CAP);
+        @memcpy(slot.buf[0..n], trimmed[0..n]);
+        slot.len = n;
+        slot.done = false;
+        self.count += 1;
+    }
+
+    pub fn toggle(self: *AppState, index: usize) void {
+        if (index >= self.count) return;
+        self.todos[index].done = !self.todos[index].done;
+    }
+
+    pub fn remove(self: *AppState, index: usize) void {
+        if (index >= self.count) return;
+        // Shift the tail down one slot to keep [0..count) contiguous.
+        var i = index;
+        while (i + 1 < self.count) : (i += 1) {
+            self.todos[i] = self.todos[i + 1];
+        }
+        self.count -= 1;
+    }
+
+    pub fn setFilter(self: *AppState, filter: Filter) void {
+        self.filter = filter;
+    }
+
+    pub fn clearCompleted(self: *AppState) void {
+        var write: usize = 0;
+        var read: usize = 0;
+        while (read < self.count) : (read += 1) {
+            if (!self.todos[read].done) {
+                self.todos[write] = self.todos[read];
+                write += 1;
+            }
+        }
+        self.count = write;
+    }
+
+    fn remaining(self: *const AppState) u32 {
+        var n: u32 = 0;
+        for (self.todos[0..self.count]) |*todo| {
+            if (!todo.done) n += 1;
+        }
+        return n;
+    }
+
+    fn visible(self: *const AppState, todo: *const Todo) bool {
+        return switch (self.filter) {
+            .all => true,
+            .active => !todo.done,
+            .done => todo.done,
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // Command — needs Window access, so it goes through `cx.command`.
+    // -------------------------------------------------------------------------
+
+    /// Add the current draft, then clear the input. The binding only flows
+    /// widget -> state, so zeroing `self.draft` is not enough; we reach the
+    /// retained `TextInputState` by its layout-id hash and clear its buffer.
+    pub fn addTodo(self: *AppState, g: *gooey.Window) void {
+        self.pushTodo(self.draft);
+        self.draft = "";
+
+        const id_hash: u64 = gooey.layout.LayoutId.fromString(draft_input_id).id;
+        if (g.element_states.get(gooey.widgets.TextInputState, id_hash)) |input| {
+            input.clear();
+        }
+    }
+};
+
+// =============================================================================
+// Entry Point
+// =============================================================================
+
+var state = AppState{};
+
+const App = gooey.App(AppState, &state, render, .{
+    .title = "Todos",
+    .width = 480,
+    .height = 560,
+});
+
+// Force type analysis — triggers @export on WASM.
+comptime {
+    _ = App;
+}
+
+pub fn main(init: std.process.Init) !void {
+    if (platform.is_wasm) unreachable;
+    return App.main(init);
+}
+
+// =============================================================================
+// Render
+// =============================================================================
+
+fn render(cx: *Cx) void {
+    const size = cx.windowSize();
+
+    cx.render(ui.box(.{
+        .width = size.width,
+        .height = size.height,
+        .direction = .column,
+        .padding = .{ .all = 24 },
+        .gap = 16,
+        .background = ui.Color.rgb(0.96, 0.96, 0.97),
+    }, .{
+        ui.text("Todos", .{ .size = 28, .color = ui.Color.rgb(0.1, 0.1, 0.15) }),
+        InputRow{},
+        FilterBar{},
+        TodoList{},
+        ui.spacer(),
+        Footer{},
+    }));
+}
+
+// =============================================================================
+// Components
+// =============================================================================
+
+/// Text field + Add button. The field binds straight to `state.draft`; Add is
+/// a command because it has to clear the input widget after appending.
+const InputRow = struct {
+    pub fn render(_: @This(), cx: *Cx) void {
+        const s = cx.state(AppState);
+
+        cx.render(ui.hstack(.{ .gap = 8, .alignment = .center }, .{
+            TextInput{
+                .id = draft_input_id,
+                .placeholder = "What needs doing?",
+                .bind = &s.draft,
+                .fill_width = true,
+            },
+            Button{ .label = "Add", .on_click_handler = cx.command(AppState.addTodo) },
+        }));
+    }
+};
+
+/// All / Active / Done. Each button packs its `Filter` into the handler arg.
+const FilterBar = struct {
+    pub fn render(_: @This(), cx: *Cx) void {
+        const s = cx.state(AppState);
+
+        cx.render(ui.hstack(.{ .gap = 8 }, .{
+            FilterButton{ .label = "All", .filter = .all, .active = s.filter == .all },
+            FilterButton{ .label = "Active", .filter = .active, .active = s.filter == .active },
+            FilterButton{ .label = "Done", .filter = .done, .active = s.filter == .done },
+        }));
+    }
+};
+
+const FilterButton = struct {
+    label: []const u8,
+    filter: Filter,
+    active: bool,
+
+    pub fn render(self: @This(), cx: *Cx) void {
+        cx.render(Button{
+            .label = self.label,
+            .size = .small,
+            .variant = if (self.active) .primary else .secondary,
+            .on_click_handler = cx.updateWith(self.filter, AppState.setFilter),
+        });
+    }
+};
+
+/// The list, or an empty-state hint when there is nothing to show.
+const TodoList = struct {
+    pub fn render(_: @This(), cx: *Cx) void {
+        const s = cx.state(AppState);
+
+        if (s.count == 0) {
+            cx.render(ui.text(
+                "Nothing yet — add your first todo above.",
+                .{ .size = 14, .color = ui.Color.rgb(0.5, 0.5, 0.55) },
+            ));
+            return;
+        }
+
+        cx.render(ui.vstack(.{ .gap = 8 }, .{TodoItems{}}));
+    }
+};
+
+/// Loops the model and emits one `TodoRow` per visible item. Iteration lives
+/// in a component (not `ui.each`) because each row needs `cx` to build its
+/// per-row handlers.
+const TodoItems = struct {
+    pub fn render(_: @This(), cx: *Cx) void {
+        const s = cx.state(AppState);
+
+        for (s.todos[0..s.count], 0..) |*todo, index| {
+            if (!s.visible(todo)) continue;
+            cx.render(TodoRow{ .index = index, .done = todo.done, .label = todo.text() });
+        }
+    }
+};
+
+const TodoRow = struct {
+    index: usize,
+    done: bool,
+    label: []const u8,
+
+    pub fn render(self: @This(), cx: *Cx) void {
+        // A row needs a background + vertical centering, so it is a `box`
+        // (with `.direction = .row`), not an `hstack` — stacks carry only
+        // gap/alignment/padding.
+        cx.render(ui.box(.{
+            .direction = .row,
+            .gap = 12,
+            .alignment = .{ .cross = .center },
+            .padding = .{ .all = 10 },
+            .background = ui.Color.white,
+            .corner_radius = 8,
+        }, .{
+            Checkbox{
+                .checked = self.done,
+                .on_click_handler = cx.updateWith(self.index, AppState.toggle),
+            },
+            ui.text(self.label, .{
+                .size = 16,
+                .color = if (self.done)
+                    ui.Color.rgb(0.6, 0.6, 0.6)
+                else
+                    ui.Color.rgb(0.1, 0.1, 0.1),
+            }),
+            ui.spacer(),
+            Button{
+                .label = "Delete",
+                .variant = .danger,
+                .size = .small,
+                .on_click_handler = cx.updateWith(self.index, AppState.remove),
+            },
+        }));
+    }
+};
+
+/// Remaining count + a pure "clear completed" action.
+const Footer = struct {
+    pub fn render(_: @This(), cx: *Cx) void {
+        const s = cx.state(AppState);
+
+        cx.render(ui.hstack(.{ .gap = 12, .alignment = .center }, .{
+            ui.textFmt("{d} left", .{s.remaining()}, .{
+                .size = 14,
+                .color = ui.Color.rgb(0.4, 0.4, 0.45),
+            }),
+            ui.spacer(),
+            Button{
+                .label = "Clear completed",
+                .variant = .secondary,
+                .size = .small,
+                .on_click_handler = cx.update(AppState.clearCompleted),
+            },
+        }));
+    }
+};
+
+// =============================================================================
+// Tests — the whole model is exercised with zero UI in play.
+// =============================================================================
+
+test "add trims, ignores blanks, and respects capacity" {
+    var s = AppState{};
+
+    s.pushTodo("  buy milk  ");
+    try std.testing.expectEqual(@as(usize, 1), s.count);
+    try std.testing.expectEqualStrings("buy milk", s.todos[0].text());
+
+    s.pushTodo("   "); // blank after trim -> ignored
+    try std.testing.expectEqual(@as(usize, 1), s.count);
+
+    var i: usize = 0;
+    while (i < MAX_TODOS + 5) : (i += 1) s.pushTodo("x");
+    try std.testing.expectEqual(@as(usize, MAX_TODOS), s.count);
+}
+
+test "toggle flips done and is bounds-checked" {
+    var s = AppState{};
+    s.pushTodo("task");
+
+    s.toggle(0);
+    try std.testing.expect(s.todos[0].done);
+    s.toggle(0);
+    try std.testing.expect(!s.todos[0].done);
+
+    s.toggle(99); // out of range -> no-op, no panic
+    try std.testing.expectEqual(@as(usize, 1), s.count);
+}
+
+test "remove keeps the list contiguous" {
+    var s = AppState{};
+    s.pushTodo("a");
+    s.pushTodo("b");
+    s.pushTodo("c");
+
+    s.remove(1); // drop "b"
+    try std.testing.expectEqual(@as(usize, 2), s.count);
+    try std.testing.expectEqualStrings("a", s.todos[0].text());
+    try std.testing.expectEqualStrings("c", s.todos[1].text());
+}
+
+test "remaining and clearCompleted" {
+    var s = AppState{};
+    s.pushTodo("a");
+    s.pushTodo("b");
+    s.pushTodo("c");
+    s.toggle(0);
+    s.toggle(2);
+
+    try std.testing.expectEqual(@as(u32, 1), s.remaining());
+
+    s.clearCompleted();
+    try std.testing.expectEqual(@as(usize, 1), s.count);
+    try std.testing.expectEqualStrings("b", s.todos[0].text());
+    try std.testing.expectEqual(@as(u32, 1), s.remaining());
+}
+
+test "filter visibility" {
+    var s = AppState{};
+    s.pushTodo("a");
+    s.pushTodo("b");
+    s.toggle(0); // "a" done, "b" active
+
+    s.setFilter(.active);
+    try std.testing.expect(!s.visible(&s.todos[0]));
+    try std.testing.expect(s.visible(&s.todos[1]));
+
+    s.setFilter(.done);
+    try std.testing.expect(s.visible(&s.todos[0]));
+    try std.testing.expect(!s.visible(&s.todos[1]));
+
+    s.setFilter(.all);
+    try std.testing.expect(s.visible(&s.todos[0]));
+    try std.testing.expect(s.visible(&s.todos[1]));
+}


### PR DESCRIPTION
## Why

The README's headline example was a counter that had drifted from the current API and no longer compiled as written:

- referenced the removed flat alias `gooey.Button` (now `gooey.components.Button`)
- called `gooey.runCx` with the pre-0.16 arg-less `pub fn main() !void` signature
- showed `*Gooey` in handler signatures where the type is now `*Window`

## What

Replace the counter with a **todo app** that doubles as a real, built-and-tested example (`src/examples/todo.zig`), so the headline snippet can no longer rot in silence. It covers a representative slice of the surface in one place:

- pure, allocator-free state model (fixed-capacity, fully testable)
- `cx.update` / `cx.updateWith` (packed **index** + **enum** args) / `cx.command`
- a command that clears the retained `TextInput` buffer — necessary because the `bind` sync only flows widget → state (traced via `syncBoundVariablesCx`)
- `TextInput` two-way `bind`, `Checkbox`, `Button` variants/sizes
- `ui.box` (backgrounds + `{ .main, .cross }` alignment) vs `ui.hstack`/`vstack` (gap/alignment/padding only), `ui.text`/`textFmt`, `ui.when`, `ui.spacer`
- the loop-in-a-component idiom for interactive lists

Build/test wiring:

- registered as a native + Linux example → `zig build run-todo`
- its state-model tests are folded into the `test` step so they run in CI

The README example is a faithful, lightly-condensed subset of `src/examples/todo.zig` (drops the WASM guard and a couple of colors for brevity), and links to the full source.

## Validation

- `zig build install` → compiles cleanly; `zig-out/bin/todo` produced
- `zig build test` → exits 0; the todo test binary reports `All 5 tests passed` (`todo.test.*`)

## Notes / possible follow-ups

This fixes the headline example's drift. A few related doc spots still reference the old names and could be cleaned up separately if desired:

- `ui/mod.zig` module doc block still shows `gooey.Button{...}` / `gooey.Checkbox{...}`
- README "Handler Types" / "Deferred Commands" still say `*Gooey` / `g.deferCommand`
- the handler table lists `cx.defer()`, which is actually spelled `cx.@"defer"()` (keyword)