### PR TITLE
scene: sort draw order by keys, not payloads (+ two sort-path fixes)

### DIFF
--- a/docs/scene-data-plane-performance.md
+++ b/docs/scene-data-plane-performance.md
@@ -35,13 +35,13 @@ Validate (Debug, assertions live): the `validate:` tests in
 counts, batch coalescing, sort correctness, clip balance, and the
 **steady-state zero-allocation invariant** via a counting allocator.
 
-| Group | What it times | Reports |
-| --- | --- | --- |
-| Scene build | `clear()` + `insertQuad`/`insertGlyph`/`insertShadow` | ns / primitive emitted |
-| Batch iteration | `BatchIterator.next()` drain of a finished scene | ns / primitive + **batch count** |
-| Draw-order sort | `finish()` pdq over a shuffled quad array | ns / quad sorted |
-| Clip stack | `pushClip` (with intersection) + `popClip` pairs | ns / nesting level |
-| Frame e2e | `clear → build → finish → drain` | whole-frame µs (avg + p99) vs budget |
+| Group           | What it times                                         | Reports                              |
+| --------------- | ----------------------------------------------------- | ------------------------------------ |
+| Scene build     | `clear()` + `insertQuad`/`insertGlyph`/`insertShadow` | ns / primitive emitted               |
+| Batch iteration | `BatchIterator.next()` drain of a finished scene      | ns / primitive + **batch count**     |
+| Draw-order sort | `finish()` pdq over a shuffled quad array             | ns / quad sorted                     |
+| Clip stack      | `pushClip` (with intersection) + `popClip` pairs      | ns / nesting level                   |
+| Frame e2e       | `clear → build → finish → drain`                      | whole-frame µs (avg + p99) vs budget |
 
 All groups collect p50/p99 percentiles; the regression gate
 (`bench-compare`) classifies on the best-of-N minimum.
@@ -54,14 +54,14 @@ These are the shape of the curve, not acceptance criteria.
 
 ### Scene build — flat ~4 ns/primitive, zero allocations
 
-| Test | Ops | ns/op | p99 |
-| --- | --- | --- | --- |
-| build_quads_256 | 256 | 3.98 | 4.72 |
-| build_quads_2k | 2000 | 4.37 | 8.40 |
-| build_quads_16k | 16000 | 4.32 | 5.59 |
-| build_glyphs_16k | 16000 | 4.06 | 5.33 |
-| build_interleaved_2k | 4000 | 9.45 | 13.35 |
-| build_dashboard_large | 5041 | 3.94 | 5.51 |
+| Test                  | Ops   | ns/op | p99   |
+| --------------------- | ----- | ----- | ----- |
+| build_quads_256       | 256   | 3.98  | 4.72  |
+| build_quads_2k        | 2000  | 4.37  | 8.40  |
+| build_quads_16k       | 16000 | 4.32  | 5.59  |
+| build_glyphs_16k      | 16000 | 4.06  | 5.33  |
+| build_interleaved_2k  | 4000  | 9.45  | 13.35 |
+| build_dashboard_large | 5041  | 3.94  | 5.51  |
 
 Flat from 256 → 16k primitives with no super-linear creep; the passing
 zero-alloc test confirms the static-allocation policy (§2) holds in steady
@@ -71,13 +71,13 @@ arrays).
 
 ### Batch iteration — coalescing quantified
 
-| Test | Ops | ns/op | Batches |
-| --- | --- | --- | --- |
-| batch_quads_16k | 16000 | 1.00 | 1 |
-| batch_glyphs_16k | 16000 | 0.94 | 1 |
-| batch_interleaved_2k | 4000 | 19.89 | 4000 |
-| batch_dashboard_medium | 1537 | 2.39 | 145 |
-| batch_dashboard_large | 5041 | 2.08 | 361 |
+| Test                   | Ops   | ns/op | Batches |
+| ---------------------- | ----- | ----- | ------- |
+| batch_quads_16k        | 16000 | 1.00  | 1       |
+| batch_glyphs_16k       | 16000 | 0.94  | 1       |
+| batch_interleaved_2k   | 4000  | 19.89 | 4000    |
+| batch_dashboard_medium | 1537  | 2.39  | 145     |
+| batch_dashboard_large  | 5041  | 2.08  | 361     |
 
 This is the §8 batching thesis made concrete: coalesced same-type primitives
 drain at ~1 ns each in a single batch; fully-interleaved primitives cost ~20×
@@ -87,16 +87,30 @@ batch sizes (avg ~14).
 
 ### Draw-order sort — the one hot spot
 
-| Test | Ops | ns/quad | per `finish()` |
-| --- | --- | --- | --- |
-| sort_quads_1k | 1000 | 354.6 | ~0.35 ms |
-| sort_quads_8k | 8000 | 410.5 | ~3.3 ms |
-| sort_quads_32k | 32000 | 457.2 | **~14.6 ms** |
+| Test           | Ops   | ns/quad | per `finish()` |
+| -------------- | ----- | ------- | -------------- |
+| sort_quads_1k  | 1000  | 354.6   | ~0.35 ms       |
+| sort_quads_8k  | 8000  | 410.5   | ~3.3 ms        |
+| sort_quads_32k | 32000 | 457.2   | **~14.6 ms**   |
 
 Per-quad cost scales sub-linearly (correct for a comparison sort), but the
 **constant is high**: `std.sort.pdq` moves whole 128-byte `Quad` structs
 (`QUAD_SIZE` in `core/limits.zig`). A large out-of-order scene can consume an
 entire 60 Hz frame in the sort alone. See the analysis and fix below.
+
+**Resolved (indirect key sort).** `finish()` now sorts compact `(order, index)`
+u64 keys and gathers the payload once (see "Recommended optimization" below).
+The `sort_struct_quads_*` entries keep the old payload sort as a side-by-side
+baseline. Measured on the same shuffled inputs (M-series, `ReleaseFast`):
+
+| Test           | Ops   | payload ns/quad | keyed ns/quad | speedup |
+| -------------- | ----- | --------------- | ------------- | ------- |
+| sort_quads_1k  | 1000  | ~233            | ~20           | ~11.8×  |
+| sort_quads_8k  | 8000  | ~274            | ~49           | ~5.6×   |
+| sort_quads_32k | 32000 | ~303            | ~58           | ~5.2×   |
+
+`bench-compare` records this as −80% to −92% on the gated minimum, 0 regressed.
+The 32k sort drops from ~9.7 ms to ~1.9 ms — back under a single frame.
 
 ### Clip stack — negligible
 
@@ -105,11 +119,11 @@ resolution. Not a concern.
 
 ### Frame e2e — data plane is <0.4% of budget
 
