### PR TITLE
Add Cmd+Q quit handler to showcase and fix readme quit docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1553,7 +1553,7 @@ const QuitApp = struct {};
 const AppState = struct {
     initialized: bool = false,
 
-    fn quitApp(_: *AppState, g: *gooey.Gooey) void {
+    fn quitApp(_: *AppState, g: *gooey.Window) void {
         g.quit();
     }
 };
@@ -1563,7 +1563,7 @@ fn setupKeymap(cx: *Cx) void {
     if (s.initialized) return;
     s.initialized = true;
 
-    cx.gooey().keymap.bind(QuitApp, "cmd-q", null);
+    cx.window().keymap().bind(QuitApp, "cmd-q", null);
 }
 
 fn render(cx: *Cx) void {
@@ -1584,6 +1584,8 @@ fn render(cx: *Cx) void {
     }));
 }
 ```
+
+For a working reference, see the `Cmd+Q` handler in `src/examples/showcase.zig`, which quits directly from the window's `onEvent` callback via `cx.quit()`.
 
 ## More Examples
 

--- a/src/examples/showcase.zig
+++ b/src/examples/showcase.zig
@@ -8,6 +8,7 @@
 //!   - [←/→] Previous/Next section
 //!   - [T] Toggle theme
 //!   - [Esc] Close modals/dropdowns
+//!   - [Cmd+Q] Quit the app
 
 const std = @import("std");
 
@@ -1729,6 +1730,13 @@ fn onEvent(cx: *Cx, event: gooey.input.InputEvent) bool {
 
     if (event == .key_down) {
         const key = event.key_down;
+
+        // Cmd+Q quits the app (no-op on web). Checked before unmodified
+        // keys so the cmd modifier isn't swallowed by a bare-key branch.
+        if (key.key == .q and key.modifiers.cmd) {
+            cx.quit();
+            return true;
+        }
 
         // Escape closes modals/dropdowns
         if (key.key == .escape) {


### PR DESCRIPTION
## Summary

Adds a working `Cmd+Q` quit shortcut to the showcase example and corrects the readme's "Quitting the App" documentation to match the current API.

## Changes

**`src/examples/showcase.zig`**
- Handle `Cmd+Q` in the `onEvent` callback via `cx.quit()` (portable: quits on macOS/Linux, no-op on web).
- The check runs before the bare-key branches so the `cmd` modifier isn't swallowed by an unmodified-key handler.
- Documented the shortcut in the header navigation list.

**`readme.md`**
- Fixed the "Quitting the App" snippet, which predated the `Gooey` → `Window` rename (PR 7b.1b) and no longer compiled:
  - `fn quitApp(_: *AppState, g: *gooey.Gooey)` → `*gooey.Window`
  - `cx.gooey().keymap.bind(...)` → `cx.window().keymap().bind(...)`
- Added a pointer to the working `Cmd+Q` reference in `showcase.zig`.

## Validation

- Diagnostics clean on `showcase.zig`.
- Showcase builds and the shortcut was confirmed working at runtime.

The readme snippet itself is a doc fragment (not a build target), so it isn't compile-checked by CI; the names were verified against `root.zig` (`pub const Window`), `cx.zig` (`window()`, `command()`), and `context/window.zig` (`keymap()`).