### PR TITLE
Fix recursive os_unfair_lock crash during live window resize

### DIFF
--- a/src/platform/macos/window.zig
+++ b/src/platform/macos/window.zig
@@ -637,9 +637,17 @@ pub const Window = struct {
             return;
         }
 
-        // Acquire render mutex to safely modify size/scale while DisplayLink might be reading
+        // Acquire render mutex to safely modify size/scale while DisplayLink might be reading.
         self.render_mutex.lock();
         defer self.render_mutex.unlock();
+
+        // Mark rendering as in progress while the lock is held. The synchronous
+        // render below invokes the user's on_render callback, which calls back
+        // into setScene/setTextAtlas/etc. Those setters re-lock render_mutex
+        // unless this flag tells them the lock is already held. Without it the
+        // re-entrant lock attempt aborts an os_unfair_lock (recursive lock).
+        self.render_in_progress.store(true, .release);
+        defer self.render_in_progress.store(false, .release);
 
         self.size.width = new_width;
         self.size.height = new_height;


### PR DESCRIPTION
## Problem

Drag-resizing the window aborts the process with:

```
BUG IN CLIENT OF LIBPLATFORM: Trying to recursively lock an os_unfair_lock
```

The crash is a re-entrant lock on `Window.render_mutex`:

1. A live-resize drag → `windowDidResize` → `Window.handleResize` acquires `render_mutex`.
2. Inside the held lock, the synchronous live-resize path invokes the user's `on_render` callback → `renderFrameImpl` → `Window.setScene`.
3. `setScene` (and the other setters) only skip re-locking when `render_in_progress` is `true`. `handleResize` held the lock but never set that flag, so `setScene` tried to lock `render_mutex` a second time on the same thread → `os_unfair_lock` aborts on recursion.

`displayLinkCallback` already sets `render_in_progress` around its locked region, which is why the normal render path never hit this — only the resize path was missing it.

## Fix

In `handleResize`, set `render_in_progress` (with a paired `defer` to clear it) immediately after acquiring `render_mutex`, mirroring `displayLinkCallback`. The re-entrant setters then see the lock is already held and skip re-acquiring it.

## Testing

- `zig build` passes.
- Manual verification: `zig build run` and drag-resize the window — confirm the recursive-lock abort no longer occurs.

## Follow-up (not in this PR)

The re-entrancy guard is a manual flag each locking site must remember to set; this bug was caused by `handleResize` forgetting it. A small `defer`-based RAII guard that pairs lock acquisition with setting `render_in_progress` would make the omission impossible. Happy to add it as a follow-up.