### PR TITLE
app,input,ui: terminal-embedding fixes (config forwarding, raw keys, canvas userdata, cap clamps)

### DIFF
--- a/docs/terminal-embedding-fixes.md
+++ b/docs/terminal-embedding-fixes.md
@@ -1,0 +1,228 @@
+# Gooey — Fixes Needed for Terminal Embedding
+
+Gaps in Gooey surfaced by `booey` (single-pane terminal prototype) and the
+Jenkins terminal-multiplexer research
+(`jenkins/docs/terminal-multiplexer-mvp.md`). Each item lists the evidence, the
+workaround currently living in booey, and the fix that belongs here.
+
+Status: **items 2, 3, 5, 6 landed; items 1, 4, 7 remaining.**
+Date: 2026-07-30.
+
+Done so far (build + `zig build test` green):
+
+- **Item 5** — `App` now forwards every `CxConfig` field and the
+  `init`/`on_init` name mismatch is fixed (native and WASM).
+- **Item 3** — `ui.canvas` gained a `*anyopaque` userdata slot
+  (`ui.canvasWithData`, surfaced as `DrawContext.user_data`).
+- **Item 2** — general raw-keys opt-out on the `Focusable` vtable
+  (`wantsRawKeys`); the CodeEditor Tab carve-out folded into it.
+- **Item 6** (partial) — the two pure-append pending pools
+  (`registerPendingCanvas`, `enqueuePendingTextWidget`) now clamp-and-warn
+  instead of silently growing in release. The broader audit
+  (`MAX_LAYOUT_ELEMENTS`, `MAX_RENDER_COMMANDS`, canvas draw-order blocks)
+  is still open — see item 6.
+
+---
+
+## 1. Bold and italic text are declared but not wired
+
+**Evidence.** `TextStyle` carries `weight` and `italic`
+(`src/ui/styles.zig:150`), but `builder.renderText` forwards only two of the
+four style flags (`src/ui/builder.zig:1232`):
+
+```zig
+.decoration = .{
+    .underline = txt.style.underline,
+    .strikethrough = txt.style.strikethrough,
+},
+```
+
+`weight` and `italic` have no path onward. `TextSystem` holds a single
+`current_face: ?PlatformFace` (`src/text/text_system.zig:504`) which
+`loadFont` replaces wholesale, clearing the glyph and shape caches — there is
+no face registry, so there is nothing for a weight to select. `.weight = .bold`
+renders identically to regular everywhere it appears today (`a11y_demo.zig`,
+`code_editor.zig`, `form_validation.zig`).
+
+**Booey workaround.** A 0.5 px double-draw (`booey/src/terminal.zig`,
+`drawGlyph` + `bold_overdraw_px`). It smears rather than embolds, and it costs
+a second glyph run per bold cell.
+
+**Fix.** Two seams already exist, so this is well-scoped:
+
+1. `TextData.font_id: u16` is already threaded from layout through to render
+   (`src/layout/render_commands.zig:86`, populated at
+   `src/layout/scroll_pass.zig:196`) — plumbed but never set meaningfully.
+2. `CoreTextFace.init(name, size)` loads any named face, so `"Menlo-Bold"` is
+   one call away; `initSystem(.monospace, size)` also exists.
+
+The work: a small fixed-capacity face registry in `TextSystem`
+(regular / bold / italic / bold-italic) replacing `current_face`; key the
+glyph and shape caches by `font_id` (the shape cache already keys on
+`font_ptr`, so this is close to free); map `weight >= .semibold` and `italic`
+to a `font_id` in `builder.renderText`.
+
+For monospace this is unusually safe: the bold face of a monospace family has
+identical advance width to the regular face, so the cell grid cannot shear.
+Proportional text would need re-measurement — out of scope.
+
+**Done when:** `.weight = .bold` visibly differs from regular in an existing
+example, and monospace cell advance is unchanged between faces.
+
+**Blocker found during scoping (2026-07-30).** The glyph cache (`GlyphKey`)
+and shape cache (`ShapedRunKey`) both already carry a `font_ptr`, so a face
+registry keyed by the _slot address_ gives correct cache separation for
+free — the easy part. But `ShapedRunCache.checkFont` wipes the **entire**
+shape cache whenever the incoming `font_ptr` differs from the last one
+(`text_system.zig:204`). It assumes single-font usage. With a 4-face
+registry, alternating regular/bold runs (a code editor with bold keywords, a
+terminal with bold cells) would clear the whole shape cache on every switch —
+catastrophic thrashing for all text, not just bold. A correct item 1 therefore
+needs the shape cache to hold multiple faces concurrently: drop the
+wipe-on-change heuristic and add a per-face generation counter to the key so
+font _reload_ still invalidates (reload reuses the same slot address, so the
+bare `font_ptr` cannot distinguish stale entries). That is a deliberate change
+to the hottest path and is the real work here — the plumbing
+(`builder.renderText` weight/italic → `font_id`; `font_id` through
+`shapeTextInto` / `resolveGlyphBatch` / `text/render.renderText`; the
+`measureTextCallback` already receives `font_id` and ignores it) is
+mechanical by comparison. Native (CoreText) can derive variants via
+`CTFontCreateCopyWithSymbolicTraits`; Linux/Web should store null variants and
+fall back to the regular face (renders as today — no regression) until their
+backends grow variant support.
+
+## 2. Tab is unconditionally consumed by focus traversal
+
+**Evidence.** `handleKeyDownEvent` (`src/runtime/input.zig:615-636`)
+intercepts Tab / Shift-Tab for focus navigation before the app-level
+`on_event` hook runs. This breaks shell tab-completion — unacceptable for a
+terminal. `CodeEditor` already carves out a special case here (it wants Tab
+for indentation), so there is precedent, but it is hard-coded to that one
+widget.
+
+**Booey workaround.** The most invasive hack in booey: `captureRawKeys`
+(`booey/src/terminal.zig:362`) swaps `platform_window.on_input` behind Gooey's
+back, chains the original callback, and reaches the widget through a
+`raw_key_owner` module global because the filter is a bare function pointer
+with no userdata slot. It works for exactly one window and one widget, and it
+depends on an internal field Gooey never promised to keep stable.
+
+**Fix.** A general "this focusable takes raw keys" opt-out on the `Focusable`
+vtable, checked before the Tab arm in `handleKeyDownEvent`, rather than a
+second hard-coded widget case next to `focusedCodeEditor`. Fold the existing
+CodeEditor carve-out into the same mechanism so there is one rule, not two
+special cases. (This is the Jenkins doc's open question §7.1 — resolving it
+here unblocks both projects.)
+
+## 3. `ui.canvas` has no userdata slot
+
+**Evidence.** `ui.canvas` takes a bare `*const fn (*DrawContext) void`. Any
+stateful canvas must reach its state through a module global —
+`booey/src/main.zig:12` (`var term: Terminal = .{}`) exists only for this
+reason. Workable for one pane, unusable for N.
+
+**Fix (preferred).** Don't patch canvas; supersede it for grid-shaped content
+with a `cellGrid` primitive (item 4). If canvas is kept for ad-hoc drawing, a
+`*anyopaque` userdata parameter is a cheap independent improvement.
+
+## 4. No cell-grid primitive; composition and canvas both hit caps
+
+**Evidence.** The two existing ways to paint a terminal-sized grid both fail
+at scale:
+
+- One `ui.text` per attribute-run: `MAX_LAYOUT_ELEMENTS = 4096`
+  (`src/core/limits.zig:80`). A full-colour 80×24 pane is 1920 runs; four
+  panes is 7680 elements, ~1.9× over the cap.
+- `ui.canvas`: reserves a fixed block of 256 draw orders each
+  (`src/runtime/frame.zig:272`), which thousands of glyphs overrun; plus
+  item 3.
+
+**Fix.** A VT-agnostic `cellGrid` primitive following the `ui.codeEditor`
+pattern: a `Builder.PendingCellGrid` that participates in layout,
+`frame.zig::renderCellGrid` painting straight into the scene (bounded by
+`MAX_GLYPHS_PER_FRAME` / `MAX_QUADS_PER_FRAME` = 65536, not the layout cap),
+per-instance state via `window.element_states.get(State, layout_id.id)`, and
+a `Focusable` implementation. Paint all background quads first, then glyph
+runs, so the batch iterator coalesces into ~2 GPU batches.
+
+Gooey must not depend on ghostty: the grid speaks
+`{codepoint(s), fg, bg, flags}` plus a cursor and knows nothing about escape
+sequences. Reusable for hex viewers, log tailers, sparkline grids.
+
+Full design: `jenkins/docs/terminal-multiplexer-mvp.md` §3 and §6 Slice 1.
+
+## 5. `gooey.App` drops config options that `runCx` supports
+
+**Evidence.** `App.main` (`src/app.zig:107-127`) forwards a hard-coded subset
+of fields to `runCx`: title, width, height, background_color, on_init,
+on_event, custom_shaders, the glass options, font, and font_size. `CxConfig`
+also has `on_close`, `on_resize`, `min_size`, `centered`, and `io` — silently
+ignored if passed. Booey needs `on_close` (to hand the keyboard back and close
+the pty before the window dies) and had to bypass `App` entirely and call
+`gooey.run(...)` directly (`booey/src/main.zig:16-18`).
+
+Note `on_init` also has a field-name mismatch: `App` reads `config.init`
+(`src/app.zig:113`) while `runCx` calls it `on_init` — callers of `App` who
+write `.on_init = ...` get it silently dropped too.
+
+**Fix.** Forward every `CxConfig` field with the same
+`@hasField`-with-default pattern, or better: accept a `CxConfig` directly and
+delete the field-by-field copy so the two can never drift again. Fix the
+`init`/`on_init` name mismatch while there.
+
+## 6. Capacity enforcement is Debug-only
+
+**Evidence.** The caps in `src/core/limits.zig` (`MAX_LAYOUT_ELEMENTS`,
+`MAX_RENDER_COMMANDS`, canvas draw-order blocks, …) are enforced by
+assertions only: Debug panics at the cap, release builds silently grow past
+it. This contradicts the project's own "put a limit on everything / fail
+fast" rule (`CLAUDE.md` §4) — the limit exists but the negative space is
+unhandled in release.
+
+**Fix.** On overflow in release, clamp and surface the condition (log once
+per frame, or a debug-overlay counter) rather than growing silently.
+Terminal-grid workloads are exactly the ones that will find these caps first.
+
+**Progress (2026-07-30).** The two pure-append builder pools now clamp and
+`std.log.warn` (matching the `Window.deferCommand` precedent):
+`registerPendingCanvas` and `enqueuePendingTextWidget`. Still open, and
+trickier because they are on hot paths or coupled to index bookkeeping:
+
+- `MAX_LAYOUT_ELEMENTS` (4096) is **defined but never referenced** —
+  `ElementList` is a growing `std.ArrayList` with no cap check at all. Adding
+  enforcement must be careful not to break legitimately-large UIs.
+- `MAX_RENDER_COMMANDS` is only `std.debug.assert`-guarded in `frame.zig`
+  (and the local constant there is 65536, not the 8192 in `limits.zig` —
+  reconcile these).
+- The index-coupled pending pools (`pending_inputs`, `pending_text_areas`,
+  `pending_code_editors`, `pending_scrolls`) capture `len` as an index before
+  appending, so a naive early-return would desync the follow-up
+  `enqueuePendingTextWidget` index. Clamp by skipping the append _and_ the
+  matching enqueue together.
+
+## 7. Lower priority: multiplexer conveniences
+
+Not blocking booey; needed by Jenkins Slice 3+.
+
+- **Weighted grow.** `Box.grow` is a bool (confirmed by the in-tree comment
+  at `src/layout/benchmarks.zig:481`). A 2:1 split needs `width_percent` or
+  explicit pixels. A numeric grow factor would make split trees natural.
+  Note (2026-07-30): `Box.width_percent` / `height_percent` already exist and
+  are wired through to `SizingAxis.percent` (`builder.zig:659`), so a 2:1
+  split is expressible **today** as `width_percent = 0.667 / 0.333`. The
+  remaining ask is ergonomic — a numeric `grow` factor for natural split
+  trees — not a capability gap.
+- **Splitter widget.** No resizable-divider exists; drag-to-resize must be
+  hand-built from a thin `ui.box` plus mouse events.
+
+---
+
+## Suggested order
+
+1. Item 5 (`App` forwarding) — smallest, immediately deletes booey's
+   `gooey.run` workaround.
+2. Item 1 (bold/italic) — independently valuable, makes existing examples
+   honest. Jenkins Slice 0.
+3. Items 2 + 4 together (raw-keys opt-out + `cellGrid`) — Jenkins Slice 1;
+   deletes booey's two module globals and the input-callback swap.
+4. Items 3, 6, 7 as they come up.

