### PR TITLE
Add repeatable Gooey previews in Amp orbs

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+zig_version="0.16.0"
+
+if ! command -v zig >/dev/null 2>&1; then
+    echo "Zig is unavailable; rerun .agents/setup." >&2
+    exit 1
+fi
+
+installed_version="$(zig version)"
+if [[ "$installed_version" != "$zig_version" ]]; then
+    echo "Expected Zig ${zig_version}, found ${installed_version}; rerun .agents/setup." >&2
+    exit 1
+fi
+
+echo "Gooey orb environment is ready."

--- a/.agents/setup
+++ b/.agents/setup
@@ -15,6 +15,8 @@ packages=(
     libpng-dev
     libvulkan-dev
     libwayland-dev
+    mesa-vulkan-drivers
+    weston
     xz-utils
 )
 

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+zig_version="0.16.0"
+zig_install_dir="/usr/local/lib/zig-${zig_version}"
+
+echo "Installing Gooey's Linux build dependencies..."
+packages=(
+    ca-certificates
+    curl
+    libdbus-1-dev
+    libfontconfig-dev
+    libfreetype-dev
+    libharfbuzz-dev
+    libpng-dev
+    libvulkan-dev
+    libwayland-dev
+    xz-utils
+)
+
+packages_missing=()
+for package in "${packages[@]}"; do
+    if ! dpkg-query -W -f='${Status}' "$package" 2>/dev/null | grep -Fqx 'install ok installed'; then
+        packages_missing+=("$package")
+    fi
+done
+
+if ((${#packages_missing[@]} > 0)); then
+    sudo apt-get update
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "${packages_missing[@]}"
+else
+    echo "Linux build dependencies are already installed."
+fi
+
+zig_installed_version=""
+if [[ -x "${zig_install_dir}/zig" ]]; then
+    zig_installed_version="$("${zig_install_dir}/zig" version)"
+fi
+
+if [[ "$zig_installed_version" != "$zig_version" ]]; then
+    case "$(uname -m)" in
+        x86_64)
+            zig_architecture="x86_64"
+            zig_sha256="70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00"
+            ;;
+        aarch64|arm64)
+            zig_architecture="aarch64"
+            zig_sha256="ea4b09bfb22ec6f6c6ceac57ab63efb6b46e17ab08d21f69f3a48b38e1534f17"
+            ;;
+        *)
+            echo "Unsupported architecture: $(uname -m)" >&2
+            exit 1
+            ;;
+    esac
+
+    echo "Installing Zig ${zig_version} for ${zig_architecture}..."
+    archive="$(mktemp --suffix=.tar.xz)"
+    extract_dir="$(mktemp -d)"
+    trap 'rm -f "$archive"; rm -rf "$extract_dir"' EXIT
+
+    zig_url="https://ziglang.org/download/${zig_version}/zig-${zig_architecture}-linux-${zig_version}.tar.xz"
+    curl --fail --location --retry 3 --output "$archive" "$zig_url"
+    echo "${zig_sha256}  ${archive}" | sha256sum --check --status
+    tar -xJf "$archive" --strip-components=1 -C "$extract_dir"
+    sudo rm -rf "$zig_install_dir"
+    sudo mv "$extract_dir" "$zig_install_dir"
+    trap - EXIT
+    rm -f "$archive"
+else
+    echo "Zig ${zig_version} is already installed."
+fi
+
+sudo ln -sfn "${zig_install_dir}/zig" /usr/local/bin/zig
+
+installed_version="$(zig version)"
+if [[ "$installed_version" != "$zig_version" ]]; then
+    echo "Expected Zig ${zig_version}, found ${installed_version}." >&2
+    exit 1
+fi
+
+echo "Gooey orb setup complete."

--- a/.agents/skills/previewing-gooey/SKILL.md
+++ b/.agents/skills/previewing-gooey/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: previewing-gooey
+description: Builds and launches the Gooey showcase in a headless Wayland/Vulkan session and captures a reviewable screenshot. Use when asked to run, preview, inspect, or screenshot the Gooey application in an Amp orb.
+compatibility: Requires an Amp Linux orb prepared by .agents/setup.
+---
+
+# Previewing Gooey
+
+Run the Gooey showcase under a supervised headless Weston compositor and capture its rendered output.
+
+## Capture workflow
+
+From the repository root, run:
+
+```bash
+.agents/skills/previewing-gooey/scripts/capture-showcase
+```
+
+The script:
+
+1. Builds only the showcase with the checked-in SPIR-V shaders.
+2. Starts Weston and Gooey as supervised orb services.
+3. Uses Mesa's software Vulkan renderer when the orb has no GPU.
+4. Captures the Weston output into `.amp/in/artifacts/gooey-showcase.png`.
+5. Leaves both services running for log and status inspection.
+
+Pass a repository-relative output path as the first argument when a different artifact name is needed.
+
+## Verification
+
+After capture:
+
+- Use `view_media` on the output file and verify the requested UI is visible.
+- Inspect `amp orb service status gooey-app` if the screenshot is blank.
+- Inspect `amp orb service logs gooey-app` for startup or rendering failures.
+- Present the image using its workspace file URI.
+
+## Teardown
+
+Stop the preview services when they are no longer needed:
+
+```bash
+amp orb service stop gooey-app
+amp orb service stop gooey-wayland
+```
+
+Do not launch Weston or Gooey with `&`, `nohup`, or `setsid`; orb services must survive Amp process restarts.

