### PR TITLE
input: name keypad, punctuation, and f13–f20 keycodes

### DIFF
--- a/src/input/events.zig
+++ b/src/input/events.zig
@@ -43,6 +43,22 @@ pub const KeyCode = enum(u16) {
     @"9" = 0x19,
     @"0" = 0x1D,
 
+    // Punctuation. Keycodes are positional (US ANSI layout); on other layouts
+    // the physical key at this position may produce a different character, so
+    // consumers that care about the typed character must use the event's
+    // `characters_ignoring_modifiers` instead of these names.
+    minus = 0x1B,
+    equal = 0x18,
+    left_bracket = 0x21,
+    right_bracket = 0x1E,
+    backslash = 0x2A,
+    semicolon = 0x29,
+    quote = 0x27,
+    comma = 0x2B,
+    period = 0x2F,
+    slash = 0x2C,
+    grave = 0x32,
+
     // Special
     @"return" = 0x24,
     tab = 0x30,
@@ -50,6 +66,27 @@ pub const KeyCode = enum(u16) {
     delete = 0x33,
     escape = 0x35,
     forward_delete = 0x75,
+
+    // Keypad (kVK_ANSI_Keypad*). Distinct from the number row so terminal
+    // emulators and games can honor application keypad mode (DECKPAM).
+    keypad_0 = 0x52,
+    keypad_1 = 0x53,
+    keypad_2 = 0x54,
+    keypad_3 = 0x55,
+    keypad_4 = 0x56,
+    keypad_5 = 0x57,
+    keypad_6 = 0x58,
+    keypad_7 = 0x59,
+    keypad_8 = 0x5B,
+    keypad_9 = 0x5C,
+    keypad_decimal = 0x41,
+    keypad_multiply = 0x43,
+    keypad_plus = 0x45,
+    keypad_clear = 0x47, // NumLock position on PC keyboards
+    keypad_divide = 0x4B,
+    keypad_enter = 0x4C,
+    keypad_minus = 0x4E,
+    keypad_equals = 0x51,
 
     // Modifiers
     command = 0x37,
@@ -81,6 +118,14 @@ pub const KeyCode = enum(u16) {
     f10 = 0x6D,
     f11 = 0x67,
     f12 = 0x6F,
+    f13 = 0x69,
+    f14 = 0x6B,
+    f15 = 0x71,
+    f16 = 0x6A,
+    f17 = 0x40,
+    f18 = 0x4F,
+    f19 = 0x50,
+    f20 = 0x5A,
 
     // Navigation
     home = 0x73,
@@ -178,3 +223,37 @@ pub const InputEvent = union(enum) {
     /// All active touch points on the surface were cancelled by the compositor.
     touch_cancelled,
 };
+
+// Goal: `KeyCode.from` must resolve every named virtual keycode to its tag and
+// collapse only genuinely unnamed codes to `.unknown`. Keypad, punctuation,
+// and extended function keys were historically absent from the enum and were
+// destroyed here before any consumer could see them; these cases pin the fix.
+test "KeyCode.from resolves named codes and collapses unnamed ones" {
+    const testing = std.testing;
+
+    // Writing keys, one per historical group.
+    try testing.expectEqual(KeyCode.a, KeyCode.from(0x00));
+    try testing.expectEqual(KeyCode.@"5", KeyCode.from(0x17));
+    try testing.expectEqual(KeyCode.@"return", KeyCode.from(0x24));
+
+    // Punctuation (kVK_ANSI_*).
+    try testing.expectEqual(KeyCode.minus, KeyCode.from(0x1B));
+    try testing.expectEqual(KeyCode.left_bracket, KeyCode.from(0x21));
+    try testing.expectEqual(KeyCode.grave, KeyCode.from(0x32));
+
+    // Keypad. KeypadEnter (0x4C) is the key regression case: it produces no
+    // printable text, so collapsing it to `.unknown` drops the keystroke.
+    try testing.expectEqual(KeyCode.keypad_enter, KeyCode.from(0x4C));
+    try testing.expectEqual(KeyCode.keypad_0, KeyCode.from(0x52));
+    try testing.expectEqual(KeyCode.keypad_9, KeyCode.from(0x5C));
+    try testing.expectEqual(KeyCode.keypad_clear, KeyCode.from(0x47));
+
+    // Extended function keys.
+    try testing.expectEqual(KeyCode.f13, KeyCode.from(0x69));
+    try testing.expectEqual(KeyCode.f20, KeyCode.from(0x5A));
+
+    // Negative space: codes with no name still collapse to `.unknown`.
+    try testing.expectEqual(KeyCode.unknown, KeyCode.from(0x42)); // gap in kVK table
+    try testing.expectEqual(KeyCode.unknown, KeyCode.from(0xFFFF));
+    try testing.expectEqual(KeyCode.unknown, KeyCode.from(0x1234));
+}

--- a/src/platform/linux/input.zig
+++ b/src/platform/linux/input.zig
@@ -28,6 +28,14 @@ pub const evdev = struct {
     pub const KEY_F10: u32 = 68;
     pub const KEY_F11: u32 = 87;
     pub const KEY_F12: u32 = 88;
+    pub const KEY_F13: u32 = 183;
+    pub const KEY_F14: u32 = 184;
+    pub const KEY_F15: u32 = 185;
+    pub const KEY_F16: u32 = 186;
+    pub const KEY_F17: u32 = 187;
+    pub const KEY_F18: u32 = 188;
+    pub const KEY_F19: u32 = 189;
+    pub const KEY_F20: u32 = 190;
 
     // Number row
     pub const KEY_1: u32 = 2;
@@ -115,6 +123,26 @@ pub const evdev = struct {
     pub const KEY_COMMA: u32 = 51; // , <
     pub const KEY_DOT: u32 = 52; // . >
     pub const KEY_SLASH: u32 = 53; // / ?
+
+    // Keypad
+    pub const KEY_NUMLOCK: u32 = 69;
+    pub const KEY_KPASTERISK: u32 = 55;
+    pub const KEY_KP7: u32 = 71;
+    pub const KEY_KP8: u32 = 72;
+    pub const KEY_KP9: u32 = 73;
+    pub const KEY_KPMINUS: u32 = 74;
+    pub const KEY_KP4: u32 = 75;
+    pub const KEY_KP5: u32 = 76;
+    pub const KEY_KP6: u32 = 77;
+    pub const KEY_KPPLUS: u32 = 78;
+    pub const KEY_KP1: u32 = 79;
+    pub const KEY_KP2: u32 = 80;
+    pub const KEY_KP3: u32 = 81;
+    pub const KEY_KP0: u32 = 82;
+    pub const KEY_KPDOT: u32 = 83;
+    pub const KEY_KPENTER: u32 = 96;
+    pub const KEY_KPSLASH: u32 = 98;
+    pub const KEY_KPEQUAL: u32 = 117;
 };
 
 // =============================================================================
@@ -284,6 +312,49 @@ pub fn evdevToKeyCode(evdev_key: u32) input.KeyCode {
         evdev.KEY_F10 => .f10,
         evdev.KEY_F11 => .f11,
         evdev.KEY_F12 => .f12,
+        evdev.KEY_F13 => .f13,
+        evdev.KEY_F14 => .f14,
+        evdev.KEY_F15 => .f15,
+        evdev.KEY_F16 => .f16,
+        evdev.KEY_F17 => .f17,
+        evdev.KEY_F18 => .f18,
+        evdev.KEY_F19 => .f19,
+        evdev.KEY_F20 => .f20,
+
+        // Punctuation. KeyCode names are positional (US ANSI); text input goes
+        // through the layout-aware path, so positional names are fine here.
+        evdev.KEY_MINUS => .minus,
+        evdev.KEY_EQUAL => .equal,
+        evdev.KEY_LEFTBRACE => .left_bracket,
+        evdev.KEY_RIGHTBRACE => .right_bracket,
+        evdev.KEY_BACKSLASH => .backslash,
+        evdev.KEY_SEMICOLON => .semicolon,
+        evdev.KEY_APOSTROPHE => .quote,
+        evdev.KEY_COMMA => .comma,
+        evdev.KEY_DOT => .period,
+        evdev.KEY_SLASH => .slash,
+        evdev.KEY_GRAVE => .grave,
+
+        // Keypad. NumLock maps to keypad_clear: same physical position, and
+        // macOS keyboards have no NumLock key to name it after.
+        evdev.KEY_KP0 => .keypad_0,
+        evdev.KEY_KP1 => .keypad_1,
+        evdev.KEY_KP2 => .keypad_2,
+        evdev.KEY_KP3 => .keypad_3,
+        evdev.KEY_KP4 => .keypad_4,
+        evdev.KEY_KP5 => .keypad_5,
+        evdev.KEY_KP6 => .keypad_6,
+        evdev.KEY_KP7 => .keypad_7,
+        evdev.KEY_KP8 => .keypad_8,
+        evdev.KEY_KP9 => .keypad_9,
+        evdev.KEY_KPDOT => .keypad_decimal,
+        evdev.KEY_KPASTERISK => .keypad_multiply,
+        evdev.KEY_KPPLUS => .keypad_plus,
+        evdev.KEY_KPMINUS => .keypad_minus,
+        evdev.KEY_KPSLASH => .keypad_divide,
+        evdev.KEY_KPENTER => .keypad_enter,
+        evdev.KEY_KPEQUAL => .keypad_equals,
+        evdev.KEY_NUMLOCK => .keypad_clear,
 
         // Modifiers
         evdev.KEY_LEFTSHIFT => .shift,
@@ -634,6 +705,12 @@ test "evdev to keycode mapping" {
     try testing.expectEqual(input.KeyCode.escape, evdevToKeyCode(evdev.KEY_ESC));
     try testing.expectEqual(input.KeyCode.left, evdevToKeyCode(evdev.KEY_LEFT));
     try testing.expectEqual(input.KeyCode.f1, evdevToKeyCode(evdev.KEY_F1));
+    try testing.expectEqual(input.KeyCode.f13, evdevToKeyCode(evdev.KEY_F13));
+    try testing.expectEqual(input.KeyCode.f20, evdevToKeyCode(evdev.KEY_F20));
+    try testing.expectEqual(input.KeyCode.left_bracket, evdevToKeyCode(evdev.KEY_LEFTBRACE));
+    try testing.expectEqual(input.KeyCode.keypad_enter, evdevToKeyCode(evdev.KEY_KPENTER));
+    try testing.expectEqual(input.KeyCode.keypad_5, evdevToKeyCode(evdev.KEY_KP5));
+    try testing.expectEqual(input.KeyCode.keypad_clear, evdevToKeyCode(evdev.KEY_NUMLOCK));
     try testing.expectEqual(input.KeyCode.unknown, evdevToKeyCode(9999));
 }
 


### PR DESCRIPTION
## Problem

`KeyCode.from()` collapses any code without a named tag to `.unknown`, and the enum only named ~60 of the ~120 macOS virtual keycodes. All punctuation, the entire keypad (0x41–0x5C), and f13–f20 were destroyed at the platform boundary before any consumer could see them.

Concrete downstream breakage (found in booey, gooey's terminal emulator consumer):

1. **Keypad Enter and f13–f20 are silently dropped.** They collapse to `.unknown` and produce no printable text (KeypadEnter's `charactersIgnoringModifiers` is `\x03`), so consumers have nothing to match on — the keystroke vanishes.
2. **Application keypad mode (DECKPAM) is unreachable.** Keypad digits arrive as `.unknown` and are only recoverable as *number-row* digits via their text, so terminal apps that enable DECKPAM (vim, emacs, TUIs) can never receive SS3 keypad sequences.
3. **Positional punctuation shortcuts can't be matched.** `performKeyEquivalent` events carry null `characters`, so Cmd+`[` style shortcuts had no keycode to compare against.

## Change

- **`src/input/events.zig`**: name the missing `kVK_ANSI_*` codes — punctuation (11), keypad (18, including `keypad_enter` 0x4C and `keypad_clear` 0x47), and f13–f20. Values cross-checked against Carbon's `Events.h` / Chromium's `dom_code_data.inc`. Punctuation names are positional (US ANSI); a doc comment directs layout-aware consumers to `characters_ignoring_modifiers`.
- **`src/platform/linux/input.zig`**: matching evdev constants and `evdevToKeyCode` arms so the new names are not macOS-only. evdev `KEY_NUMLOCK` maps to `keypad_clear` (same physical position; Apple keyboards have no NumLock).
- Tests: new `KeyCode.from` test covering each added group plus negative space (unnamed codes still collapse to `.unknown`), and extended evdev mapping assertions.

No behavior change for existing named keys; `from()`'s collapse logic is untouched — the enum just names more of the space.

## Validation

`zig build test --summary all`: 21/21 steps, 1173/1173 tests passed.