--- a/src/app.zig
+++ b/src/app.zig
@@ -105,25 +105,38 @@ pub fn App(
             // other field in the `.{...}` config literal below is
             // identical to the pre-7d-framework shape.
             pub fn main(init: std.process.Init) !void {
-                try runCx(State, state, render, .{
-                    .title = if (@hasField(@TypeOf(config), "title")) config.title else "Window App",
-                    .width = if (@hasField(@TypeOf(config), "width")) config.width else 800,
-                    .height = if (@hasField(@TypeOf(config), "height")) config.height else 600,
-                    .background_color = if (@hasField(@TypeOf(config), "background_color")) config.background_color else null,
-                    .on_init = if (@hasField(@TypeOf(config), "init")) config.init else null,
-                    .on_event = if (@hasField(@TypeOf(config), "on_event")) config.on_event else null,
-                    // Custom shaders (cross-platform - MSL for macOS, WGSL for web)
-                    .custom_shaders = if (@hasField(@TypeOf(config), "custom_shaders")) coerceShaders(config.custom_shaders) else &.{},
-                    // Glass/transparency options
-                    .background_opacity = if (@hasField(@TypeOf(config), "background_opacity")) config.background_opacity else 1.0,
-                    .glass_style = if (@hasField(@TypeOf(config), "glass_style")) config.glass_style else .none,
-                    .glass_corner_radius = if (@hasField(@TypeOf(config), "glass_corner_radius")) config.glass_corner_radius else 16.0,
-                    .titlebar_transparent = if (@hasField(@TypeOf(config), "titlebar_transparent")) config.titlebar_transparent else false,
-                    .full_size_content = if (@hasField(@TypeOf(config), "full_size_content")) config.full_size_content else false,
-                    // Font configuration
-                    .font = if (@hasField(@TypeOf(config), "font")) config.font else null,
-                    .font_size = if (@hasField(@TypeOf(config), "font_size")) config.font_size else 16.0,
-                }, init);
+                // Build a fully-defaulted `CxConfig(State)` and overwrite only
+                // the fields the caller supplied. Enumerating every `CxConfig`
+                // field (rather than a hand-picked subset) means `App` and
+                // `runCx` can never silently drift: a new `CxConfig` field is
+                // forwarded here for free, and callers no longer have to fall
+                // back to `gooey.run(...)` just to reach `on_close`,
+                // `on_resize`, `min_size`, `max_size`, `centered`, or `io`.
+                var cfg: runtime.CxConfig(State) = .{};
+                const ConfigType = @TypeOf(config);
+                inline for (@typeInfo(runtime.CxConfig(State)).@"struct".fields) |field| {
+                    // `on_init` and `custom_shaders` need special handling
+                    // (name mismatch / MSL-vs-WGSL coercion); everything else
+                    // is a straight copy when the caller provided it.
+                    if (comptime std.mem.eql(u8, field.name, "on_init")) {
+                        // Historically `App` read `config.init` while `runCx`
+                        // calls the field `on_init`, so `.on_init = ...` on an
+                        // `App` config was silently dropped. Accept both spellings
+                        // now, preferring the canonical `on_init`.
+                        if (@hasField(ConfigType, "on_init")) {
+                            cfg.on_init = config.on_init;
+                        } else if (@hasField(ConfigType, "init")) {
+                            cfg.on_init = config.init;
+                        }
+                    } else if (comptime std.mem.eql(u8, field.name, "custom_shaders")) {
+                        if (@hasField(ConfigType, "custom_shaders")) {
+                            cfg.custom_shaders = coerceShaders(config.custom_shaders);
+                        }
+                    } else if (@hasField(ConfigType, field.name)) {
+                        @field(cfg, field.name) = @field(config, field.name);
+                    }
+                }
+                try runCx(State, state, render, cfg, init);
             }
         };
     }
