### PR TITLE
Fix P0 API-review items: release-safe invariant guards + README API drift

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ Example app built with Gooey — [**chat-zig**](https://github.com/duanebester/c
 - **Declarative UI** - Component-based layout with `ui.*` primitives and flexbox-style system
 - **Cx/UI Separation** - `Cx` for state, handlers, and focus; `ui.*` for layout primitives
 - **Pure State Pattern** - Testable state methods with automatic re-rendering
-- **Animation System** - Built-in animations with easing, `animateOn` triggers
+- **Animation System** - Built-in animations with easing, `tweenOn` triggers
 - **Entity System** - Dynamic entity creation/deletion with auto-cleanup
 - **Retained Widgets** - TextInput, TextArea, Checkbox, Scroll containers
 - **Text Rendering** - CoreText (macOS), FreeType/HarfBuzz (Linux), Canvas (WASM)
@@ -320,10 +320,10 @@ test "remaining and clearCompleted" {
 
 Gooey separates concerns between `Cx` (context) and `ui` (layout primitives):
 
-| Module | Purpose                            | Examples                                                                        |
-| ------ | ---------------------------------- | ------------------------------------------------------------------------------- |
-| `cx.*` | State, handlers, animations, focus | `cx.state()`, `cx.update()`, `cx.animate()`, `cx.changed()`, `cx.render()`      |
-| `ui.*` | Layout containers and primitives   | `ui.box()`, `ui.rect()`, `ui.hstack()`, `ui.vstack()`, `ui.text()`, `ui.when()` |
+| Module | Purpose                            | Examples                                                                            |
+| ------ | ---------------------------------- | ----------------------------------------------------------------------------------- |
+| `cx.*` | State, handlers, animations, focus | `cx.state()`, `cx.update()`, `cx.animations.tween()`, `cx.changed()`, `cx.render()` |
+| `ui.*` | Layout containers and primitives   | `ui.box()`, `ui.rect()`, `ui.hstack()`, `ui.vstack()`, `ui.text()`, `ui.when()`     |
 
 ```/dev/null/example.zig#L1-19
 fn render(cx: *Cx) void {
@@ -361,14 +361,14 @@ fn render(cx: *Cx) void {
 
 ## Handler Types
 
-| Method             | Signature                      | Use Case                                 |
-| ------------------ | ------------------------------ | ---------------------------------------- |
-| `cx.update()`      | `fn(*State) void`              | Pure state mutations                     |
-| `cx.updateWith()`  | `fn(*State, Arg) void`         | Mutations with argument                  |
-| `cx.command()`     | `fn(*State, *Gooey) void`      | Framework access (focus, quit, entities) |
-| `cx.commandWith()` | `fn(*State, *Gooey, Arg) void` | Framework access with argument           |
-| `cx.defer()`       | `fn(*State, *Gooey) void`      | Run after current event completes        |
-| `cx.deferWith()`   | `fn(*State, *Gooey, Arg) void` | Deferred with argument                   |
+| Method             | Signature                       | Use Case                                 |
+| ------------------ | ------------------------------- | ---------------------------------------- |
+| `cx.update()`      | `fn(*State) void`               | Pure state mutations                     |
+| `cx.updateWith()`  | `fn(*State, Arg) void`          | Mutations with argument                  |
+| `cx.command()`     | `fn(*State, *Window) void`      | Framework access (focus, quit, entities) |
+| `cx.commandWith()` | `fn(*State, *Window, Arg) void` | Framework access with argument           |
+| `cx.defer()`       | `fn(*State, *Window) void`      | Run after current event completes        |
+| `cx.deferWith()`   | `fn(*State, *Window, Arg) void` | Deferred with argument                   |
 
 > **Note:** The state type is inferred automatically from the method pointer's first parameter — no need to pass it separately.
 
@@ -432,12 +432,12 @@ Use `defer` when you need to run code **after** the current event handler comple
 
 ```zig
 // In a command handler, use g.deferCommand():
-pub fn openFolder(self: *State, g: *Gooey) void {
+pub fn openFolder(self: *State, g: *Window) void {
     _ = self;
-    g.deferCommand(State, State.openFolderDeferred);
+    g.deferCommand(State.openFolderDeferred);
 }
 
-fn openFolderDeferred(self: *State, g: *Gooey) void {
+fn openFolderDeferred(self: *State, g: *Window) void {
     _ = g;
     // Safe to open modal dialog here - we're outside event handling
     const file_dialog = gooey.file_dialog;
@@ -449,12 +449,12 @@ fn openFolderDeferred(self: *State, g: *Gooey) void {
 }
 
 // With an argument (same 8-byte limit applies):
-pub fn deleteItem(self: *State, g: *Gooey, index: u32) void {
+pub fn deleteItem(self: *State, g: *Window, index: u32) void {
     _ = self;
-    g.deferCommandWith(State, u32, index, State.confirmDelete);
+    g.deferCommandWith(index, State.confirmDelete);
 }
 
-fn confirmDelete(self: *State, g: *Gooey, index: u32) void {
+fn confirmDelete(self: *State, g: *Window, index: u32) void {
     _ = g;
     if (dialog.confirm("Delete item?")) {
         self.items.remove(index);
@@ -1293,17 +1293,17 @@ Built-in animation support with easing functions:
 
 ```zig
 // Simple animation (runs once on mount)
-const fade = cx.animate("fade-in", .{ .duration_ms = 500 });
+const fade = cx.animations.tween("fade-in", .{ .duration_ms = 500 });
 // fade.progress goes 0.0 -> 1.0
 
 // Animation that restarts when a value changes
-const pulse = cx.animateOn("counter-pulse", s.count, .{
+const pulse = cx.animations.tweenOn("counter-pulse", s.count, .{
     .duration_ms = 200,
     .easing = Easing.easeOutBack,
 });
 
 // Continuous animation
-const spin = cx.animate("spinner", .{
+const spin = cx.animations.tween("spinner", .{
     .duration_ms = 1000,
     .mode = .ping_pong,  // or .loop
 });
@@ -1311,7 +1311,7 @@ const spin = cx.animate("spinner", .{
 // Use animation values
 cx.render(ui.box(.{
     .background = Color.white.withAlpha(fade.progress),
-    .width = gooey.lerp(100.0, 150.0, pulse.progress),
+    .width = gooey.animation.lerp(100.0, 150.0, pulse.progress),
 }, .{...}));
 ```
 
@@ -1402,22 +1402,22 @@ const Counter = struct {
 };
 
 const AppState = struct {
-    counters: [10]gooey.Entity(Counter) = ...,
+    counters: [10]gooey.context.Entity(Counter) = ...,
 
     // Command method - needs Gooey access for entity operations
-    pub fn addCounter(self: *AppState, g: *gooey.Gooey) void {
+    pub fn addCounter(self: *AppState, g: *gooey.Window) void {
         const entity = g.createEntity(Counter, .{ .count = 0 }) catch return;
         self.counters[self.counter_count] = entity;
         self.counter_count += 1;
     }
 };
 
-// In render - use entityCx for entity-scoped handlers
-var entity_cx = cx.entityCx(Counter, counter_entity) orelse return;
+// In render - use cx.entities.context for entity-scoped handlers
+var entity_cx = cx.entities.context(Counter, counter_entity) orelse return;
 Button{ .label = "+", .on_click_handler = entity_cx.update(Counter.increment) }
 
 // Read entity data
-if (cx.gooey().readEntity(Counter, entity)) |data| {
+if (cx.window().readEntity(Counter, entity)) |data| {
     ui.textFmt("{d}", .{data.count}, .{});
 }
 ```
@@ -1511,7 +1511,7 @@ try gooey.runCx(AppState, &state, render, .{
 });
 
 // Change glass style at runtime
-pub fn cycleStyle(self: *AppState, g: *gooey.Gooey) void {
+pub fn cycleStyle(self: *AppState, g: *gooey.Window) void {
     g.window.setGlassStyle(.glass_clear, 0.7, 10.0);
 }
 ```
@@ -1525,9 +1525,9 @@ const Undo = struct {};
 const Save = struct {};
 
 fn setupKeymap(cx: *Cx) void {
-    const g = cx.gooey();
-    g.keymap.bind(Undo, "cmd-z", null);        // Global
-    g.keymap.bind(Save, "cmd-s", "Editor");    // Context-specific
+    const g = cx.window();
+    g.keymap().bind(Undo, "cmd-z", null);        // Global
+    g.keymap().bind(Save, "cmd-s", "Editor");    // Context-specific
 }
 
 fn render(cx: *Cx) void {
@@ -1593,7 +1593,7 @@ For a working reference, see the `Cmd+Q` handler in `src/examples/showcase.zig`,
 | ---------------- | -------------------------------- | ------------------------------------- |
 | Showcase         | `zig build run`                  | Full feature demo with navigation     |
 | Counter          | `zig build run-counter`          | Simple state management               |
-| Animation        | `zig build run-animation`        | Animation system with animateOn       |
+| Animation        | `zig build run-animation`        | Animation system with tweenOn         |
 | Pomodoro         | `zig build run-pomodoro`         | Timer with tasks and custom shader    |
 | Dynamic Counters | `zig build run-dynamic-counters` | Entity creation and deletion          |
 | Layout           | `zig build run-layout`           | Flexbox, shrink, text wrapping        |

--- a/src/context/change_tracker.zig
+++ b/src/context/change_tracker.zig
@@ -69,8 +69,19 @@ pub const ChangeTracker = struct {
             }
         }
 
-        // New key — store and return false (no previous value to compare)
-        std.debug.assert(self.count < MAX_TRACKED_VALUES); // Would exceed capacity — too many tracked values
+        // New key — store and return false (no previous value to compare).
+        //
+        // Capacity guard is an UNCONDITIONAL runtime check, not std.debug.assert:
+        // the assert strips in ReleaseFast/ReleaseSmall (the builds users ship),
+        // and the very next line writes at index self.count into fixed [64] arrays.
+        // A stripped check would turn the 65th distinct key into an out-of-bounds
+        // write — memory corruption rather than a clean failure (rules 4, 11, 17).
+        // Fail fast: exceeding the hard cap means the caller is minting unbounded
+        // distinct cx.changed() ids, which is a programming error, not a runtime
+        // condition to degrade past. Matches entity.zig's release-safe @panic guard.
+        if (self.count >= MAX_TRACKED_VALUES) {
+            @panic("ChangeTracker capacity exceeded: too many distinct cx.changed() keys (max 64)");
+        }
         self.keys[self.count] = key_hash;
         self.value_hashes[self.count] = value_hash;
         self.count += 1;

--- a/src/context/entity.zig
+++ b/src/context/entity.zig
@@ -607,7 +607,15 @@ pub fn EntityContext(comptime T: type) type {
         ) HandlerRef {
             const Arg = @TypeOf(arg);
             comptime {
-                std.debug.assert(@sizeOf(Arg) <= 4); // Arg must fit in upper 32 bits.
+                // Structural limit: the packed u64 stores entity_id in the lower
+                // 32 bits and the arg in the upper 32, so the arg must fit in 4
+                // bytes here — half of root cx.updateWith's 8-byte budget, which
+                // has the whole u64 for the arg. Use @compileError (not a comptime
+                // std.debug.assert, whose failure is a cryptic "reached unreachable
+                // code") to match the clear message root updateWith gives.
+                if (@sizeOf(Arg) > 4) {
+                    @compileError("entity updateWith: argument type '" ++ @typeName(Arg) ++ "' exceeds 4 bytes (entity_id takes the other 4). Use a pointer or index instead.");
+                }
             }
             // Data integrity: truncation to u32 must be lossless. Runtime check
             // because std.debug.assert is stripped in ReleaseFast and silent

--- a/src/cx.zig
+++ b/src/cx.zig
@@ -160,9 +160,16 @@ pub const Cx = struct {
     // =========================================================================
 
     /// Mutable access to the application state. The type must match
-    /// the one passed to `runCx`; the assertion enforces that.
+    /// the one passed to `runCx`; the check below enforces that.
     pub fn state(self: *Self, comptime T: type) *T {
-        std.debug.assert(self.state_type_id == typeId(T));
+        // Unconditional runtime guard, NOT std.debug.assert: the assert strips in
+        // ReleaseFast/ReleaseSmall, and the @ptrCast below would then reinterpret
+        // the state pointer as an unrelated type — silent type-confusion / memory
+        // corruption in the builds users ship (rules 2, 17). This costs one integer
+        // compare per call (~once per handler), so keeping it in release is free.
+        if (self.state_type_id != typeId(T)) {
+            @panic("cx.state(T): T does not match the app state type passed to run()/App()");
+        }
         return @ptrCast(@alignCast(self.state_ptr));
     }
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -23,7 +23,8 @@
 //!
 //! pub const std_options = gooey.std_options;
 //!
-//! var state = struct { count: i32 = 0 }{};
+//! const AppState = struct { count: i32 = 0 };
+//! var state: AppState = .{};
 //!
 //! pub fn main(init: std.process.Init) !void {
 //!     try gooey.run(AppState, &state, render, .{


### PR DESCRIPTION
Knocks out both **P0** items from the API design review.

## P0-A — Debug-only asserts that became release-mode UB

`std.debug.assert` strips in `ReleaseFast`/`ReleaseSmall` (the builds users ship), so two control-plane guards degraded into undefined behavior:

- **`ChangeTracker.changed`** — the capacity assert sat immediately before a write into the fixed `[64]` arrays, so the 65th distinct key was an out-of-bounds write in release. Promoted to an unconditional `@panic`.
- **`Cx.state(T)`** — the type-id assert guarded a raw `@ptrCast`, so a mismatched `T` silently reinterpreted the state pointer in release. Promoted to an unconditional `@panic`.

Each runs ~once per handler/frame, so retaining the check in release is free.

The review also flagged **`entity.updateWith`**'s arg-size check as release UB. On inspection it already runs at **comptime** (inside a `comptime {}` block), so it was never strippable. Kept the behavior but replaced the comptime `std.debug.assert` (cryptic `reached unreachable code`) with a descriptive `@compileError` matching root `updateWith`. The 4-byte limit is structural (the arg shares the `u64` with `entity_id`) and is now documented as such.

## P0-B — README/quick-start taught an API surface that no longer exists

- `cx.animate` / `cx.animateOn` → `cx.animations.tween` / `tweenOn`
- `gooey.lerp` → `gooey.animation.lerp`
- `*Gooey` / `gooey.Gooey` → `*Window` (there is no `Gooey` type)
- `gooey.Entity(T)` → `gooey.context.Entity(T)`
- `cx.entityCx` → `cx.entities.context`
- `cx.gooey()` → `cx.window()`; `keymap` field access → `keymap()` method
- `deferCommand` / `deferCommandWith` call-site arg counts corrected
- `root.zig` quick-start referenced an undeclared `AppState` (state was an anonymous struct); now declared so the first public code sample compiles.

## Validation

- `zig build` (all examples) succeeds — confirms the tightened entity `@compileError` breaks no caller.
- Test binaries pass standalone: **All 1022 tests passed** and **All 94 tests passed**.
- `grep` for every stale README token returns no matches.

## Notes

- The review backlog doc (`docs/api-design-review.md`) is intentionally **not** included.
- `zig build test` prints `failed command: …test --listen=-` for two artifacts (incl. the untouched charts binary); both pass when run directly — a pre-existing `--listen` runner quirk, not a regression here.