### PR TITLE
Avoid stack-heavy native window initialization

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -624,7 +624,13 @@ pub fn build(b: *std.Build) void {
         // Link system libraries (Vulkan + Wayland + text rendering)
         linkLinuxLibraries(exe);
 
-        b.installArtifact(exe);
+        const install_showcase = b.addInstallArtifact(exe, .{});
+        b.getInstallStep().dependOn(&install_showcase.step);
+
+        // Keep preview builds focused: the default install step also builds
+        // every example, while this step installs only the showcase binary.
+        const showcase_step = b.step("showcase", "Build the showcase demo");
+        showcase_step.dependOn(&install_showcase.step);
 
         // Ensure shaders are compiled before building executables that @embedFile them
         // (only if shader compilation is enabled)
@@ -637,7 +643,6 @@ pub fn build(b: *std.Build) void {
         const run_cmd = b.addRunArtifact(exe);
         run_cmd.setCwd(b.path(".")); // Run from project root so assets/ can be found
         run_step.dependOn(&run_cmd.step);
-        run_cmd.step.dependOn(b.getInstallStep());
 
         if (b.args) |args| {
             run_cmd.addArgs(args);

--- a/src/runtime/window_context.zig
+++ b/src/runtime/window_context.zig
@@ -155,9 +155,9 @@ pub fn WindowContext(comptime State: type) type {
             // Initialize Window with owned resources (single-window mode).
             const window = try allocator.create(Window);
             errdefer allocator.destroy(window);
-            window.* = try Window.initOwned(allocator, platform_window, font_config, io);
+            try window.initOwnedPtr(allocator, platform_window, font_config, io);
             // Wire the borrowed `*App` onto the freshly-initialised `Window`
-            // (`initOwned` left `window.app` undefined). This is the latest
+            // (`initOwnedPtr` left `window.app` undefined). This is the latest
             // safe point; every path that reaches `window.app.*` runs after it.
             window.app = app;
             errdefer window.deinit();


### PR DESCRIPTION
## Summary

- initialize native windows through the existing in-place path
- add a focused `zig build showcase` target
- stop `zig build run` from compiling every installed example

## Why

The by-value initialization path creates a roughly 1.7 MB text-system stack temporary and crashes the Debug showcase under the normal Linux stack limit. Preview builds also traversed the full install graph even though they only need the showcase.

## Verification

- `zig build showcase -Dskip-shader-compile=true` (8.5 seconds in an Amp orb)
- Debug showcase remained running with the normal stack limit
- `dbus-run-session -- zig build test -Dskip-shader-compile=true`
- `zig fmt --check build.zig src/runtime/window_context.zig`