### PR TITLE
P1: Unify selection-state field naming across components

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -269,7 +269,7 @@ const TodoRow = struct {
             .background = ui.Color.white,
             .corner_radius = 8,
         }, .{
-            Checkbox{ .checked = self.done, .on_click_handler = cx.updateWith(self.index, AppState.toggle) },
+            Checkbox{ .selected = self.done, .on_click_handler = cx.updateWith(self.index, AppState.toggle) },
             ui.text(self.label, .{ .size = 16 }),
             ui.spacer(),
             Button{ .label = "Delete", .variant = .danger, .size = .small, .on_click_handler = cx.updateWith(self.index, AppState.remove) },
@@ -708,7 +708,7 @@ TextArea{
 ```zig
 Checkbox{
     .id = "terms",
-    .checked = s.agreed_to_terms,
+    .selected = s.agreed_to_terms,
     .on_click_handler = cx.update(State.toggleTerms),
 }
 ```
@@ -719,7 +719,7 @@ Checkbox{
 // RadioButton - individual buttons for custom layouts
 RadioButton{
     .label = "Email",
-    .is_selected = s.contact_method == 0,
+    .selected = s.contact_method == 0,
     .on_click_handler = cx.updateWith(@as(u8, 0), State.setContactMethod),
 }
 
@@ -885,12 +885,12 @@ ProgressBar{
 cx.render(ui.hstack(.{ .gap = 4 }, .{
     Tab{
         .label = "Home",
-        .is_active = s.tab == 0,
+        .selected = s.tab == 0,
         .on_click_handler = cx.updateWith(@as(u8, 0), State.setTab),
     },
     Tab{
         .label = "Settings",
-        .is_active = s.tab == 1,
+        .selected = s.tab == 1,
         .on_click_handler = cx.updateWith(@as(u8, 1), State.setTab),
         .style = .underline,  // .pills (default), .underline, .segmented
     },

--- a/src/components/checkbox.zig
+++ b/src/components/checkbox.zig
@@ -19,7 +19,7 @@ pub const Checkbox = struct {
     // box gets a stable parent-scoped auto id (PR 11b.2a). Pass an explicit
     // id only when you need to address this checkbox from outside its render.
     id: ?[]const u8 = null,
-    checked: bool,
+    selected: bool,
     label: ?[]const u8 = null,
 
     // For simple toggle callback (no bool arg, just toggles)
@@ -64,7 +64,9 @@ pub const Checkbox = struct {
             .name = self.accessible_name orelse self.label orelse self.id,
             .description = self.accessible_description,
             .state = .{
-                .checked = self.checked,
+                // The accessibility protocol names this boolean `checked`;
+                // we feed it from our unified `selected` field.
+                .checked = self.selected,
             },
         });
         defer if (a11y_pushed) cx.accessibleEnd();
@@ -78,7 +80,7 @@ pub const Checkbox = struct {
             .on_click_handler = self.on_click_handler,
         }, .{
             CheckboxBox{
-                .checked = self.checked,
+                .selected = self.selected,
                 .size = self.size,
                 .checked_background = checked_bg,
                 .unchecked_background = unchecked_bg,
@@ -96,7 +98,7 @@ pub const Checkbox = struct {
 };
 
 const CheckboxBox = struct {
-    checked: bool,
+    selected: bool,
     size: f32,
     checked_background: Color,
     unchecked_background: Color,
@@ -108,13 +110,13 @@ const CheckboxBox = struct {
         cx.box(.{
             .width = self.size,
             .height = self.size,
-            .background = if (self.checked) self.checked_background else self.unchecked_background,
+            .background = if (self.selected) self.checked_background else self.unchecked_background,
             .border_color = self.border_color,
             .border_width = .{ .all = 1 },
             .corner_radius = self.corner_radius,
             .alignment = .{ .main = .center, .cross = .center },
         }, .{
-            Checkmark{ .visible = self.checked, .color = self.checkmark_color, .size = self.size },
+            Checkmark{ .visible = self.selected, .color = self.checkmark_color, .size = self.size },
         });
     }
 };

--- a/src/components/radio_group.zig
+++ b/src/components/radio_group.zig
@@ -10,12 +10,12 @@
 //! cx.render(ui.box(.{ .direction = .column, .gap = 10 }, .{
 //!     RadioButton{
 //!         .label = "Email",
-//!         .is_selected = s.contact == 0,
+//!         .selected = s.contact == 0,
 //!         .on_click_handler = cx.updateWith(@as(u8, 0), State.setContact),
 //!     },
 //!     RadioButton{
 //!         .label = "Phone",
-//!         .is_selected = s.contact == 1,
+//!         .selected = s.contact == 1,
 //!         .on_click_handler = cx.updateWith(@as(u8, 1), State.setContact),
 //!     },
 //! }));
@@ -44,7 +44,7 @@ const HandlerRef = ui.HandlerRef;
 /// A single radio button. Can be used standalone or composed into groups.
 pub const RadioButton = struct {
     label: []const u8,
-    is_selected: bool,
+    selected: bool,
 
     // Click handler - use with cx.updateWith() for index-based selection
     on_click_handler: ?HandlerRef = null,
@@ -85,7 +85,9 @@ pub const RadioButton = struct {
             .role = .radio,
             .name = self.accessible_name orelse self.label,
             .state = .{
-                .checked = self.is_selected,
+                // The accessibility protocol names this boolean `checked`;
+                // we feed it from our unified `selected` field.
+                .checked = self.selected,
             },
             .pos_in_set = self.pos_in_set,
             .set_size = self.set_size,
@@ -99,7 +101,7 @@ pub const RadioButton = struct {
             .on_click_handler = self.on_click_handler,
         }, .{
             RadioCircle{
-                .is_selected = self.is_selected,
+                .selected = self.selected,
                 .size = self.size,
                 .selected_color = selected,
                 .unselected_color = unselected,
@@ -111,7 +113,7 @@ pub const RadioButton = struct {
 };
 
 const RadioCircle = struct {
-    is_selected: bool,
+    selected: bool,
     size: f32,
     selected_color: Color,
     unselected_color: Color,
@@ -122,13 +124,13 @@ const RadioCircle = struct {
             .width = self.size,
             .height = self.size,
             .background = self.unselected_color,
-            .border_color = if (self.is_selected) self.selected_color else self.border_color,
-            .border_width = .{ .all = if (self.is_selected) 2 else 1 },
+            .border_color = if (self.selected) self.selected_color else self.border_color,
+            .border_width = .{ .all = if (self.selected) 2 else 1 },
             .corner_radius = self.size / 2,
             .alignment = .{ .main = .center, .cross = .center },
         }, .{
             RadioDot{
-                .visible = self.is_selected,
+                .visible = self.selected,
                 .size = self.size * 0.5,
                 .color = self.selected_color,
             },
@@ -160,7 +162,9 @@ pub const RadioGroup = struct {
     // (PR 11b.2a). The old `"radio-group"` default collided across groups.
     id: ?[]const u8 = null,
     options: []const []const u8,
-    selected: usize,
+    // Optional so "no radio selected" is a uniform, first-class state
+    // (null) rather than a magic sentinel index.
+    selected: ?usize = null,
 
     /// Array of handlers, one per option. Use cx.updateWith() to create these.
     /// If null or shorter than options, missing handlers are treated as no-op.
@@ -227,7 +231,7 @@ pub const RadioGroup = struct {
 
 const RadioGroupItems = struct {
     options: []const []const u8,
-    selected: usize,
+    selected: ?usize,
     handlers: ?[]const HandlerRef,
     size: f32,
     selected_color: Color,
@@ -244,9 +248,13 @@ const RadioGroupItems = struct {
             else
                 null;
 
+            // Treat null as "no radio selected": only the item whose index
+            // matches the chosen index is selected.
+            const item_selected = if (self.selected) |sel| i == sel else false;
+
             cx.with(RadioButton{
                 .label = label,
-                .is_selected = i == self.selected,
+                .selected = item_selected,
                 .on_click_handler = handler,
                 .size = self.size,
                 .selected_color = self.selected_color,

--- a/src/components/select.zig
+++ b/src/components/select.zig
@@ -569,11 +569,13 @@ const SelectOptions = struct {
 
         for (self.options, 0..) |label, i| {
             const handler: ?HandlerRef = self.resolveOptionHandler(i);
-            const is_selected = if (self.selected) |sel| sel == i else false;
+            // `self.selected` is the chosen index (?usize); this derives the
+            // per-option boolean for the item at index `i`.
+            const option_selected = if (self.selected) |sel| sel == i else false;
 
             cx.with(SelectOption{
                 .label = label,
-                .is_selected = is_selected,
+                .selected = option_selected,
                 .on_click_handler = handler,
                 .selected_background = self.selected_background,
                 .hover_background = self.hover_background,
@@ -611,7 +613,7 @@ const SelectOptions = struct {
 /// A single option in the dropdown
 const SelectOption = struct {
     label: []const u8,
-    is_selected: bool,
+    selected: bool,
     on_click_handler: ?HandlerRef,
     selected_background: Color,
     hover_background: Color,
@@ -622,7 +624,7 @@ const SelectOption = struct {
     padding: f32,
 
     pub fn render(self: SelectOption, cx: *ui.Cx) void {
-        const bg = if (self.is_selected) self.selected_background else Color.transparent;
+        const bg = if (self.selected) self.selected_background else Color.transparent;
 
         cx.box(.{
             .fill_width = true,
@@ -637,7 +639,7 @@ const SelectOption = struct {
         }, .{
             // Checkmark for selected item
             SelectCheckmark{
-                .visible = self.is_selected,
+                .visible = self.selected,
                 .color = self.checkmark_color,
             },
             // Option text

--- a/src/components/tabs.zig
+++ b/src/components/tabs.zig
@@ -8,9 +8,9 @@
 //! Usage with Cx (recommended):
 //! ```zig
 //! cx.render(ui.box(.{ .direction = .row, .gap = 0 }, .{
-//!     Tab{ .label = "Home", .is_active = s.page == 0, .on_click_handler = cx.updateWith(@as(u8, 0), State.setPage) },
-//!     Tab{ .label = "Settings", .is_active = s.page == 1, .on_click_handler = cx.updateWith(@as(u8, 1), State.setPage) },
-//!     Tab{ .label = "About", .is_active = s.page == 2, .on_click_handler = cx.updateWith(@as(u8, 2), State.setPage) },
+//!     Tab{ .label = "Home", .selected = s.page == 0, .on_click_handler = cx.updateWith(@as(u8, 0), State.setPage) },
+//!     Tab{ .label = "Settings", .selected = s.page == 1, .on_click_handler = cx.updateWith(@as(u8, 1), State.setPage) },
+//!     Tab{ .label = "About", .selected = s.page == 2, .on_click_handler = cx.updateWith(@as(u8, 2), State.setPage) },
 //! }));
 //! ```
 //!
@@ -18,7 +18,7 @@
 //! ```zig
 //! TabBar{
 //!     .tabs = &.{ "Home", "Settings", "About" },
-//!     .active = s.current_tab,
+//!     .selected = s.current_tab,
 //!     .on_change = setTab,
 //! }
 //! ```
@@ -32,7 +32,7 @@ const HandlerRef = ui.HandlerRef;
 /// A single tab button. Can be used standalone or composed into a tab bar.
 pub const Tab = struct {
     label: []const u8,
-    is_active: bool,
+    selected: bool,
 
     // Click handler - use with cx.updateWith() for index-based navigation
     on_click_handler: ?HandlerRef = null,
@@ -88,17 +88,17 @@ pub const Tab = struct {
             .role = .tab,
             .name = self.accessible_name orelse self.label,
             .state = .{
-                .selected = self.is_active,
+                .selected = self.selected,
             },
             .pos_in_set = self.pos_in_set,
             .set_size = self.set_size,
         });
         defer if (a11y_pushed) cx.accessibleEnd();
 
-        const bg = if (self.is_active) active_bg else inactive_bg;
-        const text_color = if (self.is_active) active_text else inactive_text;
+        const bg = if (self.selected) active_bg else inactive_bg;
+        const text_color = if (self.selected) active_text else inactive_text;
 
-        const hover_bg: ?Color = if (!self.is_active)
+        const hover_bg: ?Color = if (!self.selected)
             self.hover_background orelse blendColors(inactive_bg, active_bg, 0.15)
         else
             null;
@@ -110,7 +110,7 @@ pub const Tab = struct {
         };
 
         const border_width: f32 = switch (self.style) {
-            .underline => if (self.is_active) 2 else 0,
+            .underline => if (self.selected) 2 else 0,
             else => 0,
         };
 
@@ -125,7 +125,7 @@ pub const Tab = struct {
             .hover_background = hover_bg,
             .corner_radius = style_radius,
             .border_width = .{ .all = border_width },
-            .border_color = if (self.style == .underline and self.is_active) active_bg else Color.transparent,
+            .border_color = if (self.style == .underline and self.selected) active_bg else Color.transparent,
             .alignment = .{ .main = .center, .cross = .center },
             .grow = self.grow,
             .on_click_handler = self.on_click_handler,
@@ -135,10 +135,10 @@ pub const Tab = struct {
     }
 
     /// Create a tab with common styling presets
-    pub fn styled(label: []const u8, is_active: bool, handler: ?HandlerRef, style: Style) Tab {
+    pub fn styled(label: []const u8, selected: bool, handler: ?HandlerRef, style: Style) Tab {
         return .{
             .label = label,
-            .is_active = is_active,
+            .selected = selected,
             .on_click_handler = handler,
             .style = style,
         };
@@ -152,7 +152,9 @@ pub const TabBar = struct {
     // (PR 11b.2a). The old `"tabs"` default collided across tab bars.
     id: ?[]const u8 = null,
     tabs: []const []const u8,
-    active: usize,
+    // Optional so "no tab active" is a uniform, first-class state (null)
+    // rather than a magic sentinel index.
+    selected: ?usize = null,
 
     // Simple callback (not for use with Cx.updateWith - use Tab directly for that)
     on_change: ?*const fn (usize) void = null,
@@ -228,7 +230,7 @@ pub const TabBar = struct {
         }, .{
             TabBarItems{
                 .tabs = self.tabs,
-                .active = self.active,
+                .selected = self.selected,
                 .on_change = self.on_change,
                 .style = self.style,
                 .active_background = active_bg,
@@ -249,7 +251,7 @@ pub const TabBar = struct {
 
 const TabBarItems = struct {
     tabs: []const []const u8,
-    active: usize,
+    selected: ?usize,
     on_change: ?*const fn (usize) void,
     style: Tab.Style,
     active_background: Color,
@@ -266,10 +268,14 @@ const TabBarItems = struct {
 
     pub fn render(self: TabBarItems, cx: *ui.Cx) void {
         for (self.tabs, 0..) |label, i| {
+            // Treat null as "no tab active": only the item whose index
+            // matches the chosen index is active.
+            const item_selected = if (self.selected) |sel| i == sel else false;
+
             cx.with(TabBarItem{
                 .label = label,
                 .index = i,
-                .is_active = i == self.active,
+                .selected = item_selected,
                 .on_change = self.on_change,
                 .style = self.style,
                 .active_background = self.active_background,
@@ -292,7 +298,7 @@ const TabBarItems = struct {
 const TabBarItem = struct {
     label: []const u8,
     index: usize,
-    is_active: bool,
+    selected: bool,
     on_change: ?*const fn (usize) void,
     style: Tab.Style,
     active_background: Color,
@@ -309,10 +315,10 @@ const TabBarItem = struct {
     set_size: u16,
 
     pub fn render(self: TabBarItem, cx: *ui.Cx) void {
-        const bg = if (self.is_active) self.active_background else self.inactive_background;
-        const text_color = if (self.is_active) self.active_text_color else self.inactive_text_color;
+        const bg = if (self.selected) self.active_background else self.inactive_background;
+        const text_color = if (self.selected) self.active_text_color else self.inactive_text_color;
 
-        const hover_bg: ?Color = if (!self.is_active)
+        const hover_bg: ?Color = if (!self.selected)
             self.hover_background orelse blendColors(self.inactive_background, self.active_background, 0.15)
         else
             null;
@@ -323,12 +329,12 @@ const TabBarItem = struct {
         };
 
         const border_width: f32 = switch (self.style) {
-            .underline => if (self.is_active) 2 else 0,
+            .underline => if (self.selected) 2 else 0,
             else => 0,
         };
 
         const border_color: Color = switch (self.style) {
-            .underline => if (self.is_active) self.active_background else Color.transparent,
+            .underline => if (self.selected) self.active_background else Color.transparent,
             else => Color.transparent,
         };
 
@@ -361,7 +367,7 @@ const TabBarItem = struct {
             .role = .tab,
             .name = self.label,
             .state = .{
-                .selected = self.is_active,
+                .selected = self.selected,
             },
             .pos_in_set = self.pos_in_set,
             .set_size = self.set_size,

--- a/src/examples/a11y_demo.zig
+++ b/src/examples/a11y_demo.zig
@@ -298,7 +298,7 @@ const ToggleSection = struct {
                 // Notifications toggle - Checkbox has built-in a11y
                 gooey.components.Checkbox{
                     .id = "notifications",
-                    .checked = self.notifications,
+                    .selected = self.notifications,
                     .label = if (self.notifications) "Notifications On" else "Notifications Off",
                     .accessible_name = "Enable Notifications",
                     .on_click_handler = cx.update(AppState.toggleNotifications),
@@ -306,7 +306,7 @@ const ToggleSection = struct {
                 // Dark mode toggle - Checkbox has built-in a11y
                 gooey.components.Checkbox{
                     .id = "dark_mode",
-                    .checked = self.dark_mode,
+                    .selected = self.dark_mode,
                     .label = if (self.dark_mode) "Dark Mode On" else "Dark Mode Off",
                     .accessible_name = "Dark Mode",
                     .on_click_handler = cx.update(AppState.toggleDarkMode),
@@ -405,7 +405,7 @@ const ActionLogSection = struct {
 //
 //   Checkbox{
 //       .id = "agree",
-//       .checked = state.agreed,
+//       .selected = state.agreed,
 //       .label = "I agree",
 //       .accessible_name = "Accept terms and conditions",
 //       .on_click_handler = handler,

--- a/src/examples/accessible_form.zig
+++ b/src/examples/accessible_form.zig
@@ -446,7 +446,7 @@ const ContactPreferencesSection = struct {
             ui.spacerMin(8),
             Checkbox{
                 .id = "newsletter",
-                .checked = self.newsletter,
+                .selected = self.newsletter,
                 .label = "Subscribe to our newsletter",
                 .accessible_name = "Subscribe to newsletter",
                 .accessible_description = "Receive weekly updates about our products and services",
@@ -636,7 +636,7 @@ const TermsSection = struct {
         }, .{
             Checkbox{
                 .id = "terms",
-                .checked = self.terms_accepted,
+                .selected = self.terms_accepted,
                 .label = "I accept the Terms and Conditions *",
                 .accessible_name = "Accept terms and conditions, required",
                 .accessible_description = if (self.has_error)

--- a/src/examples/pomodoro.zig
+++ b/src/examples/pomodoro.zig
@@ -431,7 +431,7 @@ const TaskItem = struct {
         cx.render(ui.hstack(.{ .gap = 12, .alignment = .center }, .{
             Checkbox{
                 .id = checkbox_id,
-                .checked = data.completed,
+                .selected = data.completed,
                 .on_click_handler = cx.commandWith(self.index, AppState.toggleTask),
                 .checked_background = ui.Color.rgb(0.3, 0.8, 0.5),
             },

--- a/src/examples/showcase.zig
+++ b/src/examples/showcase.zig
@@ -1271,20 +1271,20 @@ const CheckboxCard = struct {
             ui.box(.{ .gap = 12 }, .{
                 Checkbox{
                     .id = "opt-a",
-                    .checked = s.option_a,
+                    .selected = s.option_a,
                     .label = "Option A (checked by default)",
                     .on_click_handler = cx.update(AppState.toggleOptionA),
                     // Uses theme defaults
                 },
                 Checkbox{
                     .id = "opt-b",
-                    .checked = s.option_b,
+                    .selected = s.option_b,
                     .label = "Option B",
                     .on_click_handler = cx.update(AppState.toggleOptionB),
                 },
                 Checkbox{
                     .id = "opt-c",
-                    .checked = s.option_c,
+                    .selected = s.option_c,
                     .label = "Option C (success color)",
                     .on_click_handler = cx.update(AppState.toggleOptionC),
                     // Override just the checked color
@@ -1308,19 +1308,19 @@ const RadioCard = struct {
                     ui.text("Color", .{ .size = 13, .color = t.muted }),
                     RadioButton{
                         .label = "Red",
-                        .is_selected = s.color_choice == 0,
+                        .selected = s.color_choice == 0,
                         .on_click_handler = cx.updateWith(@as(u8, 0), AppState.setColor),
                         .selected_color = t.danger,
                     },
                     RadioButton{
                         .label = "Green",
-                        .is_selected = s.color_choice == 1,
+                        .selected = s.color_choice == 1,
                         .on_click_handler = cx.updateWith(@as(u8, 1), AppState.setColor),
                         .selected_color = t.success,
                     },
                     RadioButton{
                         .label = "Blue",
-                        .is_selected = s.color_choice == 2,
+                        .selected = s.color_choice == 2,
                         .on_click_handler = cx.updateWith(@as(u8, 2), AppState.setColor),
                         .selected_color = t.primary,
                     },

--- a/src/examples/todo.zig
+++ b/src/examples/todo.zig
@@ -300,7 +300,7 @@ const TodoRow = struct {
             .corner_radius = 8,
         }, .{
             Checkbox{
-                .checked = self.done,
+                .selected = self.done,
                 .on_click_handler = cx.updateWith(self.index, AppState.toggle),
             },
             ui.text(self.label, .{

--- a/src/ui/mod.zig
+++ b/src/ui/mod.zig
@@ -8,7 +8,7 @@
 //!
 //! // Components (preferred)
 //! gooey.Button{ .label = "Click", .on_click_handler = cx.update(State.onClick) }
-//! gooey.Checkbox{ .id = "agree", .checked = state.agreed, .on_click_handler = cx.update(State.toggle) }
+//! gooey.Checkbox{ .id = "agree", .selected = state.agreed, .on_click_handler = cx.update(State.toggle) }
 //! gooey.TextInput{ .id = "name", .placeholder = "Enter name", .bind = &state.name }
 //!
 //! // Primitives (for text, spacers, etc.)


### PR DESCRIPTION
Resolves P1 item **"Unify selection fields"** from `docs/api-design-review.md` (Theme 1).

## Problem
Six components spelled "which one is on" six different ways, so there was no muscle memory to build (review Theme 1):

| Component | Old field | Type |
|---|---|---|
| Checkbox | `checked` | `bool` |
| RadioButton | `is_selected` | `bool` |
| Tab | `is_active` | `bool` |
| RadioGroup | `selected` | `usize` (no "none") |
| Select | `selected` | `?usize` |
| TabBar | `active` | `usize` |

## Change
Standardize on one vocabulary:
- **Per-item boolean** selection → `selected: bool` (Checkbox, RadioButton, Tab + private render structs).
- **Index** selection → `selected: ?usize`, optional everywhere so "nothing selected" is a uniform first-class state. RadioGroup and TabBar join Select (already `?usize`).

Null indices are handled in the positive-invariant form (`if (self.selected) |sel| i == sel else false`), per CLAUDE.md rule 11.

## Notes
- The accessibility `AccessibleState.checked`/`.selected` protocol keys are a **separate concept** and keep their names; only their values now read the unified `selected` field.
- Call sites in examples and `readme.md` are updated.

## Validation
`zig build` and `zig build test` both exit 0.

---
Part of the P1 consistency pass (3 PRs). Touches example files and `readme.md`, so expect merge conflicts with the sibling PRs (`p1/handler-naming`, `p1/alignment-types`) — see the merge-order note in each.