@@ -196,7 +209,12 @@ pub fn WebApp(
         else
             null;
 
-        const on_init: ?*const fn (*Cx) void = if (@hasField(@TypeOf(config), "init"))
+        // Accept both `on_init` (canonical, matches `CxConfig`) and the
+        // legacy `init` spelling so `.on_init = ...` is no longer silently
+        // dropped on the WASM path either (mirrors the native fix).
+        const on_init: ?*const fn (*Cx) void = if (@hasField(@TypeOf(config), "on_init"))
+            config.on_init
+        else if (@hasField(@TypeOf(config), "init"))
             config.init
         else
             null;

--- a/src/context/focus.zig
+++ b/src/context/focus.zig
@@ -107,6 +107,15 @@ pub const Focusable = struct {
         /// `CodeEditorState` delegates to its embedded `TextArea` and
         /// cannot promise const access). The thunk does not mutate.
         is_focused: *const fn (ptr: *anyopaque) bool,
+        /// Whether this widget consumes the keyboard-navigation keys
+        /// (currently Tab / Shift-Tab) itself rather than yielding them to
+        /// the framework's focus traversal. Widgets that want raw keys —
+        /// `CodeEditor` (Tab indents), a terminal grid (Tab is shell
+        /// completion, Shift-Tab is back-tab) — return true so
+        /// `handleKeyDownEvent` stops stealing Tab for focus movement and
+        /// lets the key reach the widget and the app `on_event` hook.
+        /// Defaults to "no" for the vast majority of focusables.
+        wants_raw_keys: *const fn (ptr: *anyopaque) bool,
     };
 
     /// Call the widget's `focus()` method through the vtable.
@@ -122,6 +131,13 @@ pub const Focusable = struct {
     /// Read the widget's focused flag through the vtable.
     pub fn isFocused(self: Focusable) bool {
         return self.vtable.is_focused(self.ptr);
+    }
+
+    /// Whether the widget wants raw keyboard-navigation keys (see
+    /// `VTable.wants_raw_keys`). Read through the vtable so `runtime/input`
+    /// can consult it without importing widget types.
+    pub fn wantsRawKeys(self: Focusable) bool {
+        return self.vtable.wants_raw_keys(self.ptr);
     }
 
     /// Pointer-equality identity. Two `Focusable`s refer to the same
@@ -162,6 +178,17 @@ pub const Focusable = struct {
                 const self: *T = @ptrCast(@alignCast(ptr));
                 return self.isFocused();
             }
+            // Opt-in: a widget that wants raw navigation keys declares
+            // `pub fn wantsRawKeys(self: *T) bool`. Widgets that don't
+            // (the common case) get a constant-false thunk, so the trait
+            // shape stays a three-method contract for everyone else.
+            fn wantsRawKeysFn(ptr: *anyopaque) bool {
+                if (comptime @hasDecl(T, "wantsRawKeys")) {
+                    const self: *T = @ptrCast(@alignCast(ptr));
+                    return self.wantsRawKeys();
+                }
+                return false;
+            }
         };
 
         // One vtable per `T`, in `comptime` static storage.
@@ -169,6 +196,7 @@ pub const Focusable = struct {
             .focus = Thunks.focusFn,
             .blur = Thunks.blurFn,
             .is_focused = Thunks.isFocusedFn,
+            .wants_raw_keys = Thunks.wantsRawKeysFn,
         };
 
         return .{ .ptr = instance, .vtable = vtable };
@@ -545,6 +573,14 @@ pub const FocusManager = struct {
     /// Get the currently focused element's ID
     pub fn getFocused(self: *const Self) ?FocusId {
         return self.focused;
+    }
+
+    /// Get the `Focusable` vtable of the currently focused widget, if the
+    /// focused element has an associated widget instance. Backed by the
+    /// cached `focused_widget` (stable across frames), so it works even
+    /// when the handle has momentarily fallen out of `focus_order`.
+    pub fn getFocusedWidget(self: *const Self) ?Focusable {
+        return self.focused_widget;
     }
 
     /// Get the currently focused element's handle (if registered this frame)

--- a/src/runtime/input.zig
+++ b/src/runtime/input.zig
@@ -82,6 +82,15 @@ pub fn focusedCodeEditor(window: *Window, builder: *const Builder) ?*CodeEditorS
     return null;
 }
 
+/// Whether the currently focused widget opts into raw keyboard-navigation
+/// keys (Tab / Shift-Tab). Consulted before focus traversal so terminals,
+/// grids, and CodeEditors can consume Tab themselves. Type-erased through
+/// the `Focusable` vtable — `runtime/input` never learns the widget type.
+fn focusedWidgetWantsRawKeys(window: *Window) bool {
+    const focusable = window.focus.getFocusedWidget() orelse return false;
+    return focusable.wantsRawKeys();
+}
+
 // =============================================================================
 // Main Entry Point
 // =============================================================================
@@ -614,27 +623,28 @@ fn handleKeyDownEvent(cx: *Cx, window: *Window, k: input_mod.KeyEvent) bool {
         return true;
     }
 
-    // Tab navigation - but let CodeEditor handle Tab for indentation.
-    // The `builder` borrow is shared across the arms below so each pending-list
-    // walk is paid for at most once per key event.
+    // Tab navigation. A focused widget can opt out of focus traversal via
+    // the `Focusable` vtable (`wantsRawKeys`) so it receives Tab itself:
+    // CodeEditor indents, a terminal grid forwards Tab for shell completion
+    // and Shift-Tab as back-tab. This is one general rule rather than a
+    // hard-coded per-widget branch — the CodeEditor case folds into it
+    // (`CodeEditorState.wantsRawKeys` returns true), and Tab then falls
+    // through to the CodeEditor key arm below (Tab is a control key) or,
+    // for non-widget focusables, on to the app `on_event` hook.
+    // The `builder` borrow is shared across the arms below so each
+    // pending-list walk is paid for at most once per key event.
     const builder = cx.builder();
     if (k.key == .tab) {
-        // CodeEditor intercepts Tab for indentation (not focus navigation)
-        if (focusedCodeEditor(window, builder)) |ce| {
-            if (!k.modifiers.shift and !k.modifiers.ctrl and !k.modifiers.alt) {
-                _ = ce.handleKey(k.key, k.modifiers);
-                syncCodeEditorBoundVariablesCx(cx);
-                cx.notify();
-                return true;
-            }
-        }
-        // Default: use Tab for focus navigation
-        if (k.modifiers.shift) {
-            window.focusPrev();
+        if (focusedWidgetWantsRawKeys(window)) {
+            // Do not consume Tab: let it reach the widget / app.
         } else {
-            window.focusNext();
+            if (k.modifiers.shift) {
+                window.focusPrev();
+            } else {
+                window.focusNext();
+            }
+            return true;
         }
-        return true;
     }
 
     // Try action dispatch through focus path

--- a/src/ui/builder.zig
+++ b/src/ui/builder.zig
@@ -321,7 +321,16 @@ pub const Builder = struct {
     /// landed, so the index always resolves to a live slot later.
     fn enqueuePendingTextWidget(self: *Self, kind: TextWidgetKind, index: usize) void {
         std.debug.assert(index <= std.math.maxInt(u32));
-        std.debug.assert(self.pending_text_widgets.items.len < MAX_PENDING_TEXT_WIDGETS);
+        // Clamp-and-report rather than silently growing past the cap in release
+        // (CLAUDE.md §4: put a limit on everything / fail fast). A Debug assert
+        // alone let release builds grow the backing ArrayList unbounded.
+        if (self.pending_text_widgets.items.len >= MAX_PENDING_TEXT_WIDGETS) {
+            std.log.warn(
+                "pending text-widget queue limit ({d}) reached - dropping widget",
+                .{MAX_PENDING_TEXT_WIDGETS},
+            );
+            return;
+        }
         self.pending_text_widgets.append(self.allocator, .{
             .kind = kind,
             .index = @intCast(index),
@@ -334,7 +343,17 @@ pub const Builder = struct {
 
     /// Register a pending canvas for deferred rendering after layout.
     pub fn registerPendingCanvas(self: *Self, pending: canvas_mod.PendingCanvas) void {
-        std.debug.assert(self.pending_canvas.items.len < MAX_PENDING_CANVAS);
+        // Clamp-and-report rather than silently growing past the cap in release
+        // (CLAUDE.md §4). Terminal-grid / multi-pane workloads are the ones most
+        // likely to find this cap, so surface it instead of leaking frames into
+        // an unbounded ArrayList.
+        if (self.pending_canvas.items.len >= MAX_PENDING_CANVAS) {
+            std.log.warn(
+                "pending canvas limit ({d}) reached - dropping canvas",
+                .{MAX_PENDING_CANVAS},
+            );
+            return;
+        }
         self.pending_canvas.append(self.allocator, pending) catch {};
     }
 

--- a/src/ui/canvas.zig
+++ b/src/ui/canvas.zig
@@ -109,6 +109,11 @@ pub const PendingCanvas = struct {
     base_order: scene_mod.DrawOrder = 0,
     /// Clip bounds captured at layout time
     clip_bounds: scene_mod.ContentMask.ClipBounds = scene_mod.ContentMask.none.bounds,
+    /// Opaque state pointer forwarded to `DrawContext.user_data`. Lets a
+    /// stateful canvas reach its own state without a module global — the
+    /// paint callback keeps the bare `*DrawContext` signature and reads
+    /// `ctx.user_data`. Null for stateless canvases.
+    user_data: ?*anyopaque = null,
 };
 
 // =============================================================================
@@ -131,6 +136,12 @@ pub const DrawContext = struct {
     clip_bounds: scene_mod.ContentMask.ClipBounds = scene_mod.ContentMask.none.bounds,
     /// Current draw order (increments with each primitive)
     current_order: scene_mod.DrawOrder = 0,
+    /// Opaque state pointer supplied at canvas construction. A stateful
+    /// canvas recovers its state with
+    /// `@as(*T, @ptrCast(@alignCast(ctx.user_data.?)))`, so N independent
+    /// canvases no longer have to share one module global. Null when the
+    /// canvas was created without state.
+    user_data: ?*anyopaque = null,
 
     const Self = @This();
 
@@ -1387,6 +1398,7 @@ pub fn executePendingCanvas(
         .base_order = pending.base_order,
         .clip_bounds = pending.clip_bounds,
         .current_order = pending.base_order,
+        .user_data = pending.user_data,
     };
     pending.paint(&ctx);
 }
@@ -1404,6 +1416,10 @@ pub const Canvas = struct {
     paint: *const fn (*DrawContext) void,
     /// Optional explicit ID (defaults to auto-generated)
     id: ?[]const u8 = null,
+    /// Optional opaque state pointer, surfaced to the paint callback as
+    /// `ctx.user_data`. Supply via `ui.canvasWithData` for stateful,
+    /// multi-instance canvases (e.g. one per terminal pane).
+    user_data: ?*anyopaque = null,
 
     const Self = @This();
 
@@ -1426,6 +1442,7 @@ pub const Canvas = struct {
             .layout_id = layout_id.id,
             .paint = self.paint,
             .scale = scale,
+            .user_data = self.user_data,
         });
 
         // Create a box to reserve space in layout - use same layout_id!
@@ -1458,6 +1475,33 @@ pub fn canvas(w: f32, h: f32, paint: *const fn (*DrawContext) void) Canvas {
         .width = w,
         .height = h,
         .paint = paint,
+    };
+}
+
+/// Create a stateful canvas: the paint callback receives its `state` pointer
+/// through `ctx.user_data`. This is the multi-instance-safe alternative to a
+/// module-global — each canvas carries its own state.
+///
+/// ## Example
+/// ```zig
+/// fn paintPane(ctx: *ui.DrawContext) void {
+///     const pane: *Pane = @ptrCast(@alignCast(ctx.user_data.?));
+///     pane.draw(ctx);
+/// }
+///
+/// ui.canvasWithData(w, h, paintPane, &my_pane).render(cx);
+/// ```
+pub fn canvasWithData(
+    w: f32,
+    h: f32,
+    paint: *const fn (*DrawContext) void,
+    user_data: ?*anyopaque,
+) Canvas {
+    return Canvas{
+        .width = w,
+        .height = h,
+        .paint = paint,
+        .user_data = user_data,
     };
 }
 

--- a/src/ui/mod.zig
+++ b/src/ui/mod.zig
@@ -58,6 +58,7 @@ pub const when = primitives.when;
 pub const maybe = primitives.maybe;
 pub const each = primitives.each;
 pub const canvas = canvas_mod.canvas;
+pub const canvasWithData = canvas_mod.canvasWithData;
 
 // Container element functions: return element structs for use with cx.render().
 pub const box = primitives.box;

--- a/src/widgets/code_editor_state.zig
+++ b/src/widgets/code_editor_state.zig
@@ -316,6 +316,17 @@ pub const CodeEditorState = struct {
         return self.text_area.isFocused();
     }
 
+    /// Opt into raw keyboard-navigation keys: a code editor consumes Tab
+    /// (indent) and Shift-Tab itself instead of yielding them to focus
+    /// traversal. Read through the `Focusable` vtable by `runtime/input`,
+    /// which folds the former hard-coded CodeEditor Tab carve-out into this
+    /// one general rule. Leaving a focused editor is done with Escape
+    /// (`handleKeyDownEvent` blurs focused text widgets on Escape).
+    pub fn wantsRawKeys(self: *Self) bool {
+        _ = self;
+        return true;
+    }
+
     /// Build a `Focusable` trait for this widget instance. Called by
     /// the UI builder during render so the framework can drive focus
     /// without importing the widget type — see PR 4 in


### PR DESCRIPTION
## What

Fixes four gaps surfaced by embedding a terminal in Gooey (booey prototype + Jenkins multiplexer research). Full catalogue with evidence and remaining scoped work: `docs/terminal-embedding-fixes.md` (included).

### Item 5 — `App` config forwarding (`src/app.zig`)
`App.main` forwarded a hand-picked subset of `CxConfig` fields, silently dropping `on_close`, `on_resize`, `min_size`, `max_size`, `centered`, and `io`. It now enumerates every `CxConfig(State)` field via `inline for`, so `App` and `runCx` can never drift. Also fixes the `init`/`on_init` name mismatch on both native and WASM paths (both spellings accepted, `on_init` preferred).

### Item 2 — raw-keys opt-out (`src/context/focus.zig`, `src/runtime/input.zig`)
Tab was unconditionally consumed by focus traversal, breaking shell tab-completion. The `Focusable` vtable gains `wantsRawKeys`, auto-detected from a widget's `pub fn wantsRawKeys` decl; `handleKeyDownEvent` consults the focused widget before stealing Tab. The hard-coded CodeEditor Tab carve-out folds into this one rule.

⚠️ **Behavior change:** Shift-Tab in a focused CodeEditor now reaches the editor instead of moving focus (Escape still blurs) — the unified rule terminals also need.

### Item 3 — canvas userdata (`src/ui/canvas.zig`)
`ui.canvas` paint callbacks had no userdata slot, forcing stateful canvases through module globals (one instance max). `Canvas` → `PendingCanvas` → `DrawContext` now carry an opaque `user_data` pointer; new `ui.canvasWithData(w, h, paint, ptr)` constructs a stateful canvas. `ui.canvas` unchanged.

### Item 6 (partial) — release-mode cap enforcement (`src/ui/builder.zig`)
`registerPendingCanvas` and `enqueuePendingTextWidget` were Debug-assert-only, so release builds grew past their caps silently. They now clamp-and-warn, matching the `Window.deferCommand` precedent (CLAUDE.md §4). Broader audit (`MAX_LAYOUT_ELEMENTS`, `MAX_RENDER_COMMANDS` mismatch, index-coupled pools) recorded as follow-up in the doc.

## Not in this PR (scoped, recorded in the doc)

- **Bold/italic faces** — blocked on `ShapedRunCache.checkFont` wiping the whole shape cache on any `font_ptr` change; needs per-face generation keys before a face registry is viable.
- **`cellGrid` primitive** — new widget, unblocked by the raw-keys work here.
- **Weighted grow / splitter** — `width_percent` already covers 2:1 splits today; remaining ask is ergonomic.

## Validation

`zig build` + `zig build test --summary all`: **1173/1173 tests pass.**

## Note

Stacked on #47 (shares the `code_editor_state.zig` dead-import removal). Base retargets to `main` when #47 merges.