### PR TITLE
Fix double free when closing windows in multi-window app

### DIFF
--- a/src/runtime/multi_window_app.zig
+++ b/src/runtime/multi_window_app.zig
@@ -345,9 +345,11 @@ pub const App = struct {
         if (self.registry.unregister(id)) |window_ptr| {
             const window: *PlatformWindow = @ptrCast(@alignCast(window_ptr));
 
-            // Clean up window
+            // Clean up window. `PlatformWindow.deinit()` self-destroys (it ends
+            // with `allocator.destroy(self)`), which is the contract every
+            // single-window example relies on via `defer window.deinit()`.
+            // Do NOT also destroy here -- that is a double free.
             window.deinit();
-            self.allocator.destroy(window);
         }
 
         // Check if we should quit
@@ -376,12 +378,13 @@ pub const App = struct {
             }
         }
 
-        // Close each window
+        // Close each window. `PlatformWindow.deinit()` self-destroys (it ends
+        // with `allocator.destroy(self)`); destroying again here is a double
+        // free. See `closeWindowById` for the same ownership contract.
         for (ids[0..count]) |id| {
             if (self.registry.unregister(id)) |window_ptr| {
                 const window: *PlatformWindow = @ptrCast(@alignCast(window_ptr));
                 window.deinit();
-                self.allocator.destroy(window);
             }
         }
     }


### PR DESCRIPTION
## What

`PlatformWindow.deinit()` self-destroys — it ends with `allocator.destroy(self)`. Both `closeWindowById` and `closeAllWindows` in `multi_window_app.zig` called `window.deinit()` **and then** `self.allocator.destroy(window)` again, freeing the same allocation twice.

This removes the redundant `destroy` calls and documents the ownership contract (the same one every single-window example relies on via `defer window.deinit()`).

## Why

Double free — undefined behavior on window close in the multi-window path. With the leak-checking allocator this is a crash/abort; in release it's heap corruption.

## Scope

- `src/runtime/multi_window_app.zig` only.
- No behavior change beyond removing the second free; the window is still torn down exactly once by `deinit()`.

## Validation

`zig build` passes.
