### PR TITLE
Expose MeasureTextOptions on the public text surface

### DIFF
--- a/src/api_check.zig
+++ b/src/api_check.zig
@@ -231,6 +231,10 @@ fn pinTier1NamespacedText() void {
     comptime {
         _ = gooey.text.TextSystem;
         _ = gooey.text.FontFace;
+        // `measureText`'s value types: a downstream that stores a
+        // measurement+options pair reaches for both under `gooey.text`.
+        _ = gooey.text.TextMeasurement;
+        _ = gooey.text.MeasureTextOptions;
     }
 }
 

--- a/src/cx.zig
+++ b/src/cx.zig
@@ -502,11 +502,12 @@ pub const Cx = struct {
     // =========================================================================
 
     /// Options for `measureText`. `null` fields fall back to "no
-    /// wrapping" / "current font size" respectively.
-    pub const MeasureTextOptions = struct {
-        max_width: ?f32 = null,
-        font_size: ?f32 = null,
-    };
+    /// wrapping" / "current font size" respectively. Aliased from
+    /// `gooey.text.MeasureTextOptions` so the value type a downstream
+    /// needs to *store* a measurement+options pair lives on the public
+    /// text surface alongside `TextMeasurement`, while
+    /// `Cx.MeasureTextOptions` keeps working unchanged.
+    pub const MeasureTextOptions = text_mod.MeasureTextOptions;
 
     /// Measure a text string with optional wrapping and font size.
     /// Uses the platform text shaper (CoreText / HarfBuzz / browser)

--- a/src/text/mod.zig
+++ b/src/text/mod.zig
@@ -39,6 +39,7 @@ pub const GlyphMetrics = types.GlyphMetrics;
 pub const ShapedGlyph = types.ShapedGlyph;
 pub const ShapedRun = types.ShapedRun;
 pub const TextMeasurement = types.TextMeasurement;
+pub const MeasureTextOptions = types.MeasureTextOptions;
 pub const SystemFont = types.SystemFont;
 pub const TextDecoration = types.TextDecoration;
 pub const RasterizedGlyph = types.RasterizedGlyph;

--- a/src/text/types.zig
+++ b/src/text/types.zig
@@ -204,3 +204,17 @@ pub const TextMeasurement = struct {
     /// Number of lines (for wrapped text)
     line_count: u32 = 1,
 };
+
+/// Options for the platform text shaper's measurement pass.
+/// A `null` field selects the shaper's natural default rather than a
+/// magic numeric sentinel, so callers do not have to encode "unset"
+/// as a zero (which would otherwise be ambiguous with a real width of
+/// zero or a degenerate font size):
+/// - `max_width == null` means measure on a single line with no
+///   wrapping, so the returned width is the full unwrapped advance.
+/// - `font_size == null` means measure at the currently loaded font's
+///   size, so the caller does not have to restate it.
+pub const MeasureTextOptions = struct {
+    max_width: ?f32 = null,
+    font_size: ?f32 = null,
+};


### PR DESCRIPTION
## What

`Cx.measureText` returns a `TextMeasurement` (already re-exported from `gooey.text`) but its options type was only available as `Cx.MeasureTextOptions`. A downstream that wants to store a measurement + the options used to produce it had no value type to reach for alongside `gooey.text.TextMeasurement`.

This moves the canonical definition to `text/types.zig`, re-exports it as `gooey.text.MeasureTextOptions`, and aliases `Cx.MeasureTextOptions` to it.

## Why

Keeps the public text value types together on one surface (`gooey.text`), so a consumer storing a measurement+options pair can name both. The `null`-means-default semantics (`max_width == null` → no wrapping, `font_size == null` → current font size) are documented on the moved definition so callers don't encode "unset" as a magic zero.

## Backwards compatibility

Fully compatible — `Cx.MeasureTextOptions` is now an alias to the same struct, so existing call sites and field initializers are unchanged. Both `gooey.text.TextMeasurement` and `gooey.text.MeasureTextOptions` are pinned in `api_check.zig`.

## Files

- `src/text/types.zig` — canonical `MeasureTextOptions` definition
- `src/text/mod.zig` — re-export
- `src/cx.zig` — alias `Cx.MeasureTextOptions` → `text.MeasureTextOptions`
- `src/api_check.zig` — pin both symbols

## Validation

`zig build` passes.
