### PR TITLE
Restore trust in documented API and downstream setup

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -8,6 +8,7 @@ echo "Installing Gooey's Linux build dependencies..."
 packages=(
     ca-certificates
     curl
+    glslc
     libdbus-1-dev
     libfontconfig-dev
     libfreetype-dev

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -45,8 +45,8 @@ Gooey's accessibility system provides:
 All standard Gooey components have built-in accessibility. Simply use the `accessible_name` field to customize what screen readers announce:
 
 ```zig
-const Button = gooey.Button;
-const Checkbox = gooey.Checkbox;
+const Button = gooey.components.Button;
+const Checkbox = gooey.components.Checkbox;
 
 // Button with custom accessible name
 Button{
@@ -67,6 +67,10 @@ Checkbox{
 ### Adding Accessibility to Custom Elements
 
 For custom UI elements, use `b.accessible()`:
+
+> **Advanced API:** This is the low-level accessibility-tree builder. Prefer
+> `gooey.components.*` for standard controls because those components maintain
+> roles, state, and names automatically.
 
 ```zig
 fn renderCustomWidget(b: *ui.Builder) void {
@@ -292,7 +296,7 @@ fn renderForm(cx: *Cx) void {
     cx.text("Contact Form", .{ .size = 24, .weight = .bold });
 
     // Name field
-    gooey.TextInput{
+    gooey.components.TextInput{
         .id = "name",
         .placeholder = "Your name",
         .accessible_name = "Full name",
@@ -300,7 +304,7 @@ fn renderForm(cx: *Cx) void {
     };
 
     // Email field
-    gooey.TextInput{
+    gooey.components.TextInput{
         .id = "email",
         .placeholder = "email@example.com",
         .accessible_name = "Email address",
@@ -308,7 +312,7 @@ fn renderForm(cx: *Cx) void {
     };
 
     // Subscribe checkbox
-    gooey.Checkbox{
+    gooey.components.Checkbox{
         .id = "subscribe",
         .selected = s.subscribe,
         .label = "Subscribe to newsletter",
@@ -316,7 +320,7 @@ fn renderForm(cx: *Cx) void {
     };
 
     // Submit button
-    gooey.Button{
+    gooey.components.Button{
         .label = "Send",
         .accessible_name = "Submit contact form",
         .disabled = !s.isValid(),

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -61,9 +61,11 @@ Import both gooey and gooey-charts in your build:
 
 ```gooey/docs/charts.md#L50-58
 // build.zig
+const gooey_build = @import("gooey");
 const gooey_dep = b.dependency("gooey", .{ .target = target, .optimize = optimize });
 exe.root_module.addImport("gooey", gooey_dep.module("gooey"));
 exe.root_module.addImport("gooey-charts", gooey_dep.module("gooey-charts"));
+gooey_build.linkSystemDeps(exe);
 
 // your_app.zig
 const gooey = @import("gooey");

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,56 @@ Example app built with Gooey — [**chat-zig**](https://github.com/duanebester/c
 
 **Linux:** Wayland compositor, Vulkan drivers, FreeType, HarfBuzz, Fontconfig, libpng, D-Bus
 
+### Add Gooey to an application
+
+Add the current release to your application's `build.zig.zon`:
+
+```zig
+.dependencies = .{
+    .gooey = .{
+        .url = "https://github.com/duanebester/gooey/archive/refs/tags/v0.2.6.tar.gz",
+        .hash = "gooey-0.2.6-uPBZ7jMhXQAhifhzm8HyurjFUx5S0BrLXq1ZDO0DcwTr",
+    },
+},
+```
+
+Then import Gooey's module and apply its platform linker integration in your
+`build.zig`:
+
+```zig
+const std = @import("std");
+const gooey_build = @import("gooey");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+    const gooey_dependency = b.dependency("gooey", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const executable = b.addExecutable(.{
+        .name = "my-app",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "gooey", .module = gooey_dependency.module("gooey") },
+            },
+        }),
+    });
+    gooey_build.linkSystemDeps(executable);
+    b.installArtifact(executable);
+}
+```
+
+Application source can now use `const gooey = @import("gooey");`. The
+`linkSystemDeps` call is the supported cross-platform linker setup and keeps
+consumer builds independent of Gooey's internal framework/library list.
+
+### Run this repository's examples
+
 ```bash
 zig build run              # Showcase demo
 zig build run-counter      # Counter example
@@ -620,7 +670,7 @@ fn render(cx: *Cx) void {
 Define a light/dark pair of `Theme` values and swap between them the same way as the built-ins. Every field has a semantic role so components resolve colors automatically without per-component overrides:
 
 ```zig
-const my_light = gooey.Theme{
+const my_light = gooey.ui.Theme{
     .bg      = Color.rgb(0.97, 0.97, 0.98),
     .surface = Color.rgb(0.93, 0.93, 0.95),
     .overlay = Color.rgb(0.88, 0.88, 0.91),
@@ -646,7 +696,7 @@ const my_light = gooey.Theme{
     .font_size_base = 14,
 };
 
-const my_dark = gooey.Theme{
+const my_dark = gooey.ui.Theme{
     .bg      = Color.rgb(0.10, 0.10, 0.12),
     .surface = Color.rgb(0.15, 0.15, 0.18),
     .overlay = Color.rgb(0.20, 0.20, 0.24),
@@ -691,7 +741,7 @@ The `font_size_base` field (default `14`) is the single source of truth for text
 Set it once in your theme and every component scales consistently — no per-component font size overrides needed:
 
 ```zig
-const large_text_theme = gooey.Theme{
+const large_text_theme = gooey.ui.Theme{
     // ...colors...
     .font_size_base = 18,  // small=16, medium=18, large=20
 };
@@ -847,19 +897,19 @@ Tooltip(IconButton){
 
 ```zig
 // Simple image from path
-gooey.Image{ .src = "assets/logo.png" }
+gooey.components.Image{ .src = "assets/logo.png" }
 
 // With explicit sizing
-gooey.Image{ .src = "photo.jpg", .width = 200, .height = 150 }
+gooey.components.Image{ .src = "photo.jpg", .width = 200, .height = 150 }
 
 // Rounded avatar
-gooey.Image{ .src = "avatar.png", .size = 48, .rounded = true }
+gooey.components.Image{ .src = "avatar.png", .size = 48, .rounded = true }
 
 // Cover image (fills container, may crop)
-gooey.Image{ .src = "banner.jpg", .width = 800, .height = 200, .fit = .cover }
+gooey.components.Image{ .src = "banner.jpg", .width = 800, .height = 200, .fit = .cover }
 
 // With effects
-gooey.Image{
+gooey.components.Image{
     .src = "icon.png",
     .size = 64,
     .grayscale = 1.0,           // 0.0 = color, 1.0 = grayscale
@@ -873,8 +923,8 @@ gooey.Image{
 
 ```zig
 const gooey = @import("gooey");
-const Svg = gooey.Svg;
-const Icons = gooey.Icons;
+const Svg = gooey.components.Svg;
+const Icons = gooey.components.Icons;
 
 // Using built-in icon paths
 Svg{ .path = Icons.star, .size = 24, .color = Color.gold }
@@ -1238,7 +1288,7 @@ if (result) |r| {
 }
 
 // Use with ValidatedTextInput for full a11y control
-gooey.ValidatedTextInput{
+gooey.components.ValidatedTextInput{
     .id = "email",
     .error_result = validation.requiredResult(s.email, .{
         .message = "Required",
@@ -1270,7 +1320,7 @@ const State = struct {
 };
 
 // In render:
-gooey.ValidatedTextInput{
+gooey.components.ValidatedTextInput{
     .id = "email",
     .label = "Email Address",
     .required_indicator = true,        // Shows "*" after label
@@ -1284,7 +1334,7 @@ gooey.ValidatedTextInput{
 }
 
 // Or with structured result for different a11y messages:
-gooey.ValidatedTextInput{
+gooey.components.ValidatedTextInput{
     .id = "email",
     .label = "Email Address",
     .error_result = validation.emailResult(s.email, .{
@@ -1486,6 +1536,10 @@ ui.text("Long text...", .{ .wrap = .words });  // .none, .words, .newlines
 
 Add custom post-processing shaders for visual effects. Shaders are cross-platform with MSL for macOS and WGSL for web:
 
+> **Advanced/unstable API:** Custom shader descriptors and backend shader
+> interfaces may change while the platform renderers converge. Prefer standard
+> components unless an application owns the backend-specific shader code.
+
 ```zig
 // MSL shader (macOS)
 pub const plasma_msl =
@@ -1515,7 +1569,7 @@ pub const plasma_wgsl =
     \\}
 ;
 
-try gooey.runCx(AppState, &state, render, .{
+const App = gooey.App(AppState, &state, render, .{
     .custom_shaders = &.{.{ .msl = plasma_msl, .wgsl = plasma_wgsl }},
 });
 ```
@@ -1535,7 +1589,7 @@ You can also provide only one platform's shader:
 Transparent window with liquid glass effect:
 
 ```zig
-try gooey.runCx(AppState, &state, render, .{
+const App = gooey.App(AppState, &state, render, .{
     .title = "Glass Demo",
     .background_color = gooey.Color.rgba(0.1, 0.1, 0.15, 1.0),
     .background_opacity = 0.2,

--- a/readme.md
+++ b/readme.md
@@ -61,12 +61,10 @@ Add the current release to your application's `build.zig.zon`:
 },
 ```
 
-Then import Gooey's module and apply its platform linker integration in your
-`build.zig`:
+Then import Gooey's module in your `build.zig`:
 
 ```zig
 const std = @import("std");
-const gooey_build = @import("gooey");
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
@@ -87,14 +85,13 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
-    gooey_build.linkSystemDeps(executable);
     b.installArtifact(executable);
 }
 ```
 
-Application source can now use `const gooey = @import("gooey");`. The
-`linkSystemDeps` call is the supported cross-platform linker setup and keeps
-consumer builds independent of Gooey's internal framework/library list.
+Application source can now use `const gooey = @import("gooey");`. Gooey's
+module carries its platform linker requirements transitively, keeping consumer
+builds independent of Gooey's internal framework/library list.
 
 ### Run this repository's examples
 

--- a/src/accessibility/linux_bridge.zig
+++ b/src/accessibility/linux_bridge.zig
@@ -604,6 +604,14 @@ pub const LinuxBridge = struct {
 
     /// Emit all pending signals over D-Bus
     fn emitPendingSignals(self: *Self) void {
+        std.debug.assert(self.signal_count <= MAX_PENDING_SIGNALS);
+        std.debug.assert(self.object_count <= constants.MAX_ELEMENTS);
+
+        // A flush consumes the batch even when AT-SPI is disconnected. Keeping
+        // stale signals would make the next frame retry obsolete events and
+        // eventually write past the fixed-capacity queue.
+        defer self.signal_count = 0;
+
         if (builtin.os.tag != .linux) return;
 
         const conn = &(self.connection orelse return);
@@ -616,8 +624,6 @@ pub const LinuxBridge = struct {
 
         // Flush D-Bus connection to ensure signals are sent
         conn.flush();
-
-        self.signal_count = 0;
     }
 
     /// Emit a single AT-SPI2 signal

--- a/src/api_check.zig
+++ b/src/api_check.zig
@@ -430,3 +430,23 @@ test "tier 1 public API surface compiles" {
         pinCxSubNamespaces();
     }
 }
+
+// Compile representative declarations used by the README and accessibility
+// guide. Unlike the declaration pin list above, these literals verify the
+// canonical namespace and the documented required fields together.
+test "promoted documentation API snippets compile" {
+    const Button = gooey.components.Button;
+    const Checkbox = gooey.components.Checkbox;
+    const TextInput = gooey.components.TextInput;
+
+    const button = Button{ .label = "Save" };
+    const checkbox = Checkbox{ .selected = false, .label = "Remember me" };
+    const text_input = TextInput{ .id = "email", .placeholder = "Email" };
+
+    std.debug.assert(button.label.len > 0);
+    std.debug.assert(text_input.id.len > 0);
+    _ = checkbox;
+    _ = gooey.ui.Theme.light;
+    _ = gooey.components.Image{ .src = "logo.png" };
+    _ = gooey.components.Svg{ .path = "M0 0" };
+}

--- a/src/app.zig
+++ b/src/app.zig
@@ -1,6 +1,6 @@
 //! App - Convenience wrapper for quick application setup
 //!
-//! Provides a simple `run()` function that handles all boilerplate:
+//! Provides a native-only `run()` function that handles all boilerplate:
 //! - Platform initialization
 //! - Window creation
 //! - UI context setup
@@ -13,10 +13,9 @@
 //! var state = struct { count: i32 = 0 }{};
 //!
 //! pub fn main(init: std.process.Init) !void {
-//!     try gooey.run(init, .{
+//!     try gooey.run(@TypeOf(state), &state, render, .{
 //!         .title = "Counter",
-//!         .render = render,
-//!     });
+//!     }, init);
 //! }
 //!
 //! fn render(cx: *gooey.Cx) void {

--- a/src/components/code_editor.zig
+++ b/src/components/code_editor.zig
@@ -12,7 +12,7 @@
 //! ```zig
 //! const gooey = @import("gooey");
 //!
-//! gooey.CodeEditor{
+//! gooey.components.CodeEditor{
 //!     .id = "source",
 //!     .placeholder = "Enter code here...",
 //!     .bind = &state.source_code,

--- a/src/components/context_menu.zig
+++ b/src/components/context_menu.zig
@@ -45,7 +45,7 @@
 //!     .y = s.menu_y,
 //!     .on_close = cx.update(State.closeMenu),
 //!     .items = &.{
-//!         .{ .label = "Cut",  .icon = gooey.Icons.close, .shortcut = "Ctrl+X", .on_click = cx.update(State.cut) },
+//!         .{ .label = "Cut",  .icon = gooey.components.Icons.close, .shortcut = "Ctrl+X", .on_click = cx.update(State.cut) },
 //!         .{ .label = "Copy", .shortcut = "Ctrl+C", .on_click = cx.update(State.copy) },
 //!         .{ .separator = true },
 //!         .{ .label = "Delete", .danger = true, .on_click = cx.update(State.delete) },
@@ -110,7 +110,7 @@ pub const MenuItem = struct {
     /// named `on_select` always has one type and copy-paste can't miscompile.
     on_click: ?HandlerRef = null,
 
-    /// Optional leading icon as SVG markup (e.g. one of `gooey.Lucide`),
+    /// Optional leading icon as SVG markup (e.g. one of `gooey.components.Lucide`),
     /// rendered stroke-based to match the Lucide icon style.
     icon: ?[]const u8 = null,
 

--- a/src/components/image.zig
+++ b/src/components/image.zig
@@ -16,22 +16,22 @@
 //! const gooey = @import("gooey");
 //!
 //! // Simple image from path (works on native AND WASM)
-//! gooey.Image{ .src = "assets/logo.png" }
+//! gooey.components.Image{ .src = "assets/logo.png" }
 //!
 //! // With explicit sizing
-//! gooey.Image{ .src = "photo.jpg", .width = 200, .height = 150 }
+//! gooey.components.Image{ .src = "photo.jpg", .width = 200, .height = 150 }
 //!
 //! // Rounded avatar
-//! gooey.Image{ .src = "avatar.png", .size = 48, .rounded = true }
+//! gooey.components.Image{ .src = "avatar.png", .size = 48, .rounded = true }
 //!
 //! // Cover image (fills container, may crop)
-//! gooey.Image{ .src = "banner.jpg", .width = 800, .height = 200, .fit = .cover }
+//! gooey.components.Image{ .src = "banner.jpg", .width = 800, .height = 200, .fit = .cover }
 //!
 //! // Grayscale + tinted
-//! gooey.Image{ .src = "icon.png", .grayscale = 1.0, .tint = gooey.Color.blue }
+//! gooey.components.Image{ .src = "icon.png", .grayscale = 1.0, .tint = gooey.Color.blue }
 //!
 //! // With placeholder color (shown while loading on WASM)
-//! gooey.Image{ .src = "assets/logo.png", .size = 28, .placeholder = theme.surface }
+//! gooey.components.Image{ .src = "assets/logo.png", .size = 28, .placeholder = theme.surface }
 //! ```
 
 const std = @import("std");

--- a/src/components/svg.zig
+++ b/src/components/svg.zig
@@ -14,16 +14,16 @@
 //! const wave_path = "M2 12 Q6 6 12 12 T22 12";
 //!
 //! // Simple filled icon (uses theme text color)
-//! gooey.Svg{ .path = star_path, .size = 24 }
+//! gooey.components.Svg{ .path = star_path, .size = 24 }
 //!
 //! // Explicit fill color
-//! gooey.Svg{ .path = star_path, .size = 24, .color = .gold }
+//! gooey.components.Svg{ .path = star_path, .size = 24, .color = .gold }
 //!
 //! // Stroke-only icon (no fill) - use no_fill = true for open paths like curves
-//! gooey.Svg{ .path = wave_path, .size = 24, .no_fill = true, .stroke_color = .white, .stroke_width = 2 }
+//! gooey.components.Svg{ .path = wave_path, .size = 24, .no_fill = true, .stroke_color = .white, .stroke_width = 2 }
 //!
 //! // Both fill and stroke
-//! gooey.Svg{ .path = star_path, .size = 24, .color = .red, .stroke_color = .black, .stroke_width = 1 }
+//! gooey.components.Svg{ .path = star_path, .size = 24, .color = .red, .stroke_color = .black, .stroke_width = 1 }
 //! ```
 
 const std = @import("std");

--- a/src/components/validated_text_input.zig
+++ b/src/components/validated_text_input.zig
@@ -13,7 +13,7 @@
 //! ## Usage
 //!
 //! ```zig
-//! gooey.ValidatedTextInput{
+//! gooey.components.ValidatedTextInput{
 //!     .id = "email",
 //!     .label = "Email Address",
 //!     .required_indicator = true,

--- a/src/context/entity.zig
+++ b/src/context/entity.zig
@@ -97,7 +97,7 @@ pub fn Entity(comptime T: type) type {
         ///
         /// ```zig
         /// const CounterButtons = struct {
-        ///     counter: gooey.Entity(Counter),
+        ///     counter: gooey.context.Entity(Counter),
         ///
         ///     pub fn render(self: @This(), b: *ui.Builder) void {
         ///         var cx = self.counter.context(g_window);

--- a/src/ui/mod.zig
+++ b/src/ui/mod.zig
@@ -7,9 +7,9 @@
 //! const gooey = @import("gooey");
 //!
 //! // Components (preferred)
-//! gooey.Button{ .label = "Click", .on_click_handler = cx.update(State.onClick) }
-//! gooey.Checkbox{ .id = "agree", .selected = state.agreed, .on_click_handler = cx.update(State.toggle) }
-//! gooey.TextInput{ .id = "name", .placeholder = "Enter name", .bind = &state.name }
+//! gooey.components.Button{ .label = "Click", .on_click_handler = cx.update(State.onClick) }
+//! gooey.components.Checkbox{ .id = "agree", .selected = state.agreed, .on_click_handler = cx.update(State.toggle) }
+//! gooey.components.TextInput{ .id = "name", .placeholder = "Enter name", .bind = &state.name }
 //!
 //! // Primitives (for text, spacers, etc.)
 //! gooey.ui.text("Hello", .{})

--- a/src/widgets/mod.zig
+++ b/src/widgets/mod.zig
@@ -10,8 +10,8 @@
 //!
 //! // Components (preferred — declarative, themed). The user-facing
 //! // types `TextInput` / `TextArea` live in `components/`.
-//! gooey.TextInput{ .id = "name", .placeholder = "Enter name" }
-//! gooey.TextArea{ .id = "bio", .placeholder = "Enter bio" }
+//! gooey.components.TextInput{ .id = "name", .placeholder = "Enter name" }
+//! gooey.components.TextArea{ .id = "bio", .placeholder = "Enter bio" }
 //!
 //! // Engines (low-level state objects — direct buffer / cursor / IME
 //! // access). These are the heap-allocated structs that the framework
@@ -40,7 +40,7 @@ const interface_verify = @import("../core/interface_verify.zig");
 // Pre-PR-8.4b the engine lived in a `WidgetStore.text_inputs`
 // StringHashMap; PR 8.4b lifted it onto the pool keyed by
 // `(TextInputState, layout_id.id)`. The user-facing declarative
-// component is `gooey.TextInput` in `components/text_input.zig`.
+// component is `gooey.components.TextInput` in `components/text_input.zig`.
 // The two were merged under a single `TextInput` name historically;
 // PR 8.4-prep disambiguates them so PR 8.4b could lift the engine
 // onto the keyed pool without a name clash.
@@ -56,7 +56,7 @@ pub const TextInputStyle = text_input_state.Style;
 // =============================================================================
 //
 // Same engine-vs-component split as `TextInputState` above:
-// `TextAreaState` is the heap-allocated engine; `gooey.TextArea` in
+// `TextAreaState` is the heap-allocated engine; `gooey.components.TextArea` in
 // `components/text_area.zig` is the user-facing declarative component.
 
 pub const text_area_state = @import("text_area_state.zig");

--- a/src/widgets/text_area_state.zig
+++ b/src/widgets/text_area_state.zig
@@ -10,7 +10,7 @@
 //! Naming: this is the *engine* type — the heap-allocated state object
 //! that owns the multi-line text buffer, line index, cursor, IME
 //! composition, edit history, and focus state. The user-facing
-//! declarative component is `gooey.TextArea` in
+//! declarative component is `gooey.components.TextArea` in
 //! `components/text_area.zig`, which is what application code
 //! constructs as a literal
 //! (`TextArea{ .id = "...", .placeholder = "..." }`). The two types

--- a/src/widgets/text_input_state.zig
+++ b/src/widgets/text_input_state.zig
@@ -10,7 +10,7 @@
 //! Naming: this is the *engine* type — the heap-allocated state object
 //! that owns the text buffer, cursor, IME composition, edit history, and
 //! focus state for a single-line text input. The user-facing declarative
-//! component is `gooey.TextInput` in `components/text_input.zig`, which
+//! component is `gooey.components.TextInput` in `components/text_input.zig`, which
 //! is what application code constructs as a literal
 //! (`TextInput{ .id = "...", .placeholder = "..." }`). The two types
 //! used to share the name `TextInput`, which only worked as long as no


### PR DESCRIPTION
## Rationale

Promoted documentation still referenced flat exports removed from Gooey's public surface, leaving downstream users with examples that no longer compiled. This PR moves those references to their canonical namespaces, documents a verified consumer package/build integration, and compile-checks representative promoted snippets in the existing API test.

The default Linux test path also exposed two directly related developer-environment issues: fresh orbs lacked `glslc`, and disconnected AT-SPI signal batches were never consumed. The setup now installs the compiler and the fixed-capacity accessibility queue clears a flushed batch even without D-Bus, preventing stale retries and eventual overflow.

## Changes

- Replace stale `gooey.Button`, `gooey.Checkbox`, `gooey.TextInput`, `gooey.Theme`, asset/component, entity, and `runCx` references in promoted docs and source doc comments.
- Add `build.zig.zon` v0.2.6 coordinates and the real transitive `module("gooey")` consumer wiring to the README; align charts setup.
- Add a representative documentation API compile test to `src/api_check.zig`.
- Label low-level accessibility construction as advanced and custom shaders as advanced/unstable; retain the existing Select legacy label.
- Install `glslc` in orb setup and consume disconnected accessibility signal batches.

## Validation

- `zig fmt src/ui/mod.zig src/widgets/mod.zig src/widgets/text_input_state.zig src/widgets/text_area_state.zig src/components/image.zig src/components/svg.zig src/components/validated_text_input.zig src/components/code_editor.zig src/components/context_menu.zig src/context/entity.zig src/app.zig src/api_check.zig src/accessibility/linux_bridge.zig`
- `git diff --check`
- Local downstream package probe using `.gooey = .{ .path = "../repo" }`, `@import("gooey")`, and `dependency.module("gooey")`: build succeeded with transitive platform linking.
- `zig test src/root.zig --test-filter 'promoted documentation API snippets compile' -I/usr/include -lvulkan -lwayland-client -lfreetype -lharfbuzz -lfontconfig -lpng -ldbus-1 -lc`: 15/15 passed.
- `zig build test --summary all`: 24/24 build steps; 1088/1088 tests passed.
- `zig build -Dskip-shader-compile=true --summary all`: 51/51 build steps succeeded, including `gooey-counter` and `gooey-todo`.
- Counter and Todo launched under supervised headless Weston with llvmpipe; both remained active and rendered at ~39-40 frame callbacks/sec. Inspected screenshots showed all expected controls and empty-state content.

## Known limitation

The headless screenshots expose existing horizontal clipping in Counter's `Reset & Blur` button and Todo's input row. This PR does not change layout/runtime behavior, so that visual issue remains out of scope.