### PR TITLE
Fix Linux Wayland frame pacing and cursor behavior

### DIFF
--- a/src/platform/interface.zig
+++ b/src/platform/interface.zig
@@ -59,6 +59,12 @@ pub const WindowId = window_registry.WindowId;
 /// Central registry for tracking windows by ID.
 pub const WindowRegistry = window_registry.WindowRegistry;
 
+/// Cursor shapes selected by framework widgets.
+pub const CursorShape = enum(u8) {
+    default,
+    text,
+};
+
 // =============================================================================
 // Platform Interface
 // =============================================================================

--- a/src/platform/linux/platform.zig
+++ b/src/platform/linux/platform.zig
@@ -15,6 +15,18 @@ const linux_input = @import("input.zig");
 const input = @import("../../input/events.zig");
 const clipboard = @import("clipboard.zig");
 
+const HIDDEN_FRAME_POLL_MS: i32 = 50;
+
+fn eventLoopPollTimeout(has_pending_work: bool, waiting_for_frame: bool, refresh_rate_mhz: i32) i32 {
+    std.debug.assert(refresh_rate_mhz > 0);
+    std.debug.assert(refresh_rate_mhz <= 1_000_000);
+    if (waiting_for_frame) return HIDDEN_FRAME_POLL_MS;
+    if (has_pending_work) return 0;
+
+    const frame_time_ms = @divFloor(@as(i32, 1_000_000), refresh_rate_mhz);
+    return @max(frame_time_ms, 1);
+}
+
 // Static listeners - must persist for lifetime of Wayland objects
 const registry_listener = wayland.RegistryListener{
     .global = LinuxPlatform.registryGlobal,
@@ -104,6 +116,8 @@ pub const LinuxPlatform = struct {
     text_input_manager: ?*wayland.ZwpTextInputManagerV3 = null,
     text_input: ?*wayland.ZwpTextInputV3 = null,
     viewporter: ?*wayland.WpViewporter = null,
+    cursor_shape_manager: ?*wayland.WpCursorShapeManagerV1 = null,
+    cursor_shape_device: ?*wayland.WpCursorShapeDeviceV1 = null,
     output: ?*wayland.Output = null,
 
     // Display refresh rate in millihertz (e.g., 60000 = 60Hz, 144000 = 144Hz)
@@ -119,6 +133,8 @@ pub const LinuxPlatform = struct {
     pointer_buttons: u32 = 0,
     last_key_serial: u32 = 0,
     last_pointer_serial: u32 = 0,
+    pointer_enter_serial: ?u32 = null,
+    cursor_shape: ?interface_mod.CursorShape = null,
     modifier_alt: bool = false,
     modifier_ctrl: bool = false,
     modifier_shift: bool = false,
@@ -274,6 +290,10 @@ pub const LinuxPlatform = struct {
         }
 
         // Input devices (they depend on seat)
+        if (self.cursor_shape_device) |device| {
+            wayland.cursorShapeDeviceDestroy(device);
+            self.cursor_shape_device = null;
+        }
         if (self.keyboard) |kb| {
             wayland.keyboardDestroy(kb);
             self.keyboard = null;
@@ -293,6 +313,10 @@ pub const LinuxPlatform = struct {
         if (self.decoration_manager) |dm| {
             wayland.zxdgDecorationManagerV1Destroy(dm);
             self.decoration_manager = null;
+        }
+        if (self.cursor_shape_manager) |manager| {
+            wayland.cursorShapeManagerDestroy(manager);
+            self.cursor_shape_manager = null;
         }
         if (self.xdg_wm_base) |wm| {
             wayland.xdgWmBaseDestroy(wm);
@@ -336,13 +360,21 @@ pub const LinuxPlatform = struct {
             pollfds_buf[0] = .{ .fd = fd, .events = posix.POLL.IN, .revents = 0 };
             var pollfds = pollfds_buf[0..1];
 
-            // Render frame if we have an active window
+            // Render eagerly only when no compositor callback is pending.
+            // A redraw requested during frameCallback() must remain queued
+            // until that newly-scheduled callback fires, otherwise animation
+            // frames are submitted twice per compositor tick.
             if (self.active_window) |window| {
                 if (window.isClosed()) {
                     self.running = false;
                     break;
                 }
-                window.renderFrame();
+                // A bufferless surface may not receive its first callback, so
+                // bootstrap with one eager presentation. Every later frame is
+                // paced by the compositor callback already in flight.
+                if (window.frame_callback == null or !window.has_presented_frame) {
+                    window.renderFrame();
+                }
             }
 
             // Flush outgoing requests before polling
@@ -368,22 +400,17 @@ pub const LinuxPlatform = struct {
                 break;
             }
 
-            // Adaptive poll timeout based on work state:
-            // - 0ms if redraw/animation pending (minimize latency, max FPS)
-            // - 1000/refresh_rate if idle (reduce CPU usage, match display responsiveness)
-            // Wayland frame callbacks still pace actual rendering to vsync.
-            const timeout_ms: i32 = blk: {
-                if (self.active_window) |window| {
-                    // Check if window has pending work
-                    if (window.needs_redraw or window.continuous_render or window.pending_resize) {
-                        break :blk 0; // Work pending - poll immediately
-                    }
-                }
-                // Calculate frame time from display refresh rate (mHz to ms)
-                // refresh_rate_mhz is in millihertz, so 1000000 / mHz = ms per frame
-                const frame_time_ms: i32 = @intCast(@divTrunc(@as(i64, 1000000), self.refresh_rate_mhz));
-                break :blk frame_time_ms; // Idle - match display refresh rate
-            };
+            // Never spin while a frame callback is outstanding. Compositors
+            // can withhold callbacks for hidden windows, so use the same 20Hz
+            // fallback cadence as other Wayland clients while still waking
+            // immediately when a visible surface receives its callback.
+            var has_pending_work = false;
+            var waiting_for_frame = false;
+            if (self.active_window) |window| {
+                has_pending_work = window.needs_redraw or window.continuous_render or window.pending_resize;
+                waiting_for_frame = window.frame_callback != null;
+            }
+            const timeout_ms = eventLoopPollTimeout(has_pending_work, waiting_for_frame, self.refresh_rate_mhz);
             const poll_result = posix.poll(pollfds, timeout_ms) catch {
                 self.running = false;
                 break;
@@ -539,6 +566,33 @@ pub const LinuxPlatform = struct {
         return @floatFromInt(self.scale_factor);
     }
 
+    fn ensureCursorShapeDevice(self: *Self) void {
+        if (self.cursor_shape_device != null) std.debug.assert(self.pointer != null);
+        if (self.cursor_shape_device != null) std.debug.assert(self.cursor_shape_manager != null);
+        if (self.cursor_shape_device != null) return;
+
+        const manager = self.cursor_shape_manager orelse return;
+        const pointer = self.pointer orelse return;
+        self.cursor_shape_device = wayland.cursorShapeManagerGetPointer(manager, pointer);
+        std.debug.assert(self.cursor_shape_manager != null);
+        std.debug.assert(self.pointer != null);
+    }
+
+    pub fn setCursorShape(self: *Self, shape: interface_mod.CursorShape) void {
+        if (self.cursor_shape_device != null) std.debug.assert(self.pointer != null);
+        if (self.cursor_shape_device != null) std.debug.assert(self.cursor_shape_manager != null);
+        if (self.cursor_shape == shape) return;
+        const serial = self.pointer_enter_serial orelse return;
+        const device = self.cursor_shape_device orelse return;
+
+        const protocol_shape: u32 = switch (shape) {
+            .default => 1,
+            .text => 9,
+        };
+        wayland.cursorShapeDeviceSetShape(device, serial, protocol_shape);
+        self.cursor_shape = shape;
+    }
+
     /// Get interface for runtime polymorphism
     pub fn interface(self: *Self) interface_mod.PlatformVTable {
         return interface_mod.makePlatformVTable(Self, self);
@@ -611,6 +665,14 @@ pub const LinuxPlatform = struct {
             }
         } else if (std.mem.eql(u8, interface_name, wayland.WP_VIEWPORTER_INTERFACE_NAME)) {
             self.viewporter = wayland.bindViewporter(registry, name, version);
+        } else if (std.mem.eql(u8, interface_name, wayland.WP_CURSOR_SHAPE_MANAGER_V1_INTERFACE_NAME)) {
+            self.cursor_shape_manager = @ptrCast(@alignCast(wayland.registryBind(
+                registry,
+                name,
+                &wayland.wp_cursor_shape_manager_v1_interface,
+                @min(version, 2),
+            )));
+            self.ensureCursorShapeDevice();
         } else if (std.mem.eql(u8, interface_name, wayland.WL_OUTPUT_INTERFACE_NAME)) {
             // Bind to first output only (for refresh rate)
             if (self.output == null) {
@@ -772,9 +834,16 @@ pub const LinuxPlatform = struct {
                 // Uses module-level static listener
                 _ = wayland.pointerAddListener(ptr, &pointer_listener, self);
             }
+            self.ensureCursorShapeDevice();
         } else if (!caps.pointer and self.pointer != null) {
+            if (self.cursor_shape_device) |device| {
+                wayland.cursorShapeDeviceDestroy(device);
+                self.cursor_shape_device = null;
+            }
             wayland.pointerDestroy(self.pointer.?);
             self.pointer = null;
+            self.pointer_enter_serial = null;
+            self.cursor_shape = null;
         }
 
         // Handle keyboard
@@ -822,8 +891,11 @@ pub const LinuxPlatform = struct {
         _ = surface;
         const self: *Self = @ptrCast(@alignCast(data));
         self.last_pointer_serial = serial;
+        self.pointer_enter_serial = serial;
         self.pointer_x = wayland.fixedToDouble(surface_x);
         self.pointer_y = wayland.fixedToDouble(surface_y);
+        self.cursor_shape = null;
+        self.setCursorShape(.default);
 
         // Dispatch mouse_entered event to active window
         if (self.active_window) |window| {
@@ -848,6 +920,8 @@ pub const LinuxPlatform = struct {
         _ = serial;
         _ = surface;
         const self: *Self = @ptrCast(@alignCast(data));
+        self.pointer_enter_serial = null;
+        self.cursor_shape = null;
 
         // Dispatch mouse_exited event to active window
         if (self.active_window) |window| {
@@ -1573,3 +1647,9 @@ pub const LinuxPlatform = struct {
         }
     }
 };
+
+test "event loop waits instead of spinning for compositor frame" {
+    try std.testing.expectEqual(@as(i32, HIDDEN_FRAME_POLL_MS), eventLoopPollTimeout(true, true, 240_000));
+    try std.testing.expectEqual(@as(i32, 0), eventLoopPollTimeout(true, false, 240_000));
+    try std.testing.expectEqual(@as(i32, 4), eventLoopPollTimeout(false, false, 240_000));
+}

--- a/src/platform/linux/wayland.zig
+++ b/src/platform/linux/wayland.zig
@@ -65,6 +65,10 @@ pub const ZwpTextInputManagerV3 = opaque {};
 pub const WpViewporter = opaque {};
 pub const WpViewport = opaque {};
 
+// Cursor shape protocol types
+pub const WpCursorShapeManagerV1 = opaque {};
+pub const WpCursorShapeDeviceV1 = opaque {};
+
 // Wayland array type (used in listeners)
 pub const Array = extern struct {
     size: usize,
@@ -644,6 +648,10 @@ const zwp_text_input_manager_v3_get_text_input_types = [_]?*const Interface{ zwp
 const wp_viewport_interface_ptr: ?*const Interface = &wp_viewport_interface;
 const wp_viewporter_get_viewport_types = [_]?*const Interface{ wp_viewport_interface_ptr, &wl_surface_interface };
 
+// Cursor shape forward declarations
+const wp_cursor_shape_device_v1_interface_ptr: ?*const Interface = &wp_cursor_shape_device_v1_interface;
+const wp_cursor_shape_manager_v1_get_pointer_types = [_]?*const Interface{ wp_cursor_shape_device_v1_interface_ptr, &wl_pointer_interface };
+
 // Type arrays for text input v3 events with object arguments
 const zwp_text_input_v3_enter_types = [_]?*const Interface{&wl_surface_interface};
 const zwp_text_input_v3_leave_types = [_]?*const Interface{&wl_surface_interface};
@@ -1160,6 +1168,51 @@ pub fn pointerDestroy(pointer: *Pointer) void {
     wl_proxy_destroy(@ptrCast(pointer));
 }
 
+pub fn cursorShapeManagerGetPointer(manager: *WpCursorShapeManagerV1, pointer: *Pointer) ?*WpCursorShapeDeviceV1 {
+    const result = wl_proxy_marshal_flags(
+        @ptrCast(manager),
+        1, // get_pointer
+        &wp_cursor_shape_device_v1_interface,
+        wl_proxy_get_version(@ptrCast(manager)),
+        0,
+        @as(?*anyopaque, null),
+        pointer,
+    );
+    return @ptrCast(@alignCast(result));
+}
+
+pub fn cursorShapeManagerDestroy(manager: *WpCursorShapeManagerV1) void {
+    _ = wl_proxy_marshal_flags(
+        @ptrCast(manager),
+        0, // destroy
+        null,
+        wl_proxy_get_version(@ptrCast(manager)),
+        MARSHAL_FLAG_DESTROY,
+    );
+}
+
+pub fn cursorShapeDeviceSetShape(device: *WpCursorShapeDeviceV1, serial: u32, shape: u32) void {
+    _ = wl_proxy_marshal_flags(
+        @ptrCast(device),
+        1, // set_shape
+        null,
+        wl_proxy_get_version(@ptrCast(device)),
+        0,
+        serial,
+        shape,
+    );
+}
+
+pub fn cursorShapeDeviceDestroy(device: *WpCursorShapeDeviceV1) void {
+    _ = wl_proxy_marshal_flags(
+        @ptrCast(device),
+        0, // destroy
+        null,
+        wl_proxy_get_version(@ptrCast(device)),
+        MARSHAL_FLAG_DESTROY,
+    );
+}
+
 // Keyboard operations
 pub fn keyboardAddListener(keyboard: *Keyboard, listener: *const KeyboardListener, data: ?*anyopaque) bool {
     return wl_proxy_add_listener(@ptrCast(keyboard), @ptrCast(listener), data) == 0;
@@ -1607,6 +1660,7 @@ pub const XDG_WM_BASE_INTERFACE_NAME = "xdg_wm_base";
 pub const ZXDG_DECORATION_MANAGER_V1_INTERFACE_NAME = "zxdg_decoration_manager_v1";
 pub const ZWP_TEXT_INPUT_MANAGER_V3_INTERFACE_NAME = "zwp_text_input_manager_v3";
 pub const WP_VIEWPORTER_INTERFACE_NAME = "wp_viewporter";
+pub const WP_CURSOR_SHAPE_MANAGER_V1_INTERFACE_NAME = "wp_cursor_shape_manager_v1";
 
 // =============================================================================
 // wp_viewporter interface (for HiDPI support)
@@ -1623,6 +1677,37 @@ pub const wp_viewporter_interface: Interface = .{
     .version = 1,
     .method_count = 2,
     .methods = @ptrCast(&wp_viewporter_methods),
+    .event_count = 0,
+    .events = null,
+};
+
+// wp_cursor_shape_manager_v1 methods: destroy, get_pointer, get_tablet_tool_v2
+const wp_cursor_shape_manager_v1_methods = [_]Message{
+    .{ .name = "destroy", .signature = "", .types = null },
+    .{ .name = "get_pointer", .signature = "no", .types = @ptrCast(&wp_cursor_shape_manager_v1_get_pointer_types) },
+    .{ .name = "get_tablet_tool_v2", .signature = "no", .types = null },
+};
+
+pub const wp_cursor_shape_manager_v1_interface: Interface = .{
+    .name = "wp_cursor_shape_manager_v1",
+    .version = 2,
+    .method_count = 3,
+    .methods = @ptrCast(&wp_cursor_shape_manager_v1_methods),
+    .event_count = 0,
+    .events = null,
+};
+
+// wp_cursor_shape_device_v1 methods: destroy, set_shape
+const wp_cursor_shape_device_v1_methods = [_]Message{
+    .{ .name = "destroy", .signature = "", .types = null },
+    .{ .name = "set_shape", .signature = "uu", .types = null },
+};
+
+pub const wp_cursor_shape_device_v1_interface: Interface = .{
+    .name = "wp_cursor_shape_device_v1",
+    .version = 2,
+    .method_count = 2,
+    .methods = @ptrCast(&wp_cursor_shape_device_v1_methods),
     .event_count = 0,
     .events = null,
 };

--- a/src/platform/linux/window.zig
+++ b/src/platform/linux/window.zig
@@ -90,9 +90,11 @@ pub const Window = struct {
     renderer: VulkanRenderer,
     background_color: geometry.Color = geometry.Color.rgba(0.2, 0.2, 0.25, 1.0),
     needs_redraw: bool = true,
+    has_presented_frame: bool = false,
 
-    /// When true, continuously schedule frames at vsync rate (like macOS DisplayLink).
-    /// This enables smooth 120fps+ rendering without requiring explicit requestRender() calls.
+    /// Continuously schedule frames at vsync rate for immediate-mode UI.
+    /// Hidden windows are throttled by the platform event loop while their
+    /// compositor frame callback is withheld.
     continuous_render: bool = true,
 
     // Scene reference (set externally)
@@ -499,6 +501,12 @@ pub const Window = struct {
         self.scheduleFrame();
     }
 
+    pub fn setCursorShape(self: *Self, shape: interface_mod.CursorShape) void {
+        std.debug.assert(self.platform.pointer == null or self.platform.seat != null);
+        std.debug.assert(self.platform.cursor_shape_device == null or self.platform.pointer != null);
+        self.platform.setCursorShape(shape);
+    }
+
     pub fn setScene(self: *Self, scene: *const scene_mod.Scene) void {
         self.scene = scene;
     }
@@ -758,6 +766,10 @@ pub const Window = struct {
         if (!self.configured) return;
         if (!self.needs_redraw and !self.pending_resize) return;
 
+        // Clear before invoking application code so requestRender() calls made
+        // while building an animation survive for the following frame.
+        self.needs_redraw = false;
+
         // Handle pending resize
         if (self.pending_resize) {
             const old_width = self.size.width;
@@ -794,8 +806,6 @@ pub const Window = struct {
             }
             self.renderer.resize(self.width, self.height, self.scale_factor);
             self.pending_resize = false;
-            self.needs_redraw = true; // Ensure we redraw after resize
-
             // Notify user of resize if size actually changed
             const size_changed = (old_width != self.size.width or old_height != self.size.height);
             if (size_changed) {
@@ -836,6 +846,7 @@ pub const Window = struct {
             defer empty_scene.deinit();
             self.renderer.render(&empty_scene);
         }
+        self.has_presented_frame = true;
 
         const gpu_end = std.Io.Timestamp.now(render_io, .awake);
         const gpu_ns: i96 = gpu_start.durationTo(gpu_end).toNanoseconds();
@@ -843,7 +854,6 @@ pub const Window = struct {
         self.last_gpu_submit_ns = @intCast(gpu_ns);
         self.last_atlas_upload_ns = 0; // Atlas transfers are now async (inside render cmd buf)
 
-        self.needs_redraw = false;
     }
 
     // =========================================================================
@@ -909,7 +919,9 @@ pub const Window = struct {
         _ = surface;
         _ = output;
         const self: *Self = @ptrCast(@alignCast(data));
-        self.mouse_inside = true;
+        // Output membership can change scale/configure state when moving a
+        // window between workspaces or displays, so rebuild layout once.
+        self.requestRender();
     }
 
     fn surfaceLeave(
@@ -920,7 +932,7 @@ pub const Window = struct {
         _ = surface;
         _ = output;
         const self: *Self = @ptrCast(@alignCast(data));
-        self.mouse_inside = false;
+        self.requestRender();
     }
 
     fn surfacePreferredScale(

--- a/src/runtime/frame.zig
+++ b/src/runtime/frame.zig
@@ -185,6 +185,9 @@ fn renderFrameImpl(cx: *Cx, render_fn: anytype) !void {
 
     // Update IME cursor position for focused text input
     updateImeCursorPosition(window, builder);
+    if (comptime @import("../platform/mod.zig").is_linux) {
+        updateCursorShape(window, builder);
+    }
 
     // End render timing for profiler
     window.debugger().endRender(window.io);
@@ -448,6 +451,29 @@ fn updateImeCursorPosition(window: *Window, builder: *const Builder) void {
         const rect = ce.getCursorRect();
         platform_window.setImeCursorRect(rect.x, rect.y, rect.width, rect.height);
     }
+}
+
+/// Text controls select an I-beam while all other content resets to the
+/// compositor's default cursor. The protocol call itself is Linux-only.
+fn updateCursorShape(window: *Window, builder: *const Builder) void {
+    std.debug.assert(builder.pending_inputs.items.len <= Builder.MAX_PENDING_INPUTS);
+    std.debug.assert(builder.pending_text_areas.items.len <= Builder.MAX_PENDING_TEXT_AREAS);
+    const hovered_layout_id = window.hover.hovered_layout_id orelse {
+        if (window.getPlatformWindow()) |platform_window| platform_window.setCursorShape(.default);
+        return;
+    };
+
+    var shape: @import("../platform/interface.zig").CursorShape = .default;
+    for (builder.pending_inputs.items) |pending| {
+        if (pending.layout_id.id == hovered_layout_id) shape = .text;
+    }
+    for (builder.pending_text_areas.items) |pending| {
+        if (pending.layout_id.id == hovered_layout_id) shape = .text;
+    }
+    for (builder.pending_code_editors.items) |pending| {
+        if (pending.layout_id.id == hovered_layout_id) shape = .text;
+    }
+    if (window.getPlatformWindow()) |platform_window| platform_window.setCursorShape(shape);
 }
 
 /// Render debug overlays if enabled

--- a/src/runtime/input.zig
+++ b/src/runtime/input.zig
@@ -114,6 +114,14 @@ pub fn handleInputCx(
         .mouse_moved => |move_ev| {
             if (handleMouseMoveEvent(cx, window, move_ev.position, false)) return true;
         },
+        .mouse_entered => |enter_ev| {
+            // Wayland does not guarantee a motion event after pointer enter,
+            // so hit-test the supplied coordinates immediately without
+            // consuming the enter event or running drag-move behavior.
+            const x: f32 = @floatCast(enter_ev.position.x);
+            const y: f32 = @floatCast(enter_ev.position.y);
+            if (window.updateHover(x, y)) cx.notify();
+        },
         .mouse_dragged => |drag_ev| {
             if (handleMouseDragEvent(cx, window, builder, drag_ev.position)) return true;
             if (handleMouseMoveEvent(cx, window, drag_ev.position, true)) return true;


### PR DESCRIPTION
## Summary

- preserve continuous immediate-mode rendering while waiting efficiently when hidden surfaces stop receiving frame callbacks
- bootstrap the first presentation eagerly, then pace subsequent redraws behind compositor callbacks
- refresh rendering and layout when a surface changes output membership
- add cursor-shape-v1 support for default and text cursors, including pointer-enter hover handling

## Validation

- `zig build showcase -Dskip-shader-compile=true`
- launched and captured the showcase under headless Weston/Vulkan
- compositor-withheld simulation consumed 1 CPU tick over 3 seconds
- `zig build test -Dskip-shader-compile=true`: 1084/1085 pass; the existing Linux accessibility signal-queue test fails when its D-Bus connection is unavailable in the orb
- Oracle final review: approve, no blockers

Addresses #35.