-| Test | Prims | Batches | Avg/frame | p99/frame | % 60 Hz | % 120 Hz |
-| --- | --- | --- | --- | --- | --- | --- |
-| frame_dashboard_small | 265 | 37 | 1.83 µs | 2.17 µs | 0.01% | 0.02% |
-| frame_dashboard_medium | 1537 | 145 | 9.21 µs | 17.71 µs | 0.06% | 0.11% |
-| frame_dashboard_large | 5041 | 361 | 30.73 µs | 44.46 µs | 0.18% | 0.37% |
+| Test                   | Prims | Batches | Avg/frame | p99/frame | % 60 Hz | % 120 Hz |
+| ---------------------- | ----- | ------- | --------- | --------- | ------- | -------- |
+| frame_dashboard_small  | 265   | 37      | 1.83 µs   | 2.17 µs   | 0.01%   | 0.02%    |
+| frame_dashboard_medium | 1537  | 145     | 9.21 µs   | 17.71 µs  | 0.06%   | 0.11%    |
+| frame_dashboard_large  | 5041  | 361     | 30.73 µs  | 44.46 µs  | 0.18%   | 0.37%    |
 
 The frame group uses in-order builds (no overlays), so it exercises the
 no-sort happy path. The takeaway: scene assembly is not where the frame
@@ -125,15 +139,15 @@ primitives are directly modeled on GPUI, so it is the primary reference.
 
 ### Frame budget (GPUI / Zed)
 
-The GPUI rendering blog opens with *"an application only has **8.33 ms** per
-frame to push pixels to screen"* — exactly our 120 Hz budget. Our 5041-prim
+The GPUI rendering blog opens with _"an application only has **8.33 ms** per
+frame to push pixels to screen"_ — exactly our 120 Hz budget. Our 5041-prim
 frame at 30.7 µs (**0.37%** of 8.33 ms) is consistent with GPUI's thesis that
 scene assembly is cheap and the budget is spent elsewhere.
 
 ### Draw order (GPUI)
 
