### PR TITLE
Add Window.widgetState string-keyed accessor; drop hand-rolled hashing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -174,8 +174,7 @@ const AppState = struct {
     pub fn addTodo(self: *AppState, g: *gooey.Window) void {
         self.pushTodo(self.draft);
         self.draft = "";
-        const id_hash: u64 = gooey.layout.LayoutId.fromString(draft_input_id).id;
-        if (g.element_states.get(gooey.widgets.TextInputState, id_hash)) |input| {
+        if (g.widgetState(gooey.widgets.TextInputState, draft_input_id)) |input| {
             input.clear();
         }
     }

--- a/src/context/window.zig
+++ b/src/context/window.zig
@@ -1420,6 +1420,27 @@ pub const Window = struct {
     // exposes `pub fn focusable(self) Focusable` and the builder registers
     // that vtable on its `FocusHandle`; `Window` doesn't learn the type.
 
+    /// Look up retained engine state of type `S` by string `id`, or `null`
+    /// if no widget with that id has mounted yet. Generic over `S` so no
+    /// concrete widget-state type leaks into `Window` (see the module note
+    /// at the top of this file): the caller names the type at the call site,
+    /// e.g. `g.widgetState(gooey.widgets.TextInputState, "draft")`.
+    ///
+    /// This is the string-keyed twin of the raw `window.element_states.get`
+    /// pool call — it folds in the `LayoutId.fromString(id).id` hashing so
+    /// `*Window`-shaped command handlers don't hand-roll it. `Cx.textField`
+    /// and friends are the typed sugar over this same path for `*Cx`
+    /// contexts; both land on the same pool lookup.
+    pub fn widgetState(self: *Self, comptime S: type, id: []const u8) ?*S {
+        std.debug.assert(id.len > 0);
+        const id_hash: u64 = @as(u64, LayoutId.fromString(id).id);
+        // A real string id never collides with `LayoutId.none` (id 0),
+        // the reserved null/invalid sentinel — mirrors the `*ById`
+        // accessors' precondition in `cx/element_states.zig`.
+        std.debug.assert(id_hash != 0);
+        return self.element_states.get(S, id_hash);
+    }
+
     /// Focus a widget by string ID. Generic over widget type — the
     /// `FocusManager` uses the `Focusable` vtable registered on the matching
     /// `FocusHandle` to drive `blur()` on the previously focused widget and

--- a/src/cx.zig
+++ b/src/cx.zig
@@ -569,16 +569,13 @@ pub const Cx = struct {
     // accessors stay `?*T` for the case where the widget hasn't
     // mounted yet (e.g. a callback firing before the first render).
     pub fn textField(self: *Self, id: []const u8) ?*text_field_mod.TextInputState {
-        const hash: u64 = @as(u64, LayoutId.fromString(id).id);
-        return self._window.element_states.get(text_field_mod.TextInputState, hash);
+        return self._window.widgetState(text_field_mod.TextInputState, id);
     }
     pub fn textAreaWidget(self: *Self, id: []const u8) ?*text_area_mod.TextAreaState {
-        const hash: u64 = @as(u64, LayoutId.fromString(id).id);
-        return self._window.element_states.get(text_area_mod.TextAreaState, hash);
+        return self._window.widgetState(text_area_mod.TextAreaState, id);
     }
     pub fn codeEditorWidget(self: *Self, id: []const u8) ?*code_editor_mod.CodeEditorState {
-        const hash: u64 = @as(u64, LayoutId.fromString(id).id);
-        return self._window.element_states.get(code_editor_mod.CodeEditorState, hash);
+        return self._window.widgetState(code_editor_mod.CodeEditorState, id);
     }
     pub fn scrollView(self: *Self, id: []const u8) ?*scroll_view_mod.ScrollContainer {
         // PR 8.4 — storage moved off `WidgetStore.scroll_containers`

--- a/src/examples/code_editor.zig
+++ b/src/examples/code_editor.zig
@@ -311,13 +311,12 @@ const AppState = struct {
         }
     }
 
-    /// Reach the `"source"` `CodeEditorState` through
-    /// `Window.element_states`. PR 8.4b — retired the
+    /// Reach the `"source"` `CodeEditorState` through the string-keyed
+    /// `Window.widgetState` accessor. PR 8.4b — retired the
     /// `g.widgets.codeEditor(id)` accessor (see
     /// `docs/cleanup-implementation-plan.md` PR 8.4b).
     fn sourceCodeEditor(g: *gooey.Window) ?*gooey.widgets.CodeEditorState {
-        const hash: u64 = @as(u64, gooey.layout.LayoutId.fromString("source").id);
-        return g.element_states.get(gooey.widgets.CodeEditorState, hash);
+        return g.widgetState(gooey.widgets.CodeEditorState, "source");
     }
 
     // =========================================================================

--- a/src/examples/pomodoro.zig
+++ b/src/examples/pomodoro.zig
@@ -244,10 +244,8 @@ const AppState = struct {
 
         // PR 8.4b — `g.widgets.textInput` retired alongside the
         // StringHashMap-keyed `text_inputs` map; reach the engine
-        // state through `Window.element_states` keyed by
-        // `LayoutId.id`.
-        const input_hash: u64 = @as(u64, gooey.layout.LayoutId.fromString("task-input").id);
-        if (g.element_states.get(gooey.widgets.TextInputState, input_hash)) |input| {
+        // state through the string-keyed `Window.widgetState` accessor.
+        if (g.widgetState(gooey.widgets.TextInputState, "task-input")) |input| {
             input.clear();
         }
         self.input_text = "";

--- a/src/examples/todo.zig
+++ b/src/examples/todo.zig
@@ -144,13 +144,12 @@ const AppState = struct {
 
     /// Add the current draft, then clear the input. The binding only flows
     /// widget -> state, so zeroing `self.draft` is not enough; we reach the
-    /// retained `TextInputState` by its layout-id hash and clear its buffer.
+    /// retained `TextInputState` by its string id and clear its buffer.
     pub fn addTodo(self: *AppState, g: *gooey.Window) void {
         self.pushTodo(self.draft);
         self.draft = "";
 
-        const id_hash: u64 = gooey.layout.LayoutId.fromString(draft_input_id).id;
-        if (g.element_states.get(gooey.widgets.TextInputState, id_hash)) |input| {
+        if (g.widgetState(gooey.widgets.TextInputState, draft_input_id)) |input| {
             input.clear();
         }
     }


### PR DESCRIPTION
## Motivation

The README todo example (and the `todo`, `pomodoro`, `code_editor` examples) hand-rolled the layout-id hash to reach a widget's retained state:

```zig
const id_hash: u64 = gooey.layout.LayoutId.fromString(draft_input_id).id;
if (g.element_states.get(gooey.widgets.TextInputState, id_hash)) |input| input.clear();
```

The friendly `cx.textField(id)` accessor already does this, but it lives on `Cx`. These call sites are `cx.command(...)` handlers, whose shape is `fn(*State, *Window)` — so they only get a `*Window`, which deliberately keeps concrete widget-state types out of its surface (`window.zig` module note) and only exposed the raw `element_states.get(S, hash)` pool. Hence the manual hashing.

## Change

- **`src/context/window.zig`** — new generic `Window.widgetState(comptime S, id)`. Generic over `S` so no concrete widget-state type leaks into `Window`; the caller names the type at the call site. Folds in the `LayoutId.fromString(id).id` hashing. Asserts `id.len > 0` and that the id never collides with the reserved `LayoutId.none` (id 0) sentinel.
- **`src/cx.zig`** — re-point `cx.textField` / `textAreaWidget` / `codeEditorWidget` at `window.widgetState(...)` so the hashing lives in exactly one place (removes the duplicated `LayoutId.fromString` in three accessors).
- **`readme.md`**, **`src/examples/todo.zig`**, **`pomodoro.zig`**, **`code_editor.zig`** — collapse the hand-rolled pattern to `g.widgetState(SomeState, id)`.

## Validation

- `zig build` → exit 0 (all native examples compile, including `pomodoro` and `code_editor`).
- `zig build test` → `todo.zig` + core module/`cx`/`window` changes compile and pass. The two pre-existing `failed command` suites (`charts` and a context stress test) were confirmed failing on the clean tree before this change and are unrelated.

## Note / follow-up

Command handlers still receive `*Window`, not `*Cx`, so they use `g.widgetState(SomeState, id)` (type named explicitly) rather than the typed `cx.textField(id)` sugar. Giving command handlers a `*Cx` would be a larger dispatch-layer change — happy to explore separately if desired.