--- a/.agents/skills/previewing-gooey/scripts/capture-showcase
+++ b/.agents/skills/previewing-gooey/scripts/capture-showcase
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../../../.." && pwd)"
+output_path="${1:-.amp/in/artifacts/gooey-showcase.png}"
+
+if [[ "$output_path" != /* ]]; then
+    output_path="${repo_root}/${output_path}"
+fi
+
+for command in amp dbus-run-session weston weston-screenshooter zig; do
+    if ! command -v "$command" >/dev/null 2>&1; then
+        echo "Missing ${command}; run .agents/setup first." >&2
+        exit 1
+    fi
+done
+
+cd "$repo_root"
+echo "Building the Gooey showcase..."
+zig build showcase -Dskip-shader-compile=true
+
+amp orb service stop gooey-app >/dev/null 2>&1 || true
+amp orb service stop gooey-wayland >/dev/null 2>&1 || true
+
+echo "Starting headless Wayland..."
+amp orb service start gooey-wayland --command \
+    'install -d -m 700 /tmp/gooey-runtime; export XDG_RUNTIME_DIR=/tmp/gooey-runtime; exec weston --backend=headless-backend.so --socket=wayland-gooey --width=1280 --height=800 --use-pixman --idle-time=0 --no-config --debug'
+
+socket_ready=false
+for _ in $(seq 1 100); do
+    if [[ -S /tmp/gooey-runtime/wayland-gooey ]]; then
+        socket_ready=true
+        break
+    fi
+    sleep 0.1
+done
+
+if [[ "$socket_ready" != true ]]; then
+    amp orb service logs gooey-wayland | tail -n 80 >&2
+    echo "Weston did not create its Wayland socket within 10 seconds." >&2
+    exit 1
+fi
+
+echo "Starting Gooey..."
+amp orb service start gooey-app --command \
+    'export XDG_RUNTIME_DIR=/tmp/gooey-runtime WAYLAND_DISPLAY=wayland-gooey; exec dbus-run-session -- ./zig-out/bin/gooey'
+
+# Software Vulkan needs several frames to populate the first presentation.
+sleep 5
+if ! amp orb service status gooey-app | grep -Fq 'Active: active (running)'; then
+    amp orb service logs gooey-app | tail -n 120 >&2
+    echo "Gooey did not remain active." >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "$output_path")"
+capture_dir="$(mktemp -d)"
+trap 'rm -rf "$capture_dir"' EXIT
+
+(
+    cd "$capture_dir"
+    XDG_RUNTIME_DIR=/tmp/gooey-runtime \
+        WAYLAND_DISPLAY=wayland-gooey \
+        weston-screenshooter
+)
+
+captures=("${capture_dir}"/wayland-screenshot-*.png)
+if [[ ! -f "${captures[0]}" ]]; then
+    echo "Weston did not produce a screenshot." >&2
+    exit 1
+fi
+
+mv "${captures[0]}" "$output_path"
+echo "Captured ${output_path}"


### PR DESCRIPTION
## Summary

- prepare fresh Amp orbs with Zig 0.16.0 and Gooey Linux dependencies
- add fast resume-time toolchain verification
- add a checked-in `previewing-gooey` skill
- automate supervised Weston and Gooey startup plus screenshot capture

## Usage

```bash
.agents/skills/previewing-gooey/scripts/capture-showcase
```

The screenshot is written to `.amp/in/artifacts/gooey-showcase.png`, and both supervised services remain available for status and log inspection.

## Verification

- `.agents/setup` completed from the orb and converged to 0.39 seconds on repeat
- `.agents/resume` completed successfully
- capture workflow completed end to end in 12.3 seconds
- captured image was visually verified as a rendered Gooey showcase
- Amp reloaded and discovered the `previewing-gooey` workspace skill

## Dependency

This is stacked on #49 so the preview uses the focused showcase build and in-place native initialization. Retarget to `main` after #49 merges.