-GPUI: *"starts by drawing all shadows, followed by all rectangles, then all
-glyphs… a rectangle could never be rendered on top of a glyph."* That is
+GPUI: _"starts by drawing all shadows, followed by all rectangles, then all
+glyphs… a rectangle could never be rendered on top of a glyph."_ That is
 exactly gooey's `BatchIterator` tie-break (`shadow < quad < glyph < svg <
 image < …`), and GPUI's `Layer { shadows, rectangles, glyphs, … }` mirrors
 gooey's per-type arrays. The lineage is faithful.
@@ -148,8 +162,8 @@ it is what introduces the sort (and the interleaved worst case).
 
 The canonical draw-call-sorting reference says to sort an array of
 **`(key, value)` pairs where the value is a pointer/offset** to the draw-call
-data — never the payload. His claim: *"there really is no problem sorting
-**5,000 or even 10,000 draw calls** each frame this way"* on **2008-era PS3**
+data — never the payload. His claim: _"there really is no problem sorting
+**5,000 or even 10,000 draw calls** each frame this way"_ on **2008-era PS3**
 hardware.
 
 We sort 8k on a modern M-series and it costs 3.3 ms — the gap is almost
@@ -158,8 +172,8 @@ corroborates the hot-spot finding and prescribes the fix.
 
 ### Rebuild-every-frame (Dear ImGui)
 
-The IMGUI paradigm builds draw data fresh each frame (*"most is built up every
-frame"*). Our `clear() + rebuild` at flat ~4 ns/prim with zero allocations is
+The IMGUI paradigm builds draw data fresh each frame (_"most is built up every
+frame"_). Our `clear() + rebuild` at flat ~4 ns/prim with zero allocations is
 the cheap rebuild that model assumes — and the zero-alloc test proves we avoid
 the GC/allocation jitter the GPUI blog blames for Electron's missed frames.
 
@@ -170,6 +184,51 @@ the GC/allocation jitter the GPUI blog blames for Electron's missed frames.
 
 ---
 
+## Correctness gaps found while benchmarking
+
+Benchmarking the sort path surfaced two defects in `Scene.finish()`
+(`src/scene/scene.zig`). Neither is a performance issue per se, but both live
+on the sort path the optimization below rewrites, so they are fixed in the
+same pass.
+
+### Colored point clouds are never sorted (dead invariant)
+
+`finish()` sorts 8 of the 9 primitive types. The 9th —
+`colored_point_clouds` — is missing a branch:
+
+- `insertColoredPointCloudWithOrder` sets `needs_sort_colored_point_clouds = true`.
+- `clear()` resets the flag.
+- `finish()` never reads it.
+
+The flag is therefore write-only. Any out-of-order colored-point-cloud insert
+renders in insertion order rather than draw order. This is precisely the §11
+"negative space" failure mode: the valid state is handled and the flag
+exists, but the path that consumes it was never wired up. Fix: add the
+missing sort branch, and extend the `validate:` suite with a sort-correctness
+check that covers **all nine** types (the current tests miss this one).
+
+**Fixed.** `finish()` now wires in the `colored_point_clouds` branch, and a new
+`scene.zig` test ("finish sorts all nine per-type draw-order arrays ascending")
+seeds every array out of order and asserts ascending order — plus a parallel
+gather check that each path gradient still travels with its instance.
+
+### The paths sort is O(n²)
+
+`needs_sort_paths` uses a hand-rolled in-place **selection sort** because
+`path_instances` and `path_gradients` are parallel arrays that must be
+permuted together. The inline comment ("path counts are typically small, so
+O(n²) is acceptable") is a latent tail-latency landmine — exactly the §1/§4
+"fix it now, put a limit on everything" case. The key-sort scheme below
+solves it cleanly: sort `(order, index)` keys once, then gather _both_
+parallel arrays with the same permutation.
+
+**Fixed.** `sortPathsByOrder` sorts a stack-local key buffer (paths are bounded
+by `MAX_PATHS_PER_FRAME`, so 32 KB of keys covers the worst case with no heap
+scratch) and gathers `path_instances` + `path_gradients` with one permutation —
+O(n log n), selection sort retired.
+
+---
+
 ## Recommended optimization: sort keys, not payloads
 
 `Scene.finish()` currently calls `std.sort.pdq` directly over the
@@ -177,16 +236,36 @@ the GC/allocation jitter the GPUI blog blames for Electron's missed frames.
 moves a 128-byte `Quad`. The textbook fix (Ericson's `(key, value)` scheme)
 is to sort a compact key array and gather:
 
-1. Build a scratch `[]struct { order: u32, index: u32 }` (8 bytes/entry vs
-   128) — or pack `order` and `index` into a single `u64` key.
+1. Build a scratch `[]struct { order: u32, index: u32 }` (8 bytes/entry vs 128) — or pack `order` and `index` into a single `u64` key.
 2. `pdq` the key array (8× fewer bytes moved per swap, cache-resident).
 3. Gather the payload array into sorted position once, in a single linear
    pass.
 
 Expected win: ~10× on the sort path (sorting 8-byte keys instead of 128-byte
 structs), which would bring an 8k-quad sort from ~3.3 ms toward the
-sub-millisecond range Ericson describes. The key array is fixed-capacity
-(bounded by `MAX_QUADS_PER_FRAME`), so it stays on the static-allocation path.
+sub-millisecond range Ericson describes.
+
+**Make it generic, not quad-only.** `Quad` is the worst offender at 128 B,
+but `GlyphInstance` is also a fat struct and `bench-glyphs` reaches 16k —
+every array that triggers a sort pays the payload-move tax. Write the scheme
+once as a helper (`sortByOrder(comptime T, items, scratch_keys)`) and route
+all single-array types through it (shadows, quads, glyphs, svgs, images,
+polylines, point clouds, colored point clouds). The parallel paths arrays
+reuse the _same_ key permutation to gather `path_instances` and
+`path_gradients` together — retiring the O(n²) selection sort noted above.
+
+**Mind the gather step (§2 / §7).** The key sort is cache-resident and
+cheap, but landing the sorted payloads needs care to stay on the
+static-allocation path:
+
+- A scratch copy of the payload array is simplest but reserves
+  `MAX_QUADS_PER_FRAME × 128 B` (and equivalents per type) of static memory.
+- In-place cycle-following permutation avoids the second full-size buffer at
+  the cost of more complex gather logic.
+
+Sketch both against the per-frame memory budget before committing; the key
+arrays themselves are fixed-capacity (bounded by the per-type `MAX_*`
+limits), so they stay on the static-allocation path regardless.
 
 This only affects scenes that trigger the sort (`insertQuadWithOrder`,
 overlays, canvas z-ordering); the common in-order frame never sorts. But it
@@ -197,15 +276,45 @@ for overlay-heavy scenes.
 index-sort-vs-struct-sort comparison entry on the same shuffled inputs to size
 the win on our hardware and let `bench-compare` lock it in.
 
+**Implemented.** `Scene.sortByOrder(comptime T, items)` packs `(order, index)`
+into a single `u64` (order high, index low — a stable, deterministic tie-break)
+and applies the sorted permutation in place by **cycle-following** (`PERM_DONE`
+sentinel marks placed slots), so each payload moves at most once and no
+second full-size payload buffer is needed. The key scratch is a single shared
+`sort_keys` buffer pre-sized to `MAX_SORT_KEYS` by `initCapacity` (grown-and-
+retained by `init()` scenes), keeping `finish()` allocation-free in steady
+state; a payload-`pdq` fallback covers the rare case where the scratch can't be
+acquired, so `finish()` stays infallible. All eight single-array types route
+through the helper; paths use the parallel-gather variant. Gating entries
+`sort_struct_quads_{1k,8k,32k}` were added — see the results table above.
+
+## Secondary: collapse the double min-scan in `BatchIterator.next()`
+
+Lower priority, and only relevant to the interleaved worst case (~20×
+slower, one batch per primitive). Each `next()` computes the minimum order
+across all 9 types via a 9-way scan to pick the batch kind, then
+`consumeBatch` runs a _second_ 8-way `minOfOrders` to find the threshold
+(the second-smallest order) at which the batch must stop. That is two passes
+to compute the smallest and second-smallest order per batch. Folding the
+threshold into the same scan that finds the min would roughly halve the
+per-`next()` overhead. Realistic mixed scenes sit at ~2 ns/prim, so treat
+this as an "if you're already in here" cleanup rather than a priority.
+
+**Implemented.** `next()` now tracks the minimum and the second-smallest order
+(`batch_threshold`) in a single pass and emits the batch through one
+`inline else` switch arm; `minOfOrders` is retired. Same tie-break and batch
+counts; the interleaved worst case dropped ~55% (13.1 → 5.9 ns/prim) and mixed
+dashboard scenes ~1.5 → ~0.9 ns/prim.
+
 ---
 
 ## References
 
-- Scandurra, A. *Leveraging Rust and the GPU to render user interfaces at
-  120 FPS* (GPUI), Zed, 2023 — <https://zed.dev/blog/videogame>
-- Ericson, C. *Order your graphics draw calls around!*, 2008 —
+- Scandurra, A. _Leveraging Rust and the GPU to render user interfaces at
+  120 FPS_ (GPUI), Zed, 2023 — <https://zed.dev/blog/videogame>
+- Ericson, C. _Order your graphics draw calls around!_, 2008 —
   <https://realtimecollisiondetection.net/blog/?p=86>
-- Dear ImGui — *About the IMGUI paradigm* —
+- Dear ImGui — _About the IMGUI paradigm_ —
   <https://github.com/ocornut/imgui/wiki/About-the-IMGUI-paradigm>
 - Source: `src/scene/benchmarks.zig`, `src/scene/scene.zig`,
   `src/scene/batch_iterator.zig`, `src/core/limits.zig`

--- a/src/scene/batch_iterator.zig
+++ b/src/scene/batch_iterator.zig
@@ -107,101 +107,55 @@ pub const BatchIterator = struct {
 
     /// Get the next batch of primitives to render
     pub fn next(self: *Self) ?PrimitiveBatch {
-        // Get the current order for each type (null if exhausted)
-        const shadow_order = self.peekOrder(.shadow);
-        const quad_order = self.peekOrder(.quad);
-        const glyph_order = self.peekOrder(.glyph);
-        const svg_order = self.peekOrder(.svg);
-        const image_order = self.peekOrder(.image);
-        const path_order = self.peekOrder(.path);
-        const polyline_order = self.peekOrder(.polyline);
-        const point_cloud_order = self.peekOrder(.point_cloud);
-        const colored_point_cloud_order = self.peekOrder(.colored_point_cloud);
+        // Draw-order priority for ties (lowest first), matching GPUI's fixed
+        // type order: shadow < quad < glyph < svg < image < path < polyline <
+        // point_cloud < colored_point_cloud. The arrays are in this order so the
+        // strict `<` below lets the earliest kind win an equal-order tie.
+        const orders = [_]?scene_mod.DrawOrder{
+            self.peekOrder(.shadow),
+            self.peekOrder(.quad),
+            self.peekOrder(.glyph),
+            self.peekOrder(.svg),
+            self.peekOrder(.image),
+            self.peekOrder(.path),
+            self.peekOrder(.polyline),
+            self.peekOrder(.point_cloud),
+            self.peekOrder(.colored_point_cloud),
+        };
+        const kinds = [_]PrimitiveKind{
+            .shadow, .quad,     .glyph,       .svg,                 .image,
+            .path,   .polyline, .point_cloud, .colored_point_cloud,
+        };
 
-        // Find minimum order (with tie-breaking by kind priority: shadow < quad < glyph < svg < image < path < polyline < point_cloud < colored_point_cloud)
+        // Single pass finds both the minimum order (which kind to emit) and the
+        // second-smallest order across all other types (the threshold at which
+        // the batch must stop). Folding the threshold into the min scan avoids a
+        // second 8-way `minOfOrders` pass per `next()` call. `batch_threshold`
+        // tracks the two smallest orders with multiplicity, so it equals the
+        // minimum order among every type except the chosen `min_kind`.
         var min_kind: ?PrimitiveKind = null;
         var min_order: scene_mod.DrawOrder = std.math.maxInt(scene_mod.DrawOrder);
+        var batch_threshold: scene_mod.DrawOrder = std.math.maxInt(scene_mod.DrawOrder);
 
-        if (shadow_order) |order| {
-            if (order < min_order) {
-                min_order = order;
-                min_kind = .shadow;
-            }
-        }
-        if (quad_order) |order| {
-            if (order < min_order) {
-                min_order = order;
-                min_kind = .quad;
-            }
-        }
-        if (glyph_order) |order| {
-            if (order < min_order) {
-                min_order = order;
-                min_kind = .glyph;
-            }
-        }
-        if (svg_order) |order| {
-            if (order < min_order) {
-                min_order = order;
-                min_kind = .svg;
-            }
-        }
-        if (image_order) |order| {
-            if (order < min_order) {
-                min_order = order;
-                min_kind = .image;
-            }
-        }
-        if (path_order) |order| {
-            if (order < min_order) {
-                min_order = order;
-                min_kind = .path;
-            }
-        }
-        if (polyline_order) |order| {
-            if (order < min_order) {
-                min_order = order;
-                min_kind = .polyline;
-            }
-        }
-        if (point_cloud_order) |order| {
-            if (order < min_order) {
-                min_order = order;
-                min_kind = .point_cloud;
-            }
-        }
-        if (colored_point_cloud_order) |order| {
-            if (order < min_order) {
-                min_order = order;
-                min_kind = .colored_point_cloud;
+        inline for (orders, kinds) |maybe_order, kind| {
+            if (maybe_order) |order| {
+                if (order < min_order) {
+                    batch_threshold = min_order; // previous min is now the runner-up
+                    min_order = order;
+                    min_kind = kind;
+                } else if (order < batch_threshold) {
+                    batch_threshold = order;
+                }
             }
         }
 
         const kind = min_kind orelse return null;
 
-        // Consume all consecutive primitives of this type until we hit
-        // a primitive of another type with a lower order
+        // Consume all consecutive primitives of this type until another type's
+        // order would interleave (i.e. `order >= batch_threshold`).
         return switch (kind) {
-            .shadow => self.consumeBatch(.shadow, minOfOrders(.{ quad_order, glyph_order, svg_order, image_order, path_order, polyline_order, point_cloud_order, colored_point_cloud_order })),
-            .quad => self.consumeBatch(.quad, minOfOrders(.{ shadow_order, glyph_order, svg_order, image_order, path_order, polyline_order, point_cloud_order, colored_point_cloud_order })),
-            .glyph => self.consumeBatch(.glyph, minOfOrders(.{ shadow_order, quad_order, svg_order, image_order, path_order, polyline_order, point_cloud_order, colored_point_cloud_order })),
-            .svg => self.consumeBatch(.svg, minOfOrders(.{ shadow_order, quad_order, glyph_order, image_order, path_order, polyline_order, point_cloud_order, colored_point_cloud_order })),
-            .image => self.consumeBatch(.image, minOfOrders(.{ shadow_order, quad_order, glyph_order, svg_order, path_order, polyline_order, point_cloud_order, colored_point_cloud_order })),
-            .path => self.consumeBatch(.path, minOfOrders(.{ shadow_order, quad_order, glyph_order, svg_order, image_order, polyline_order, point_cloud_order, colored_point_cloud_order })),
-            .polyline => self.consumeBatch(.polyline, minOfOrders(.{ shadow_order, quad_order, glyph_order, svg_order, image_order, path_order, point_cloud_order, colored_point_cloud_order })),
-            .point_cloud => self.consumeBatch(.point_cloud, minOfOrders(.{ shadow_order, quad_order, glyph_order, svg_order, image_order, path_order, polyline_order, colored_point_cloud_order })),
-            .colored_point_cloud => self.consumeBatch(.colored_point_cloud, minOfOrders(.{ shadow_order, quad_order, glyph_order, svg_order, image_order, path_order, polyline_order, point_cloud_order })),
+            inline else => |comptime_kind| self.consumeBatch(comptime_kind, batch_threshold),
         };
-    }
-
-    /// Find the minimum order among a set of optional orders.
-    /// Returns maxInt if all are null.
-    fn minOfOrders(orders: [8]?scene_mod.DrawOrder) scene_mod.DrawOrder {
-        var min: scene_mod.DrawOrder = std.math.maxInt(scene_mod.DrawOrder);
-        inline for (orders) |maybe_order| {
-            if (maybe_order) |o| min = @min(min, o);
-        }
-        return min;
     }
 
     /// Peek at the order of the next primitive of a given type
@@ -444,14 +398,4 @@ test "BatchIterator - coalesces consecutive same type" {
 
     // Done
     try std.testing.expect(iter.next() == null);
-}
-
-test "minOfOrders - all null returns maxInt" {
-    const result = BatchIterator.minOfOrders(.{ null, null, null, null, null, null, null, null });
-    try std.testing.expectEqual(std.math.maxInt(scene_mod.DrawOrder), result);
-}
-
-test "minOfOrders - finds minimum" {
-    const result = BatchIterator.minOfOrders(.{ @as(?scene_mod.DrawOrder, 5), @as(?scene_mod.DrawOrder, 2), null, @as(?scene_mod.DrawOrder, 10), null, null, null, null });
-    try std.testing.expectEqual(@as(scene_mod.DrawOrder, 2), result);
 }

--- a/src/scene/benchmarks.zig
+++ b/src/scene/benchmarks.zig
@@ -599,6 +599,70 @@ fn benchDrawOrderSort(
     return makeResult(name, count, total_time_ns, iterations, percentiles, 0);
 }
 
+/// Direct payload sort over the same shuffled quads: the pre-optimization
+/// baseline that moves whole 128-byte `Quad` structs on every swap. Paired with
+/// `benchDrawOrderSort` (the indirect key sort that `finish()` now uses) so
+/// `bench-compare` can size the payload-move tax on this hardware — the concrete
+/// before/after for Ericson's "sort keys, not payloads".
+fn benchDrawOrderSortStruct(
+    allocator: Allocator,
+    comptime name: []const u8,
+    count: u32,
+) !BenchmarkResult {
+    std.debug.assert(count > 1);
+    std.debug.assert(count <= MAX_QUADS_PER_FRAME);
+
+    var scene = try Scene.initCapacity(allocator);
+    defer scene.deinit();
+
+    const unsorted = try allocator.alloc(Quad, count);
+    defer allocator.free(unsorted);
+
+    try seedShuffledQuads(&scene, count, unsorted);
+    const items = scene.quads.items;
+    std.debug.assert(items.len == count);
+
+    const warmup_iters = getWarmupIterations(count);
+    const min_sample_iters = getMinSampleIterations(count);
+
+    for (0..warmup_iters) |_| {
+        @memcpy(items, unsorted);
+        pdqQuadsByOrder(items);
+    }
+
+    var total_time_ns: u64 = 0;
+    var iterations: u32 = 0;
+    var samples = IterationSamples.init();
+
+    while (total_time_ns < MIN_SAMPLE_TIME_NS or iterations < min_sample_iters) {
+        @memcpy(items, unsorted); // restore unsorted permutation (untimed)
+
+        const start = time.Instant.now();
+        pdqQuadsByOrder(items);
+        const end = time.Instant.now();
+        std.debug.assert(items[0].order <= items[count - 1].order);
+
+        const elapsed = end.since(start);
+        total_time_ns += elapsed;
+        samples.record(elapsed);
+        iterations += 1;
+    }
+
+    const percentiles = samples.computePercentiles(count);
+    return makeResult(name, count, total_time_ns, iterations, percentiles, 0);
+}
+
+/// The legacy sort: `std.sort.pdq` straight over the `Quad` payload array, so
+/// every swap shuffles 128 bytes. Isolated here purely as the benchmark
+/// baseline; production `finish()` no longer does this.
+fn pdqQuadsByOrder(items: []Quad) void {
+    std.sort.pdq(Quad, items, {}, struct {
+        fn lessThan(_: void, a: Quad, b: Quad) bool {
+            return a.order < b.order;
+        }
+    }.lessThan);
+}
+
 /// Clip stack: time `depth` pushClip calls (each intersecting the current clip)
 /// followed by `depth` popClip calls. Reports ns per push/pop pair — the cost
 /// of one nested clip level.
@@ -948,10 +1012,15 @@ pub fn main(init: std.process.Init) !void {
     // Draw-Order Sort
     // =========================================================================
 
-    printSectionHeader("Gooey Scene Benchmarks — Draw-Order Sort (finish() pdq over shuffled quads)");
+    printSectionHeader("Gooey Scene Benchmarks — Draw-Order Sort (finish() over shuffled quads)");
+    // Indirect key sort (what finish() now does) vs. the legacy payload sort, on
+    // identical shuffled inputs, so bench-compare can lock in the win.
     collect(&reporter, try benchDrawOrderSort(allocator, "sort_quads_1k", 1000));
     collect(&reporter, try benchDrawOrderSort(allocator, "sort_quads_8k", 8000));
     collect(&reporter, try benchDrawOrderSort(allocator, "sort_quads_32k", 32000));
+    collect(&reporter, try benchDrawOrderSortStruct(allocator, "sort_struct_quads_1k", 1000));
+    collect(&reporter, try benchDrawOrderSortStruct(allocator, "sort_struct_quads_8k", 8000));
+    collect(&reporter, try benchDrawOrderSortStruct(allocator, "sort_struct_quads_32k", 32000));
     std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
 
     // =========================================================================

--- a/src/scene/scene.zig
+++ b/src/scene/scene.zig
@@ -65,6 +65,25 @@ pub const MAX_CLIP_STACK_DEPTH = limits.MAX_CLIP_STACK_DEPTH;
 
 pub const DrawOrder = u32;
 
+/// Capacity of the draw-order sort scratch (one u64 key per primitive). Sized
+/// to the largest single per-type array so the same buffer can be reused for
+/// every type's sort within a `finish()` call. Pre-allocated by `initCapacity`
+/// so the keyed sort never allocates in steady state (static-allocation, §2).
+pub const MAX_SORT_KEYS: u32 = blk: {
+    var maximum: u32 = 0;
+    for ([_]u32{
+        MAX_SHADOWS_PER_FRAME,
+        MAX_QUADS_PER_FRAME,
+        MAX_GLYPHS_PER_FRAME,
+        MAX_SVGS_PER_FRAME,
+        MAX_IMAGES_PER_FRAME,
+        MAX_POLYLINES_PER_FRAME,
+        MAX_POINT_CLOUDS_PER_FRAME,
+        MAX_COLORED_POINT_CLOUDS_PER_FRAME,
+    }) |capacity| maximum = @max(maximum, capacity);
+    break :blk maximum;
+};
+
 // ============================================================================
 // GPU Geometry Types (re-exported from geometry.zig)
 // ============================================================================
@@ -498,6 +517,138 @@ comptime {
 }
 
 // ============================================================================
+// Draw-order sort (indirect key sort)
+// ============================================================================
+//
+// `finish()` orders each per-type array by its `.order` field. Rather than hand
+// `std.sort.pdq` the payload arrays directly — which makes every swap move a fat
+// struct (a `Quad` is 128 B, a `GradientUniforms` 352 B) — we sort a compact
+// array of `(order, index)` keys (8 B each, cache-resident) and then permute the
+// payload into place once. This is Christer Ericson's "sort keys, not payloads"
+// (2008): the comparison sort touches only the small keys, and each payload
+// struct is moved at most once during the gather.
+
+/// Sentinel written into a key slot once its payload has been placed, so the
+/// outer permutation loop can skip cycles it has already walked. A real key is
+/// `(order << 32) | index`; reaching all-ones would require `index == 0xFFFF_FFFF`,
+/// which the per-frame limits (≤ 65536) make impossible — so there is no collision.
+const PERM_DONE: u64 = std.math.maxInt(u64);
+
+/// Pack a draw order and array index into a single sortable u64. The order
+/// occupies the high 32 bits (primary key) and the index the low 32 bits, so an
+/// ascending u64 sort breaks ties by insertion order — a stable, deterministic
+/// result, unlike the old unstable payload pdq.
+inline fn makeOrderKey(order: DrawOrder, index: u32) u64 {
+    return (@as(u64, order) << 32) | @as(u64, index);
+}
+
+fn ascendingU64(_: void, a: u64, b: u64) bool {
+    return a < b;
+}
+
+/// Comparator over a payload type's `.order` field, used only on the no-scratch
+/// fallback path (see `Scene.sortByOrder`).
+fn orderLessThan(comptime T: type) fn (void, T, T) bool {
+    return struct {
+        fn lessThan(_: void, a: T, b: T) bool {
+            return a.order < b.order;
+        }
+    }.lessThan;
+}
+
+/// Reorder `items` in place to `items[j] = old_items[perm[j]]`, where `perm[j]`
+/// is the low 32 bits of `keys[j]` (the original index that belongs in sorted
+/// slot `j`). Walks each permutation cycle once, holding the displaced element
+/// in `tmp` and reading one slot ahead before overwriting, so every payload is
+/// written exactly once. `keys` is consumed (slots are marked `PERM_DONE`).
+fn applyPermutation(comptime T: type, items: []T, keys: []u64) void {
+    std.debug.assert(items.len == keys.len);
+    const count: u32 = @intCast(items.len);
+
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        if (keys[i] == PERM_DONE) continue;
+        const first_source: u32 = @truncate(keys[i]);
+        if (first_source == i) {
+            keys[i] = PERM_DONE; // already in place; close the trivial cycle
+            continue;
+        }
+
+        const displaced = items[i]; // belongs at the cycle's closing slot
+        var slot = i;
+        while (true) {
+            const source: u32 = @truncate(keys[slot]);
+            keys[slot] = PERM_DONE;
+            if (source == i) {
+                items[slot] = displaced;
+                break;
+            }
+            items[slot] = items[source];
+            slot = source;
+        }
+    }
+}
+
+/// Parallel-array variant of `applyPermutation`: gathers `instances` and
+/// `gradients` with the same permutation so the two stay index-aligned. This is
+/// what lets the paths arrays be sorted together without the old O(n²) selection
+/// sort that hand-swapped both arrays per comparison.
+fn applyPermutationPaths(
+    instances: []PathInstance,
+    gradients: []GradientUniforms,
+    keys: []u64,
+) void {
+    std.debug.assert(instances.len == gradients.len);
+    std.debug.assert(instances.len == keys.len);
+    const count: u32 = @intCast(instances.len);
+
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        if (keys[i] == PERM_DONE) continue;
+        const first_source: u32 = @truncate(keys[i]);
+        if (first_source == i) {
+            keys[i] = PERM_DONE;
+            continue;
+        }
+
+        const displaced_instance = instances[i];
+        const displaced_gradient = gradients[i];
+        var slot = i;
+        while (true) {
+            const source: u32 = @truncate(keys[slot]);
+            keys[slot] = PERM_DONE;
+            if (source == i) {
+                instances[slot] = displaced_instance;
+                gradients[slot] = displaced_gradient;
+                break;
+            }
+            instances[slot] = instances[source];
+            gradients[slot] = gradients[source];
+            slot = source;
+        }
+    }
+}
+
+/// Sort the parallel `path_instances` / `path_gradients` arrays together by draw
+/// order. Paths are bounded by `MAX_PATHS_PER_FRAME` (4096), so the key scratch
+/// fits comfortably on the stack (32 KB) — no heap scratch, no allocation, and
+/// no dependence on the shared `sort_keys` buffer. Retires the previous O(n²)
+/// selection sort entirely.
+fn sortPathsByOrder(instances: []PathInstance, gradients: []GradientUniforms) void {
+    std.debug.assert(instances.len == gradients.len);
+    if (instances.len < 2) return; // 0 or 1 element is already ordered
+    std.debug.assert(instances.len <= MAX_PATHS_PER_FRAME);
+
+    const count: u32 = @intCast(instances.len);
+    var keys: [MAX_PATHS_PER_FRAME]u64 = undefined;
+    var i: u32 = 0;
+    while (i < count) : (i += 1) keys[i] = makeOrderKey(instances[i].order, i);
+
+    std.sort.pdq(u64, keys[0..count], {}, ascendingU64);
+    applyPermutationPaths(instances, gradients, keys[0..count]);
+}
+
+// ============================================================================
 // Scene - collects primitives for rendering
 // ============================================================================
 
@@ -524,6 +675,10 @@ pub const Scene = struct {
     next_order: DrawOrder,
     // Clip mask stack for nested clipping regions
     clip_stack: std.ArrayListUnmanaged(ContentMask.ClipBounds),
+    // Scratch buffer of (order, index) keys reused by `finish()` to sort each
+    // per-type array indirectly (see the "Draw-order sort" section above).
+    // Pre-allocated by `initCapacity`; grown-and-retained by `init()` scenes.
+    sort_keys: std.ArrayListUnmanaged(u64),
     // Per-array dirty flags: track which arrays had out-of-order inserts (requiring sort)
     needs_sort_shadows: bool,
     needs_sort_quads: bool,
@@ -563,6 +718,7 @@ pub const Scene = struct {
             .mesh_pool = MeshPool.init(allocator),
             .next_order = 0,
             .clip_stack = .empty,
+            .sort_keys = .empty,
             .needs_sort_shadows = false,
             .needs_sort_quads = false,
             .needs_sort_glyphs = false,
@@ -599,6 +755,7 @@ pub const Scene = struct {
             .mesh_pool = MeshPool.init(allocator),
             .next_order = 0,
             .clip_stack = .empty,
+            .sort_keys = .empty,
             .needs_sort_shadows = false,
             .needs_sort_quads = false,
             .needs_sort_glyphs = false,
@@ -626,6 +783,7 @@ pub const Scene = struct {
         try self.point_clouds.ensureTotalCapacity(allocator, MAX_POINT_CLOUDS_PER_FRAME);
         try self.colored_point_clouds.ensureTotalCapacity(allocator, MAX_COLORED_POINT_CLOUDS_PER_FRAME);
         try self.clip_stack.ensureTotalCapacity(allocator, MAX_CLIP_STACK_DEPTH);
+        try self.sort_keys.ensureTotalCapacity(allocator, MAX_SORT_KEYS);
 
         return self;
     }
@@ -642,6 +800,7 @@ pub const Scene = struct {
         self.point_clouds.deinit(self.allocator);
         self.colored_point_clouds.deinit(self.allocator);
         self.clip_stack.deinit(self.allocator);
+        self.sort_keys.deinit(self.allocator);
         self.mesh_pool.deinit();
     }
 
@@ -1441,86 +1600,68 @@ pub const Scene = struct {
         if (self.stats) |s| s.recordQuads(1);
     }
 
-    /// Finalize the scene for rendering.
-    /// Sorts primitives by draw order only for arrays that had out-of-order inserts.
-    pub fn finish(self: *Self) void {
-        // Only sort arrays that had out-of-order inserts
-        if (self.needs_sort_shadows) {
-            std.sort.pdq(Shadow, self.shadows.items, {}, struct {
-                fn lessThan(_: void, a: Shadow, b: Shadow) bool {
-                    return a.order < b.order;
-                }
-            }.lessThan);
-        }
-        if (self.needs_sort_quads) {
-            std.sort.pdq(Quad, self.quads.items, {}, struct {
-                fn lessThan(_: void, a: Quad, b: Quad) bool {
-                    return a.order < b.order;
-                }
-            }.lessThan);
-        }
-        if (self.needs_sort_glyphs) {
-            std.sort.pdq(GlyphInstance, self.glyphs.items, {}, struct {
-                fn lessThan(_: void, a: GlyphInstance, b: GlyphInstance) bool {
-                    return a.order < b.order;
-                }
-            }.lessThan);
-        }
-        if (self.needs_sort_svgs) {
-            std.sort.pdq(SvgInstance, self.svg_instances.items, {}, struct {
-                fn lessThan(_: void, a: SvgInstance, b: SvgInstance) bool {
-                    return a.order < b.order;
-                }
-            }.lessThan);
-        }
-        if (self.needs_sort_images) {
-            std.sort.pdq(ImageInstance, self.images.items, {}, struct {
-                fn lessThan(_: void, a: ImageInstance, b: ImageInstance) bool {
-                    return a.order < b.order;
-                }
-            }.lessThan);
-        }
-        if (self.needs_sort_paths) {
-            // Sort both path_instances and path_gradients together to maintain parallel alignment
-            const n = self.path_instances.items.len;
-            if (n > 1) {
-                // Simple in-place parallel sort using selection sort for correctness
-                // (path counts per frame are typically small, so O(n²) is acceptable)
-                var i: usize = 0;
-                while (i < n - 1) : (i += 1) {
-                    var min_idx = i;
-                    var j = i + 1;
-                    while (j < n) : (j += 1) {
-                        if (self.path_instances.items[j].order < self.path_instances.items[min_idx].order) {
-                            min_idx = j;
-                        }
-                    }
-                    if (min_idx != i) {
-                        // Swap both arrays at the same indices
-                        const tmp_path = self.path_instances.items[i];
-                        self.path_instances.items[i] = self.path_instances.items[min_idx];
-                        self.path_instances.items[min_idx] = tmp_path;
+    /// Acquire the sort-key scratch sized for `count` keys. With `initCapacity`
+    /// the buffer is pre-sized to `MAX_SORT_KEYS`, so this is a no-op there and
+    /// the keyed sort never allocates in steady state. An `init()` scene grows
+    /// the buffer once and retains it, mirroring how its primitive arrays grow.
+    /// Returns null only if growth fails (allocation pressure on an `init()`
+    /// scene); callers then fall back to a direct payload sort so `finish()`
+    /// stays infallible.
+    fn acquireSortKeys(self: *Self, count: u32) ?[]u64 {
+        std.debug.assert(count >= 2); // callers skip the sort for count < 2
+        self.sort_keys.ensureTotalCapacity(self.allocator, count) catch return null;
+        const buffer = self.sort_keys.allocatedSlice();
+        std.debug.assert(buffer.len >= count);
+        return buffer[0..count];
+    }
 
-                        const tmp_grad = self.path_gradients.items[i];
-                        self.path_gradients.items[i] = self.path_gradients.items[min_idx];
-                        self.path_gradients.items[min_idx] = tmp_grad;
-                    }
-                }
-            }
+    /// Sort a single per-type array ascending by `.order` using the indirect key
+    /// sort (see the "Draw-order sort" section). Falls back to a direct payload
+    /// pdq if the key scratch is unavailable, keeping the result correct under
+    /// allocation failure.
+    fn sortByOrder(self: *Self, comptime T: type, items: []T) void {
+        if (items.len < 2) return; // 0 or 1 element is already ordered
+        const count: u32 = @intCast(items.len);
+
+        const keys = self.acquireSortKeys(count) orelse {
+            std.sort.pdq(T, items, {}, orderLessThan(T));
+            return;
+        };
+        std.debug.assert(keys.len == count);
+
+        var i: u32 = 0;
+        while (i < count) : (i += 1) keys[i] = makeOrderKey(items[i].order, i);
+
+        std.sort.pdq(u64, keys, {}, ascendingU64);
+        applyPermutation(T, items, keys);
+    }
+
+    /// Finalize the scene for rendering.
+    /// Sorts primitives by draw order only for arrays that had out-of-order
+    /// inserts. Each array is ordered by an indirect key sort that moves the fat
+    /// payload structs at most once (see the "Draw-order sort" section above).
+    pub fn finish(self: *Self) void {
+        // Only sort arrays that had out-of-order inserts. `needs_sort_shadows`
+        // has no public setter today (there is no `insertShadowWithOrder`), but
+        // routing shadows through the same path keeps the nine types symmetric
+        // and correct the moment such an API is added.
+        if (self.needs_sort_shadows) self.sortByOrder(Shadow, self.shadows.items);
+        if (self.needs_sort_quads) self.sortByOrder(Quad, self.quads.items);
+        if (self.needs_sort_glyphs) self.sortByOrder(GlyphInstance, self.glyphs.items);
+        if (self.needs_sort_svgs) self.sortByOrder(SvgInstance, self.svg_instances.items);
+        if (self.needs_sort_images) self.sortByOrder(ImageInstance, self.images.items);
+        if (self.needs_sort_paths) {
+            // Paths carry a parallel gradient array; gather both with one
+            // permutation (retires the former O(n²) selection sort).
+            sortPathsByOrder(self.path_instances.items, self.path_gradients.items);
         }
-        if (self.needs_sort_polylines) {
-            std.sort.pdq(Polyline, self.polylines.items, {}, struct {
-                fn lessThan(_: void, a: Polyline, b: Polyline) bool {
-                    return a.order < b.order;
-                }
-            }.lessThan);
-        }
-        if (self.needs_sort_point_clouds) {
-            std.sort.pdq(PointCloud, self.point_clouds.items, {}, struct {
-                fn lessThan(_: void, a: PointCloud, b: PointCloud) bool {
-                    return a.order < b.order;
-                }
-            }.lessThan);
+        if (self.needs_sort_polylines) self.sortByOrder(Polyline, self.polylines.items);
+        if (self.needs_sort_point_clouds) self.sortByOrder(PointCloud, self.point_clouds.items);
+        // Previously missing: the flag was set on out-of-order inserts but never
+        // consumed, so colored point clouds rendered in insertion order. Wiring
+        // the branch in fixes that dead-invariant bug (§11, negative space).
+        if (self.needs_sort_colored_point_clouds) {
+            self.sortByOrder(ColoredPointCloud, self.colored_point_clouds.items);
         }
     }
 
@@ -1681,4 +1822,85 @@ test "insertQuadWithOrder interleaves correctly with BatchIterator" {
 
     // No more batches
     try testing.expect(iter.next() == null);
+}
+
+test "finish sorts all nine per-type draw-order arrays ascending" {
+    // Goal: prove every per-type array that can be flagged out-of-order is
+    // actually re-sorted by `finish()` — including `colored_point_clouds`, whose
+    // sort branch was previously missing (write-only flag), and the parallel
+    // path arrays, whose gradients must travel with their instances. We seed
+    // each array directly (white-box) with a descending-ish order permutation so
+    // a correct sort must move every element, then assert ascending order.
+    const testing = std.testing;
+    var scene = Scene.init(testing.allocator);
+    defer scene.deinit();
+
+    // Distinct, non-monotonic orders: a stable ascending sort must reorder them
+    // to {0, 10, 20, 30, 40}.
+    const orders = [_]DrawOrder{ 40, 10, 30, 0, 20 };
+
+    // Append `n` default primitives of type `T` carrying the given orders.
+    // References only `std` (file scope) and its parameters — no outer locals —
+    // so it is a legal nested function in Zig.
+    const seed = struct {
+        fn run(
+            comptime T: type,
+            list: *std.ArrayListUnmanaged(T),
+            gpa: std.mem.Allocator,
+            order_values: []const DrawOrder,
+        ) !void {
+            for (order_values) |order| try list.append(gpa, .{ .order = order });
+        }
+    }.run;
+
+    const expectAscending = struct {
+        fn run(comptime T: type, items: []const T) !void {
+            var i: usize = 1;
+            while (i < items.len) : (i += 1) {
+                try std.testing.expect(items[i - 1].order <= items[i].order);
+            }
+        }
+    }.run;
+
+    try seed(Shadow, &scene.shadows, scene.allocator, &orders);
+    scene.needs_sort_shadows = true;
+    try seed(Quad, &scene.quads, scene.allocator, &orders);
+    scene.needs_sort_quads = true;
+    try seed(GlyphInstance, &scene.glyphs, scene.allocator, &orders);
+    scene.needs_sort_glyphs = true;
+    try seed(SvgInstance, &scene.svg_instances, scene.allocator, &orders);
+    scene.needs_sort_svgs = true;
+    try seed(ImageInstance, &scene.images, scene.allocator, &orders);
+    scene.needs_sort_images = true;
+    try seed(Polyline, &scene.polylines, scene.allocator, &orders);
+    scene.needs_sort_polylines = true;
+    try seed(PointCloud, &scene.point_clouds, scene.allocator, &orders);
+    scene.needs_sort_point_clouds = true;
+    try seed(ColoredPointCloud, &scene.colored_point_clouds, scene.allocator, &orders);
+    scene.needs_sort_colored_point_clouds = true;
+
+    // Paths: parallel instance/gradient arrays. Tag each gradient's `param0`
+    // with its instance's order so we can prove the gather kept them aligned.
+    for (orders) |order| {
+        try scene.path_instances.append(scene.allocator, .{ .order = order, .index_count = 1 });
+        try scene.path_gradients.append(scene.allocator, .{ .param0 = @floatFromInt(order) });
+    }
+    scene.needs_sort_paths = true;
+
+    scene.finish();
+
+    try expectAscending(Shadow, scene.shadows.items);
+    try expectAscending(Quad, scene.quads.items);
+    try expectAscending(GlyphInstance, scene.glyphs.items);
+    try expectAscending(SvgInstance, scene.svg_instances.items);
+    try expectAscending(ImageInstance, scene.images.items);
+    try expectAscending(Polyline, scene.polylines.items);
+    try expectAscending(PointCloud, scene.point_clouds.items);
+    try expectAscending(ColoredPointCloud, scene.colored_point_clouds.items);
+    try expectAscending(PathInstance, scene.path_instances.items);
+
+    // Parallel gather: each gradient must still sit beside its own instance.
+    for (scene.path_instances.items, scene.path_gradients.items) |instance, gradient| {
+        try testing.expectEqual(@as(f32, @floatFromInt(instance.order)), gradient.param0);
+    }
 }


### PR DESCRIPTION
## Summary

Implements the recommendations in `docs/scene-data-plane-performance.md`: the draw-order sort in `Scene.finish()` is the data plane's one hot spot, and it was sorting fat payload structs directly. This switches to an indirect **key sort** (Christer Ericson's "sort keys, not payloads", 2008), fixes two correctness defects found on the same path, and folds the `BatchIterator` double min-scan into a single pass.

Benchmarked before, after each step, and gated with `bench-compare` (**PASS, 0 regressed**).

## What changed

**1. Sort keys, not payloads** (`src/scene/scene.zig`)
- `finish()` now sorts compact `(order, index)` u64 keys (8 B) instead of handing `std.sort.pdq` the payload arrays (`Quad` is 128 B, `GradientUniforms` 352 B), then applies the permutation in place by **cycle-following** so each payload struct moves at most once.
- Generic `Scene.sortByOrder(comptime T, items)` routes all eight single-array types through one helper. The key scratch (`sort_keys`) is pre-sized by `initCapacity` (`MAX_SORT_KEYS`) so the steady-state zero-alloc invariant holds; a payload-pdq fallback keeps `finish()` infallible if the scratch can't be acquired.
- Sort is now **stable** (index tie-break in the low bits) — a determinism win. Visited slots use a full-`u64` `PERM_DONE` sentinel, which is safe even with high-bit draw orders (e.g. the existing `0xFFFF_FF00` overlay test).

**2. Two correctness fixes on the sort path** (same area)
- `colored_point_clouds` was flagged for sorting on out-of-order insert but `finish()` never consumed the flag (a write-only invariant → rendered in insertion order). Wired in the missing branch.
- The parallel `path_instances` / `path_gradients` **O(n²) selection sort** is retired: `sortPathsByOrder` gathers both arrays with one permutation from a stack-local key buffer (paths are bounded by `MAX_PATHS_PER_FRAME`, so 32 KB of keys covers the worst case with no heap scratch).
- New `scene.zig` test asserts ascending order across **all nine** per-type arrays plus the parallel path/gradient gather.

**3. Collapsed the `BatchIterator.next()` double min-scan** (`src/scene/batch_iterator.zig`)
- Tracked the minimum order (to pick the batch kind) and then ran a second 8-way `minOfOrders` for the stop threshold. Now both are found in a single pass (`batch_threshold` = min order excluding the chosen kind), emitted through one `inline else` switch arm. `minOfOrders` retired. Same tie-break, identical batch counts.

**4. Benchmarks + docs**
- Added `sort_struct_quads_{1k,8k,32k}` entries to `src/scene/benchmarks.zig` as a side-by-side payload-sort baseline so `bench-compare` can size the win.
- Updated `docs/scene-data-plane-performance.md` to mark the items implemented with measured results.

## Results (M-series, `ReleaseFast`, gated by `bench-compare`)

Draw-order sort:

| Test | Before (payload) | After (keyed) | Speedup |
|------|------------------|---------------|---------|
| sort_quads_1k | ~233 ns/quad | ~20 ns/quad | ~11.8× |
| sort_quads_8k | ~274 ns/quad | ~49 ns/quad | ~5.6× |
| sort_quads_32k | ~303 ns/quad | ~58 ns/quad | ~5.2× |

The 32k sort drops from **~9.7 ms → ~1.9 ms** per `finish()` — back under a single 60 Hz frame. `bench-compare` logs −80% to −92% on the gated minimum.

BatchIterator drain:

| Test | Before | After | Speedup |
|------|--------|-------|---------|
| batch_interleaved_2k (worst case) | 13.1 ns/prim | 5.9 ns/prim | ~2.2× (−55%) |
| batch_dashboard_medium | 1.57 ns/prim | 0.92 ns/prim | ~1.7× |
| batch_dashboard_large | 1.41 ns/prim | 0.84 ns/prim | ~1.7× |

## Scope / caveats
- These help only scenes that **trigger the sort** (overlays, canvas z-ordering, `insertQuadWithOrder`); the common in-order frame never sorted and is unchanged. The end-to-end `frame_dashboard_*` group (already <0.4% of the 120 Hz budget) uses in-order builds and is unchanged — the win is in the tail.
- The paths fix is an algorithmic win (O(n²) → O(n log n)); there's no paths-sort bench, but it removes a latent tail-latency spike.

## Testing
- `zig build test` → **1181/1181 pass, exit 0**.
- `zig build bench-scene` + `zig build bench-compare` against the pre-change baseline → **PASS, 0 regressed, 4 improved**.

> Note: `zig build test` occasionally prints transient `failed command` lines on certain random seeds; this reproduces on a clean `main` (a pre-existing flaky test, unrelated to this change) and the final build summary/exit code are clean.