### PR TITLE
Fix runtime action handler registration

### DIFF
--- a/src/context/dispatch.zig
+++ b/src/context/dispatch.zig
@@ -973,10 +973,15 @@ pub const DispatchTree = struct {
 
     /// Register an action handler using HandlerRef (new pattern)
     pub fn onActionHandler(self: *Self, comptime Action: type, ref: HandlerRef) void {
+        self.onActionHandlerRaw(actionTypeId(Action), ref);
+    }
+
+    /// Register an action handler whose type ID was resolved by a UI primitive.
+    pub fn onActionHandlerRaw(self: *Self, action_type: ActionTypeId, ref: HandlerRef) void {
         const node_id = self.currentNode();
         if (self.getNode(node_id)) |node| {
             node.getOrCreateListeners(self.allocator).action_listeners_handler.append(self.allocator, .{
-                .action_type = actionTypeId(Action),
+                .action_type = action_type,
                 .handler = ref,
             }) catch @panic("dispatch: action handler registration failed (OOM)");
         }
@@ -1122,6 +1127,29 @@ test "DispatchTree construction" {
 
     const grandchild_node = tree.getNodeConst(grandchild).?;
     try std.testing.expectEqual(child2, grandchild_node.parent);
+}
+
+test "DispatchTree registers a pre-resolved action handler" {
+    // The UI builder resolves action types before rendering, so verify the raw
+    // registration path preserves both that ID and its handler reference.
+    const allocator = std.testing.allocator;
+    var tree = DispatchTree.init(allocator);
+    defer tree.deinit();
+
+    const callback = struct {
+        fn invoke(_: *Window, _: handler_mod.EntityId) void {}
+    }.invoke;
+    const handler = HandlerRef{ .callback = callback };
+    const action_type: ActionTypeId = 42;
+
+    const root = tree.pushNode();
+    tree.onActionHandlerRaw(action_type, handler);
+    tree.popNode();
+
+    const listeners = tree.getNodeConst(root).?.listeners.?;
+    try std.testing.expectEqual(@as(usize, 1), listeners.action_listeners_handler.items.len);
+    try std.testing.expectEqual(action_type, listeners.action_listeners_handler.items[0].action_type);
+    try std.testing.expectEqual(handler.callback, listeners.action_listeners_handler.items[0].handler.callback);
 }
 
 test "DispatchTree hit testing" {

--- a/src/ui/builder.zig
+++ b/src/ui/builder.zig
@@ -1817,6 +1817,33 @@ fn testBuilderHarness(
     return Builder.init(allocator, engine, scene_ptr, tree);
 }
 
+test "onActionHandler primitive registers its pre-resolved action type" {
+    // Render the public primitive through a real Builder to cover the bridge
+    // from its runtime action ID into DispatchTree listener registration.
+    const gpa = std.testing.allocator;
+    var engine: LayoutEngine = undefined;
+    var scene_buf: Scene = undefined;
+    var tree: DispatchTree = undefined;
+    var builder = testBuilderHarness(gpa, &engine, &scene_buf, &tree);
+    defer builder.deinit();
+    defer engine.deinit();
+    defer scene_buf.deinit();
+    defer tree.deinit();
+
+    const Action = struct {};
+    const callback = struct {
+        fn invoke(_: *Window, _: handler_mod.EntityId) void {}
+    }.invoke;
+    const handler = HandlerRef{ .callback = callback };
+
+    builder.box(.{}, .{primitives.onActionHandler(Action, handler)});
+
+    const listeners = tree.getNodeConst(tree.root).?.listeners.?;
+    try std.testing.expectEqual(@as(usize, 1), listeners.action_listeners_handler.items.len);
+    try std.testing.expectEqual(actionTypeId(Action), listeners.action_listeners_handler.items[0].action_type);
+    try std.testing.expectEqual(handler.callback, listeners.action_listeners_handler.items[0].handler.callback);
+}
+
 test "generateId: same-parent siblings never collide" {
     const gpa = std.testing.allocator;
     var engine: LayoutEngine = undefined;


### PR DESCRIPTION
## Summary

- add `DispatchTree.onActionHandlerRaw` for action IDs resolved by UI primitives
- route the comptime action-handler API through the raw registration path
- cover both direct dispatch registration and `ui.onActionHandler` rendering through `Builder`

Closes #45

## Verification

- focused dispatch regression test passes
- focused Builder/UI primitive regression test passes
- `zig build showcase -Dskip-shader-compile=true`
- showcase starts and renders under headless Wayland/Vulkan

## Full-suite note

`zig build test -Dskip-shader-compile=true` completed 1085/1086 tests locally. The unrelated Linux accessibility signal-queue test failed while its D-Bus session connection was unavailable; both new focused tests pass independently.