### PR TITLE
P1: Unify stack/center/scroll layout types with box

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -214,7 +214,7 @@ fn render(cx: *Cx) void {
         ui.text("Todos", .{ .size = 28 }),
 
         // Input row: TextInput binds to state.draft; Add is a command.
-        ui.hstack(.{ .gap = 8, .alignment = .center }, .{
+        ui.hstack(.{ .gap = 8, .alignment = .{ .cross = .center } }, .{
             TextInput{ .id = draft_input_id, .placeholder = "What needs doing?", .bind = &s.draft, .fill_width = true },
             Button{ .label = "Add", .on_click_handler = cx.command(AppState.addTodo) },
         }),
@@ -233,7 +233,7 @@ fn render(cx: *Cx) void {
         TodoItems{},
 
         ui.spacer(),
-        ui.hstack(.{ .gap = 12, .alignment = .center }, .{
+        ui.hstack(.{ .gap = 12, .alignment = .{ .cross = .center } }, .{
             ui.textFmt("{d} left", .{s.remaining()}, .{ .size = 14 }),
             ui.spacer(),
             Button{ .label = "Clear completed", .variant = .secondary, .size = .small, .on_click_handler = cx.update(AppState.clearCompleted) },

--- a/src/examples/a11y_demo.zig
+++ b/src/examples/a11y_demo.zig
@@ -195,7 +195,7 @@ const A11yStatusSection = struct {
             defer cx.accessibleEnd();
         }
 
-        cx.render(ui.hstack(.{ .gap = 8, .alignment = .center }, .{
+        cx.render(ui.hstack(.{ .gap = 8, .alignment = .{ .cross = .center } }, .{
             ui.box(.{
                 .width = 12,
                 .height = 12,
@@ -239,7 +239,7 @@ const CounterSection = struct {
                 .weight = .semibold,
             }),
 
-            ui.hstack(.{ .gap = 16, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 16, .alignment = .{ .cross = .center } }, .{
                 // Decrement button - Button has built-in a11y
                 Button{
                     .label = "−",
@@ -351,7 +351,7 @@ const StatusSection = struct {
             .background = bg_color,
             .corner_radius = 8,
         }, .{
-            ui.hstack(.{ .gap = 12, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 12, .alignment = .{ .cross = .center } }, .{
                 ui.text(if (is_error) "⚠" else "✓", .{ .size = 16, .color = text_color }),
                 ui.text(self.message, .{ .size = 14, .color = text_color }),
                 ui.spacerMin(20),

--- a/src/examples/accessible_form.zig
+++ b/src/examples/accessible_form.zig
@@ -294,7 +294,7 @@ const A11yStatus = struct {
             defer cx.accessibleEnd();
         }
 
-        cx.render(ui.hstack(.{ .gap = 8, .alignment = .center }, .{
+        cx.render(ui.hstack(.{ .gap = 8, .alignment = .{ .cross = .center } }, .{
             ui.box(.{
                 .width = 10,
                 .height = 10,
@@ -723,7 +723,7 @@ const ErrorMessage = struct {
             defer cx.accessibleEnd();
         }
 
-        cx.render(ui.hstack(.{ .gap = 4, .alignment = .center }, .{
+        cx.render(ui.hstack(.{ .gap = 4, .alignment = .{ .cross = .center } }, .{
             ui.text("⚠", .{
                 .size = 12,
                 .color = ui.Color.rgb(0.9, 0.3, 0.3),

--- a/src/examples/ai_canvas.zig
+++ b/src/examples/ai_canvas.zig
@@ -208,7 +208,7 @@ const StatusBar = struct {
         else
             wasm_canvas.commandCount();
 
-        cx.render(ui.hstack(.{ .gap = 20, .alignment = .center }, .{
+        cx.render(ui.hstack(.{ .gap = 20, .alignment = .{ .cross = .center } }, .{
             ui.text("AI Canvas", .{
                 .size = 18,
                 .color = ui.Color.hex(0xe0e0ff),

--- a/src/examples/animation.zig
+++ b/src/examples/animation.zig
@@ -100,7 +100,7 @@ const ControlButtons = struct {
         std.debug.assert(@TypeOf(s) == *AppState);
         std.debug.assert(@sizeOf(AppState) > 0);
 
-        cx.render(ui.hstack(.{ .gap = 12, .alignment = .center }, .{
+        cx.render(ui.hstack(.{ .gap = 12, .alignment = .{ .cross = .center } }, .{
             Button{
                 .label = "-",
                 .size = .large,
@@ -313,7 +313,7 @@ const LoadingSpinner = struct {
         std.debug.assert(pulse.progress >= 0.0);
         std.debug.assert(pulse.progress <= 1.0);
 
-        cx.render(ui.hstack(.{ .gap = 8, .alignment = .center }, .{
+        cx.render(ui.hstack(.{ .gap = 8, .alignment = .{ .cross = .center } }, .{
             ui.text("Loading:", .{ .size = 14, .color = Color.rgb(0.5, 0.5, 0.5) }),
             SpinnerBall{ .progress = pulse.progress },
         }));

--- a/src/examples/code_editor.zig
+++ b/src/examples/code_editor.zig
@@ -826,7 +826,7 @@ const EditorPanel = struct {
                     .corner_radius = 8,
                     .alignment = .{ .main = .center, .cross = .center },
                 }, .{
-                    ui.vstack(.{ .gap = 16, .alignment = .center }, .{
+                    ui.vstack(.{ .gap = 16, .alignment = .{ .cross = .center } }, .{
                         Svg{
                             .path = s.file_status.getIconPath(),
                             .size = 48,

--- a/src/examples/counter.zig
+++ b/src/examples/counter.zig
@@ -143,7 +143,7 @@ const CounterDisplay = struct {
 
 const ControlButtons = struct {
     pub fn render(_: @This(), cx: *Cx) void {
-        cx.render(ui.hstack(.{ .gap = 12, .alignment = .center }, .{
+        cx.render(ui.hstack(.{ .gap = 12, .alignment = .{ .cross = .center } }, .{
             // Pure state handlers - cx.update()
             Button{ .label = "−", .size = .large, .on_click_handler = cx.update(AppState.decrement) },
             Button{ .label = "+", .size = .large, .on_click_handler = cx.update(AppState.increment) },
@@ -163,7 +163,7 @@ const StepSelector = struct {
     pub fn render(_: @This(), cx: *Cx) void {
         const s = cx.state(AppState);
 
-        cx.render(ui.hstack(.{ .gap = 8, .alignment = .center }, .{
+        cx.render(ui.hstack(.{ .gap = 8, .alignment = .{ .cross = .center } }, .{
             ui.text("Step:", .{ .size = 14, .color = ui.Color.rgb(0.5, 0.5, 0.5) }),
 
             // Using cx.updateWith() to pass arguments

--- a/src/examples/drag_drop.zig
+++ b/src/examples/drag_drop.zig
@@ -227,7 +227,7 @@ const ListColumns = struct {
     pub fn render(_: @This(), cx: *Cx) void {
         cx.render(ui.hstack(.{
             .gap = 32,
-            .alignment = .stretch,
+            .alignment = .{ .cross = .stretch },
         }, .{
             ItemList{ .side = .left, .title = "Fruits" },
             ItemList{ .side = .right, .title = "Basket" },
@@ -339,7 +339,7 @@ const DragCardContent = struct {
     item: *Item,
 
     pub fn render(self: @This(), cx: *Cx) void {
-        cx.render(ui.hstack(.{ .gap = 12, .alignment = .center }, .{
+        cx.render(ui.hstack(.{ .gap = 12, .alignment = .{ .cross = .center } }, .{
             // Drag handle icon (three lines)
             DragHandle{},
             // Item name

--- a/src/examples/dynamic_counters.zig
+++ b/src/examples/dynamic_counters.zig
@@ -170,7 +170,7 @@ const ControlPanel = struct {
     pub fn render(_: @This(), cx: *Cx) void {
         const s = cx.stateConst(AppState);
 
-        cx.render(ui.hstack(.{ .gap = 12, .alignment = .center }, .{
+        cx.render(ui.hstack(.{ .gap = 12, .alignment = .{ .cross = .center } }, .{
             // These need command() because they create/remove entities
             Button{ .label = "+ Add Counter", .on_click_handler = cx.command(AppState.addCounter) },
             Button{ .label = "- Remove Counter", .variant = .secondary, .on_click_handler = cx.command(AppState.removeCounter) },

--- a/src/examples/linux_text_demo.zig
+++ b/src/examples/linux_text_demo.zig
@@ -170,7 +170,7 @@ const CounterSection = struct {
             }),
 
             // Control buttons
-            ui.hstack(.{ .gap = 12, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 12, .alignment = .{ .cross = .center } }, .{
                 Button{
                     .label = "−",
                     .size = .large,
@@ -196,7 +196,7 @@ const FontSizeSection = struct {
     pub fn render(_: @This(), cx: *Cx) void {
         const s = cx.state(AppState);
 
-        cx.render(ui.hstack(.{ .gap = 12, .alignment = .center }, .{
+        cx.render(ui.hstack(.{ .gap = 12, .alignment = .{ .cross = .center } }, .{
             ui.text("Font Size:", .{
                 .size = 14,
                 .color = ui.Color.rgb(0.6, 0.6, 0.65),
@@ -298,7 +298,7 @@ const ImageSection = struct {
             }),
 
             // Row of images at different sizes
-            ui.hstack(.{ .gap = 16, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 16, .alignment = .{ .cross = .center } }, .{
                 ui.box(.{ .gap = 4, .alignment = .{ .cross = .center } }, .{
                     Image{
                         .src = "assets/ziglang_logo.png",
@@ -330,7 +330,7 @@ const ImageSection = struct {
             }),
 
             // Row with corner radius and effects
-            ui.hstack(.{ .gap = 16, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 16, .alignment = .{ .cross = .center } }, .{
                 ui.box(.{ .gap = 4, .alignment = .{ .cross = .center } }, .{
                     Image{
                         .src = "assets/ziglang_logo.png",
@@ -391,7 +391,7 @@ const SvgIconsSection = struct {
             }),
 
             // Row of navigation icons
-            ui.hstack(.{ .gap = 16, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 16, .alignment = .{ .cross = .center } }, .{
                 Svg{ .path = Icons.menu, .size = 24, .color = ui.Color.rgb(0.9, 0.9, 0.95) },
                 Svg{ .path = Icons.arrow_back, .size = 24, .color = ui.Color.rgb(0.9, 0.9, 0.95) },
                 Svg{ .path = Icons.arrow_forward, .size = 24, .color = ui.Color.rgb(0.9, 0.9, 0.95) },
@@ -400,7 +400,7 @@ const SvgIconsSection = struct {
             }),
 
             // Row of action icons with colors
-            ui.hstack(.{ .gap = 16, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 16, .alignment = .{ .cross = .center } }, .{
                 Svg{ .path = Icons.add, .size = 24, .color = ui.Color.rgb(0.3, 0.8, 0.3) },
                 Svg{ .path = Icons.remove, .size = 24, .color = ui.Color.rgb(0.8, 0.3, 0.3) },
                 Svg{ .path = Icons.check, .size = 24, .color = ui.Color.rgb(0.3, 0.8, 0.3) },
@@ -410,7 +410,7 @@ const SvgIconsSection = struct {
             }),
 
             // Row of status icons
-            ui.hstack(.{ .gap = 16, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 16, .alignment = .{ .cross = .center } }, .{
                 Svg{ .path = Icons.star, .size = 24, .color = ui.Color.rgb(1.0, 0.8, 0.0) },
                 Svg{ .path = Icons.star_outline, .size = 24, .color = ui.Color.rgb(1.0, 0.8, 0.0) },
                 Svg{ .path = Icons.favorite, .size = 24, .color = ui.Color.rgb(1.0, 0.3, 0.4) },
@@ -420,7 +420,7 @@ const SvgIconsSection = struct {
             }),
 
             // Row of media icons
-            ui.hstack(.{ .gap = 16, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 16, .alignment = .{ .cross = .center } }, .{
                 Svg{ .path = Icons.play, .size = 24, .color = ui.Color.rgb(0.3, 0.8, 0.5) },
                 Svg{ .path = Icons.pause, .size = 24, .color = ui.Color.rgb(0.8, 0.8, 0.85) },
                 Svg{ .path = Icons.skip_prev, .size = 24, .color = ui.Color.rgb(0.8, 0.8, 0.85) },
@@ -429,7 +429,7 @@ const SvgIconsSection = struct {
             }),
 
             // Different sizes
-            ui.hstack(.{ .gap = 20, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 20, .alignment = .{ .cross = .center } }, .{
                 Svg{ .path = Icons.star, .size = 16, .color = ui.Color.rgb(1.0, 0.8, 0.0) },
                 Svg{ .path = Icons.star, .size = 24, .color = ui.Color.rgb(1.0, 0.8, 0.0) },
                 Svg{ .path = Icons.star, .size = 32, .color = ui.Color.rgb(1.0, 0.8, 0.0) },
@@ -437,7 +437,7 @@ const SvgIconsSection = struct {
             }),
 
             // Stroked icons
-            ui.hstack(.{ .gap = 16, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 16, .alignment = .{ .cross = .center } }, .{
                 ui.text("Stroked:", .{ .size = 12, .color = ui.Color.rgb(0.5, 0.5, 0.55) }),
                 Svg{ .path = Icons.star_outline, .size = 24, .no_fill = true, .stroke_color = ui.Color.rgb(1.0, 0.8, 0.0), .stroke_width = 1.5 },
                 Svg{ .path = Icons.favorite, .size = 24, .no_fill = true, .stroke_color = ui.Color.rgb(1.0, 0.3, 0.4), .stroke_width = 1.5 },

--- a/src/examples/multi_window.zig
+++ b/src/examples/multi_window.zig
@@ -296,7 +296,7 @@ fn renderDialog(cx: *Cx) void {
                 }),
             }),
             // New value display
-            ui.hstack(.{ .gap = 8, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 8, .alignment = .{ .cross = .center } }, .{
                 ui.text("New value:", .{
                     .size = 16,
                     .weight = .semibold,
@@ -343,7 +343,7 @@ fn renderDialog(cx: *Cx) void {
         ui.spacer(),
 
         // Action buttons row
-        ui.hstack(.{ .gap = 12, .alignment = .end }, .{
+        ui.hstack(.{ .gap = 12, .alignment = .{ .cross = .end } }, .{
             Button{
                 .label = "Cancel",
                 .variant = .secondary,

--- a/src/examples/new_api_demo.zig
+++ b/src/examples/new_api_demo.zig
@@ -96,11 +96,12 @@ fn render(cx: *Cx) void {
     const s = cx.state(AppState);
     const size = cx.windowSize();
 
-    // Resolve alignment based on state
-    const main_align: ui.StackStyle.Alignment = switch (s.selected_alignment) {
-        .start => .start,
-        .center => .center,
-        .end => .end,
+    // Resolve alignment based on state. Stacks now take a full `Box.Alignment`;
+    // this demo only varies the cross axis, matching the pre-unification behavior.
+    const main_align: ui.Box.Alignment = switch (s.selected_alignment) {
+        .start => .{ .cross = .start },
+        .center => .{ .cross = .center },
+        .end => .{ .cross = .end },
     };
 
     cx.render(ui.box(.{
@@ -148,7 +149,7 @@ fn render(cx: *Cx) void {
         // Test 2: on_click_handler on ui.box()
         // =================================================================
         SectionHeader{ .title = "2. Click Handler on Box" },
-        ui.hstack(.{ .gap = 12, .alignment = .center }, .{
+        ui.hstack(.{ .gap = 12, .alignment = .{ .cross = .center } }, .{
             ui.box(.{
                 .padding = .{ .all = 16 },
                 .background = Color.rgb(0.3, 0.5, 0.7),
@@ -168,7 +169,7 @@ fn render(cx: *Cx) void {
         // Test 3: Alignment on ui.hstack() / ui.vstack()
         // =================================================================
         SectionHeader{ .title = "3. Stack Alignment" },
-        ui.hstack(.{ .gap = 8, .alignment = .center }, .{
+        ui.hstack(.{ .gap = 8, .alignment = .{ .cross = .center } }, .{
             ui.text("Alignment:", .{ .size = 12, .color = Color.rgb(0.6, 0.6, 0.6) }),
             Button{
                 .label = "Start",
@@ -208,7 +209,7 @@ fn render(cx: *Cx) void {
         // Test 4: Nested ui.when() inside ui.box()
         // =================================================================
         SectionHeader{ .title = "4. Nested Conditionals" },
-        ui.hstack(.{ .gap = 8, .alignment = .center }, .{
+        ui.hstack(.{ .gap = 8, .alignment = .{ .cross = .center } }, .{
             Button{
                 .label = if (s.show_details) "Hide" else "Show",
                 .size = .small,
@@ -236,7 +237,7 @@ fn render(cx: *Cx) void {
         // Test 5: Components with render() inside new containers
         // =================================================================
         SectionHeader{ .title = "5. Components in Containers" },
-        ui.hstack(.{ .gap = 12, .alignment = .center }, .{
+        ui.hstack(.{ .gap = 12, .alignment = .{ .cross = .center } }, .{
             // Custom component inside ui.hstack
             CounterBadge{ .value = s.count, .label = "Count" },
             CounterBadge{ .value = s.click_count, .label = "Clicks" },
@@ -269,7 +270,7 @@ fn render(cx: *Cx) void {
             .corner_radius = 6,
             .padding = .{ .all = 12 },
         }, .{
-            ui.hstack(.{ .gap = 8, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 8, .alignment = .{ .cross = .center } }, .{
                 ui.text("Left", .{ .size = 12, .color = Color.white }),
                 ui.spacer(), // Flexible spacer pushes content apart
                 ui.text("Right", .{ .size = 12, .color = Color.white }),
@@ -281,7 +282,7 @@ fn render(cx: *Cx) void {
             .corner_radius = 6,
             .padding = .{ .all = 12 },
         }, .{
-            ui.hstack(.{ .gap = 8, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 8, .alignment = .{ .cross = .center } }, .{
                 ui.text("A", .{ .size = 12, .color = Color.white }),
                 ui.spacerMin(50), // Fixed minimum spacer
                 ui.text("B", .{ .size = 12, .color = Color.white }),

--- a/src/examples/pomodoro.zig
+++ b/src/examples/pomodoro.zig
@@ -335,7 +335,7 @@ const TimerDisplay = struct {
 
 const TimerControls = struct {
     pub fn render(_: @This(), cx: *Cx) void {
-        cx.render(ui.hstack(.{ .gap = 12, .alignment = .center }, .{
+        cx.render(ui.hstack(.{ .gap = 12, .alignment = .{ .cross = .center } }, .{
             ControlButtons{},
             ResetButton{},
         }));
@@ -393,7 +393,7 @@ const TaskInput = struct {
     pub fn render(_: @This(), cx: *Cx) void {
         const s = cx.state(AppState);
 
-        cx.render(ui.hstack(.{ .gap = 12, .alignment = .center }, .{
+        cx.render(ui.hstack(.{ .gap = 12, .alignment = .{ .cross = .center } }, .{
             TextInput{
                 .id = "task-input",
                 .placeholder = "Add a task...",
@@ -428,7 +428,7 @@ const TaskItem = struct {
         else
             ui.Color.rgb(0.2, 0.2, 0.2);
 
-        cx.render(ui.hstack(.{ .gap = 12, .alignment = .center }, .{
+        cx.render(ui.hstack(.{ .gap = 12, .alignment = .{ .cross = .center } }, .{
             Checkbox{
                 .id = checkbox_id,
                 .checked = data.completed,
@@ -455,7 +455,7 @@ const TaskList = struct {
             .min_height = 150,
             .min_width = 320,
         }, .{
-            ui.hstack(.{ .gap = 8, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 8, .alignment = .{ .cross = .center } }, .{
                 ui.text("Tasks", .{ .size = 16, .color = ui.Color.rgb(0.3, 0.3, 0.3) }),
                 ui.spacer(),
                 ClearDoneButton{},

--- a/src/examples/showcase.zig
+++ b/src/examples/showcase.zig
@@ -1120,13 +1120,13 @@ const ButtonVariantsCard = struct {
         const card = Card{ .title = "Button Variants", .description = "Different button styles for various contexts" };
 
         card.render(cx, .{
-            ui.hstack(.{ .gap = 12, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 12, .alignment = .{ .cross = .center } }, .{
                 Button{ .label = "Primary", .variant = .primary },
                 Button{ .label = "Secondary", .variant = .secondary },
                 Button{ .label = "Danger", .variant = .danger },
             }),
 
-            ui.hstack(.{ .gap = 12, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 12, .alignment = .{ .cross = .center } }, .{
                 Button{ .label = "Disabled", .variant = .primary, .enabled = false },
                 Tooltip(Button){
                     .text = "This button has a tooltip!",
@@ -1144,7 +1144,7 @@ const ButtonSizesCard = struct {
         const card = Card{ .title = "Button Sizes", .description = "Small, medium, and large variants" };
 
         card.render(cx, .{
-            ui.hstack(.{ .gap = 12, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 12, .alignment = .{ .cross = .center } }, .{
                 Button{ .label = "Small", .size = .small },
                 Button{ .label = "Medium", .size = .medium },
                 Button{ .label = "Large", .size = .large },
@@ -1160,7 +1160,7 @@ const ButtonInteractiveCard = struct {
         const card = Card{ .title = "Interactive Demo", .description = "Click to see state updates" };
 
         card.render(cx, .{
-            ui.hstack(.{ .gap = 16, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 16, .alignment = .{ .cross = .center } }, .{
                 Button{
                     .label = "Click Me!",
                     .variant = .primary,
@@ -1204,7 +1204,7 @@ const TextInputCard = struct {
 
         card.render(cx, .{
             ui.box(.{ .gap = 16 }, .{
-                ui.hstack(.{ .gap = 16, .alignment = .center }, .{
+                ui.hstack(.{ .gap = 16, .alignment = .{ .cross = .center } }, .{
                     TextInput{
                         .id = "name-input",
                         .placeholder = "Your name",
@@ -1302,7 +1302,7 @@ const RadioCard = struct {
         const card = Card{ .title = "Radio Buttons", .description = "Select one option from a group" };
 
         card.render(cx, .{
-            ui.hstack(.{ .gap = 32, .alignment = .start }, .{
+            ui.hstack(.{ .gap = 32, .alignment = .{ .cross = .start } }, .{
                 // Color selection - vertical
                 ui.box(.{ .gap = 8 }, .{
                     ui.text("Color", .{ .size = 13, .color = t.muted }),
@@ -1358,7 +1358,7 @@ const SelectCard = struct {
         const card = Card{ .title = "Select / Dropdown", .description = "Choose from a list of options" };
 
         card.render(cx, .{
-            ui.hstack(.{ .gap = 24, .alignment = .start }, .{
+            ui.hstack(.{ .gap = 24, .alignment = .{ .cross = .start } }, .{
                 ui.box(.{ .gap = 8 }, .{
                     ui.text("Fruit", .{ .size = 13, .color = t.muted }),
                     Select{
@@ -1407,7 +1407,7 @@ const ProgressCard = struct {
 
         card.render(cx, .{
             ui.box(.{ .gap = 16 }, .{
-                ui.hstack(.{ .gap = 16, .alignment = .center }, .{
+                ui.hstack(.{ .gap = 16, .alignment = .{ .cross = .center } }, .{
                     ui.text("65%", .{ .size = 13, .color = t.muted }),
                     ProgressBar{
                         .progress = 0.65,
@@ -1416,7 +1416,7 @@ const ProgressCard = struct {
                         // Uses theme defaults (overlay bg, primary fill)
                     },
                 }),
-                ui.hstack(.{ .gap = 16, .alignment = .center }, .{
+                ui.hstack(.{ .gap = 16, .alignment = .{ .cross = .center } }, .{
                     ui.text("25%", .{ .size = 13, .color = t.muted }),
                     ProgressBar{
                         .progress = 0.25,
@@ -1425,7 +1425,7 @@ const ProgressCard = struct {
                         .fill = t.warning,
                     },
                 }),
-                ui.hstack(.{ .gap = 16, .alignment = .center }, .{
+                ui.hstack(.{ .gap = 16, .alignment = .{ .cross = .center } }, .{
                     ui.text("100%", .{ .size = 13, .color = t.muted }),
                     ProgressBar{
                         .progress = 1.0,
@@ -1434,7 +1434,7 @@ const ProgressCard = struct {
                         .fill = t.success,
                     },
                 }),
-                ui.hstack(.{ .gap = 16, .alignment = .center }, .{
+                ui.hstack(.{ .gap = 16, .alignment = .{ .cross = .center } }, .{
                     Button{
                         .label = "Step Progress",
                         .variant = .secondary,
@@ -1462,7 +1462,7 @@ const TooltipCard = struct {
         const card = Card{ .title = "Tooltips", .description = "Hover to see contextual information" };
 
         card.render(cx, .{
-            ui.hstack(.{ .gap = 16, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 16, .alignment = .{ .cross = .center } }, .{
                 Tooltip(Button){
                     .text = "Appears above",
                     .position = .top,
@@ -1508,7 +1508,7 @@ const ModalCard = struct {
 
         card.render(cx, .{
             ui.box(.{ .gap = 16 }, .{
-                ui.hstack(.{ .gap = 16, .alignment = .center }, .{
+                ui.hstack(.{ .gap = 16, .alignment = .{ .cross = .center } }, .{
                     Button{
                         .label = "Info Modal",
                         .variant = .primary,
@@ -1560,7 +1560,7 @@ const ConfirmModalContent = struct {
                 .color = t.subtext,
                 .wrap = .words,
             }),
-            ui.hstack(.{ .gap = 12, .alignment = .end }, .{
+            ui.hstack(.{ .gap = 12, .alignment = .{ .cross = .end } }, .{
                 ui.spacer(),
                 Button{
                     .label = "Cancel",
@@ -1597,7 +1597,7 @@ const BasicIconsCard = struct {
         const card = Card{ .title = "Basic Icons", .description = "Built-in Material Design icon set" };
 
         card.render(cx, .{
-            ui.hstack(.{ .gap = 20, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 20, .alignment = .{ .cross = .center } }, .{
                 IconWithLabel{ .icon = Icons.folder, .label = "Folder" },
                 IconWithLabel{ .icon = Icons.search, .label = "Search" },
                 IconWithLabel{ .icon = Icons.edit, .label = "Edit" },
@@ -1607,7 +1607,7 @@ const BasicIconsCard = struct {
                 IconWithLabel{ .icon = Icons.menu, .label = "Menu" },
                 IconWithLabel{ .icon = Icons.download, .label = "Download" },
             }),
-            ui.hstack(.{ .gap = 20, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 20, .alignment = .{ .cross = .center } }, .{
                 IconWithLabel{ .icon = Icons.check, .label = "Check", .color = t.success },
                 IconWithLabel{ .icon = Icons.close, .label = "Close", .color = t.danger },
                 IconWithLabel{ .icon = Icons.warning, .label = "Warning", .color = t.warning },
@@ -1647,7 +1647,7 @@ const StyledIconsCard = struct {
         const card = Card{ .title = "Icon Styles", .description = "Different sizes and stroke widths" };
 
         card.render(cx, .{
-            ui.hstack(.{ .gap = 24, .alignment = .end }, .{
+            ui.hstack(.{ .gap = 24, .alignment = .{ .cross = .end } }, .{
                 ui.box(.{ .gap = 4, .alignment = .{ .cross = .center } }, .{
                     // Use no_fill = true for stroke-only rendering
                     Svg{ .path = Icons.star_outline, .size = 16, .no_fill = true, .stroke_color = t.subtext, .stroke_width = 1.5 },
@@ -1666,7 +1666,7 @@ const StyledIconsCard = struct {
                     ui.text("48px", .{ .size = 11, .color = t.muted }),
                 }),
             }),
-            ui.hstack(.{ .gap = 24, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 24, .alignment = .{ .cross = .center } }, .{
                 // Filled star (use fill for solid icons)
                 Svg{ .path = Icons.star, .size = 32, .color = t.warning },
                 // Stroke only (use no_fill + stroke for outline icons)
@@ -1689,7 +1689,7 @@ const CustomPathsCard = struct {
         const card = Card{ .title = "Custom SVG Paths", .description = "Arcs, beziers, and custom shapes" };
 
         card.render(cx, .{
-            ui.hstack(.{ .gap = 24, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 24, .alignment = .{ .cross = .center } }, .{
                 ui.box(.{ .gap = 4, .alignment = .{ .cross = .center } }, .{
                     Svg{ .path = circle_path, .size = 32, .no_fill = true, .stroke_color = t.primary, .stroke_width = 2 },
                     ui.text("Circle (Arc)", .{ .size = 11, .color = t.muted }),

--- a/src/examples/spaceship.zig
+++ b/src/examples/spaceship.zig
@@ -451,7 +451,7 @@ const ShipName = struct {
     opacity: f32 = 1.0,
 
     pub fn render(self: @This(), cx: *Cx) void {
-        cx.render(ui.hstack(.{ .gap = 12, .alignment = .center }, .{
+        cx.render(ui.hstack(.{ .gap = 12, .alignment = .{ .cross = .center } }, .{
             Svg{
                 .path = SpaceIcons.ship,
                 .size = 28,
@@ -483,7 +483,7 @@ const StatusIndicator = struct {
 
         const status_alpha = 1.0 - (pulse_intensity * (1.0 - pulse.progress));
 
-        cx.render(ui.hstack(.{ .gap = 16, .alignment = .center }, .{
+        cx.render(ui.hstack(.{ .gap = 16, .alignment = .{ .cross = .center } }, .{
             ui.text("STATUS:", .{ .size = 12, .color = Colors.text_dim }),
             ui.text(s.alert_level.label(), .{
                 .size = 14,
@@ -514,7 +514,7 @@ const AlertBadge = struct {
                 .background = Colors.red.withAlpha(glow_alpha),
                 .corner_radius = 10,
             }, .{
-                ui.hstack(.{ .gap = 4, .alignment = .center }, .{
+                ui.hstack(.{ .gap = 4, .alignment = .{ .cross = .center } }, .{
                     Svg{
                         .path = SpaceIcons.alert,
                         .size = 12,
@@ -634,7 +634,7 @@ const JumpDrive = struct {
             .gap = 12,
             .direction = .column,
         }, .{
-            ui.hstack(.{ .gap = 6, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 6, .alignment = .{ .cross = .center } }, .{
                 Svg{
                     .path = SpaceIcons.jump_drive,
                     .size = 14,
@@ -778,7 +778,7 @@ const SystemGauge = struct {
             .direction = .column,
         }, .{
             ui.box(.{ .direction = .row, .fill_width = true, .alignment = .{ .main = .space_between, .cross = .center } }, .{
-                ui.hstack(.{ .gap = 6, .alignment = .center }, .{
+                ui.hstack(.{ .gap = 6, .alignment = .{ .cross = .center } }, .{
                     Svg{
                         .path = self.icon,
                         .size = 14,
@@ -854,7 +854,7 @@ const ReactorStatus = struct {
             .gap = 8,
             .direction = .column,
         }, .{
-            ui.hstack(.{ .gap = 6, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 6, .alignment = .{ .cross = .center } }, .{
                 Svg{
                     .path = SpaceIcons.reactor,
                     .size = 14,
@@ -909,7 +909,7 @@ const AutopilotStatus = struct {
     pub fn render(_: @This(), cx: *Cx) void {
         const s = cx.stateConst(AppState);
 
-        cx.render(ui.hstack(.{ .gap = 8, .alignment = .center }, .{
+        cx.render(ui.hstack(.{ .gap = 8, .alignment = .{ .cross = .center } }, .{
             Svg{
                 .path = SpaceIcons.autopilot,
                 .size = 16,
@@ -986,7 +986,7 @@ const CoordinatesPanel = struct {
             .gap = 12,
             .direction = .column,
         }, .{
-            ui.hstack(.{ .gap = 6, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 6, .alignment = .{ .cross = .center } }, .{
                 Svg{
                     .path = SpaceIcons.coords,
                     .size = 14,
@@ -1034,7 +1034,7 @@ const VelocityDisplay = struct {
             .direction = .row,
             .alignment = .{ .main = .space_between, .cross = .center },
         }, .{
-            ui.hstack(.{ .gap = 6, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 6, .alignment = .{ .cross = .center } }, .{
                 Svg{
                     .path = SpaceIcons.velocity,
                     .size = 16,
@@ -1044,7 +1044,7 @@ const VelocityDisplay = struct {
                 },
                 ui.text("VELOCITY", .{ .size = 11, .color = Colors.text_dim }),
             }),
-            ui.hstack(.{ .gap = 4, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 4, .alignment = .{ .cross = .center } }, .{
                 ui.textFmt("{}", .{s.velocity}, .{ .size = 24, .color = vel_color }),
                 ui.text("km/s", .{ .size = 11, .color = Colors.text_dim }),
             }),
@@ -1064,7 +1064,7 @@ const ShipControls = struct {
             .gap = 12,
             .direction = .column,
         }, .{
-            ui.hstack(.{ .gap = 6, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 6, .alignment = .{ .cross = .center } }, .{
                 Svg{
                     .path = SpaceIcons.target,
                     .size = 12,
@@ -1130,7 +1130,7 @@ const AutopilotToggle = struct {
             .alignment = .{ .cross = .center },
             .on_click_handler = cx.update(AppState.toggleAutopilot),
         }, .{
-            ui.hstack(.{ .gap = 6, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 6, .alignment = .{ .cross = .center } }, .{
                 Svg{
                     .path = SpaceIcons.autopilot,
                     .size = 14,
@@ -1166,7 +1166,7 @@ const ShieldsToggle = struct {
             .alignment = .{ .cross = .center },
             .on_click_handler = cx.update(AppState.toggleShields),
         }, .{
-            ui.hstack(.{ .gap = 6, .alignment = .center }, .{
+            ui.hstack(.{ .gap = 6, .alignment = .{ .cross = .center } }, .{
                 Svg{
                     .path = SpaceIcons.shield,
                     .size = 14,
@@ -1289,7 +1289,7 @@ const Footer = struct {
 
 const FooterVersion = struct {
     pub fn render(_: @This(), cx: *Cx) void {
-        cx.render(ui.hstack(.{ .gap = 6, .alignment = .center }, .{
+        cx.render(ui.hstack(.{ .gap = 6, .alignment = .{ .cross = .center } }, .{
             Svg{
                 .path = SpaceIcons.dashboard,
                 .size = 12,
@@ -1304,7 +1304,7 @@ const FooterVersion = struct {
 
 const FooterBrand = struct {
     pub fn render(_: @This(), cx: *Cx) void {
-        cx.render(ui.hstack(.{ .gap = 6, .alignment = .center }, .{
+        cx.render(ui.hstack(.{ .gap = 6, .alignment = .{ .cross = .center } }, .{
             Svg{
                 .path = SpaceIcons.star,
                 .size = 12,

--- a/src/examples/todo.zig
+++ b/src/examples/todo.zig
@@ -211,7 +211,7 @@ const InputRow = struct {
     pub fn render(_: @This(), cx: *Cx) void {
         const s = cx.state(AppState);
 
-        cx.render(ui.hstack(.{ .gap = 8, .alignment = .center }, .{
+        cx.render(ui.hstack(.{ .gap = 8, .alignment = .{ .cross = .center } }, .{
             TextInput{
                 .id = draft_input_id,
                 .placeholder = "What needs doing?",
@@ -326,7 +326,7 @@ const Footer = struct {
     pub fn render(_: @This(), cx: *Cx) void {
         const s = cx.state(AppState);
 
-        cx.render(ui.hstack(.{ .gap = 12, .alignment = .center }, .{
+        cx.render(ui.hstack(.{ .gap = 12, .alignment = .{ .cross = .center } }, .{
             ui.textFmt("{d} left", .{s.remaining()}, .{
                 .size = 14,
                 .color = ui.Color.rgb(0.4, 0.4, 0.45),

--- a/src/examples/tree_example.zig
+++ b/src/examples/tree_example.zig
@@ -177,7 +177,7 @@ const Header = struct {
     pub fn render(_: @This(), cx: *Cx) void {
         const theme = cx.theme();
 
-        cx.render(ui.hstack(.{ .gap = 8, .alignment = .center }, .{
+        cx.render(ui.hstack(.{ .gap = 8, .alignment = .{ .cross = .center } }, .{
             ui.text("Tree List Demo", .{
                 .size = 18,
                 .weight = .bold,

--- a/src/ui/builder.zig
+++ b/src/ui/builder.zig
@@ -816,18 +816,13 @@ pub const Builder = struct {
     }
 
     fn vstackImpl(self: *Self, style: StackStyle, children: anytype, loc: SourceLoc) void {
+        // A vstack is a box fixed to column direction; alignment and padding
+        // pass straight through now that they share Box's types.
         self.boxWithIdTracked(null, .{
             .direction = .column,
             .gap = style.gap,
-            .padding = .{ .all = style.padding },
-            .alignment = .{
-                .cross = switch (style.alignment) {
-                    .start => .start,
-                    .center => .center,
-                    .end => .end,
-                    .stretch => .stretch,
-                },
-            },
+            .padding = style.padding,
+            .alignment = style.alignment,
         }, children, loc);
     }
 
@@ -843,18 +838,13 @@ pub const Builder = struct {
     }
 
     fn hstackImpl(self: *Self, style: StackStyle, children: anytype, loc: SourceLoc) void {
+        // A hstack is a box fixed to row direction; alignment and padding
+        // pass straight through now that they share Box's types.
         self.boxWithIdTracked(null, .{
             .direction = .row,
             .gap = style.gap,
-            .padding = .{ .all = style.padding },
-            .alignment = .{
-                .cross = switch (style.alignment) {
-                    .start => .start,
-                    .center => .center,
-                    .end => .end,
-                    .stretch => .stretch,
-                },
-            },
+            .padding = style.padding,
+            .alignment = style.alignment,
         }, children, loc);
     }
 
@@ -862,7 +852,7 @@ pub const Builder = struct {
     pub fn center(self: *Self, style: CenterStyle, children: anytype) void {
         self.box(.{
             .grow = true,
-            .padding = .{ .all = style.padding },
+            .padding = style.padding,
             .alignment = .{ .main = .center, .cross = .center },
         }, children);
     }
@@ -1010,7 +1000,10 @@ pub const Builder = struct {
                     .height = content_height_sizing,
                 },
                 .layout_direction = .top_to_bottom,
-                .child_gap = style.gap,
+                // `style.gap` is f32 (matching Box/StackStyle); the layout
+                // engine's `child_gap` is an integer pixel count, so truncate
+                // here exactly as box does with `props.gap`.
+                .child_gap = @intFromFloat(style.gap),
             },
         }) catch return;
 

--- a/src/ui/primitives.zig
+++ b/src/ui/primitives.zig
@@ -543,10 +543,10 @@ test "hstack element primitive" {
 }
 
 test "vstack element primitive" {
-    const v = vstack(.{ .gap = 12, .alignment = .center }, .{});
+    const v = vstack(.{ .gap = 12, .alignment = .{ .cross = .center } }, .{});
     try std.testing.expectEqual(PrimitiveType.vstack, @TypeOf(v).primitive_type);
     try std.testing.expectEqual(@as(f32, 12), v.style.gap);
-    try std.testing.expectEqual(styles.StackStyle.Alignment.center, v.style.alignment);
+    try std.testing.expectEqual(styles.Box.Alignment{ .cross = .center }, v.style.alignment);
 }
 
 test "scroll element primitive" {
@@ -636,10 +636,10 @@ test "hstackTracked with source location" {
 
 test "vstackTracked with source location" {
     const src = @src();
-    const v = vstackTracked(.{ .gap = 24, .alignment = .end }, .{}, src);
+    const v = vstackTracked(.{ .gap = 24, .alignment = .{ .cross = .end } }, .{}, src);
     try std.testing.expectEqual(PrimitiveType.vstack, @TypeOf(v).primitive_type);
     try std.testing.expectEqual(@as(f32, 24), v.style.gap);
-    try std.testing.expectEqual(styles.StackStyle.Alignment.end, v.style.alignment);
+    try std.testing.expectEqual(styles.Box.Alignment{ .cross = .end }, v.style.alignment);
     try std.testing.expectEqualStrings("primitives.zig", v.source_loc.file[v.source_loc.file.len - 14 ..]);
 }
 

--- a/src/ui/styles.zig
+++ b/src/ui/styles.zig
@@ -438,17 +438,21 @@ pub const CodeEditorStyle = struct {
 // =============================================================================
 
 /// Stack layout options
+///
+/// A stack is a `Box` with a fixed `.direction`, so it shares `Box`'s
+/// alignment and padding types. This makes a stack a clean subset of box
+/// (and a superset: main-axis distribution is now available on stacks too).
+/// The `.{}` default (main=start, cross=start) preserves prior behavior,
+/// where stack alignment only affected the cross axis.
 pub const StackStyle = struct {
     gap: f32 = 0,
-    alignment: Alignment = .start,
-    padding: f32 = 0,
-
-    pub const Alignment = enum { start, center, end, stretch };
+    alignment: Box.Alignment = .{},
+    padding: Box.PaddingValue = .{ .all = 0 },
 };
 
 /// Center container options
 pub const CenterStyle = struct {
-    padding: f32 = 0,
+    padding: Box.PaddingValue = .{ .all = 0 },
 };
 
 /// Scroll container options
@@ -469,7 +473,10 @@ pub const ScrollStyle = struct {
 
     /// Padding inside the scroll area
     padding: Box.PaddingValue = .{ .all = 0 },
-    gap: u16 = 0,
+    /// Gap between children, in pixels. `f32` to match `Box.gap` and
+    /// `StackStyle.gap`; converted to the layout engine's integer
+    /// `child_gap` at the point of use.
+    gap: f32 = 0,
     background: ?Color = null,
     corner_radius: f32 = 0,
     /// Scrollbar styling


### PR DESCRIPTION
Resolves the **highest-leverage** P1 item, "Unify `.alignment` shape + `gap`/`padding` types" from `docs/api-design-review.md` (Theme 1).

## Problem
`.alignment`, `gap`, and `padding` drifted in both shape and type across containers:
- `.alignment` was **three different types** — a `{main, cross}` struct on `box`, a single-axis enum on stacks, a third enum on `text`.
- `gap` was `f32` on box/stack but `u16` on scroll.
- `padding` was a `PaddingValue` union on box/scroll but a bare `f32` on stack/center.

The nastiest trap: refactoring a `vstack` into a `box` (required the moment you want a background) produced a compile error on the alignment field that "was already correct."

## Change
Make hstack/vstack/center/scroll a clean, mechanical subset of `box`:
- `StackStyle.alignment`: own `enum{start,center,end,stretch}` → **`Box.Alignment`** struct. Stacks fix their direction, so the old single-axis value maps to `.cross`; the struct also unlocks main-axis distribution on stacks. Default `.{}` preserves prior behavior.
- `StackStyle.padding` and `CenterStyle.padding`: `f32` → **`Box.PaddingValue`** (per-side padding now possible on stacks).
- `ScrollStyle.gap`: `u16` → **`f32`** (matches `Box.gap`/`StackStyle.gap`), converted to the engine's integer `child_gap` at point of use, exactly as `box` does.

The builder now forwards `style.alignment`/`style.padding` straight through instead of re-wrapping. `box` and `text` alignment are untouched.

## Call-site migration
78 stack alignment sites migrated `.alignment = .center` → `.alignment = .{ .cross = .center }` across 16 examples + `readme.md` + `primitives.zig` unit tests. No `center` call passed a scalar padding, so the new default sufficed.

## Validation
`zig build` and `zig build test` both exit 0 (155/155 lib tests pass).

---
Part of the P1 consistency pass (3 PRs). This one has the widest example blast radius, so I'd suggest **merging it last** of the three to absorb conflicts once, rather than rebasing it repeatedly.