### PR TITLE
Add a fill-window root layout primitive

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -227,11 +227,8 @@ pub fn main(init: std.process.Init) !void {
 
 fn render(cx: *Cx) void {
     const s = cx.state(AppState);
-    const size = cx.windowSize();
 
-    cx.render(ui.box(.{
-        .width = size.width,
-        .height = size.height,
+    cx.render(ui.root(.{
         .direction = .column,
         .padding = .{ .all = 24 },
         .gap = 16,
@@ -1461,6 +1458,9 @@ if (cx.window().readEntity(Counter, entity)) |data| {
 Flexbox-inspired layout with shrink behavior and text wrapping:
 
 ```zig
+// Application roots track the current window size automatically.
+cx.render(ui.root(.{ .padding = .{ .all = 24 } }, .{...}));
+
 cx.render(ui.box(.{
     .direction = .row,           // or .column
     .gap = 16,
@@ -1481,6 +1481,13 @@ cx.render(ui.box(.{ .width = 150, .min_width = 60 }, .{...}));
 // Text wrapping
 ui.text("Long text...", .{ .wrap = .words });  // .none, .words, .newlines
 ```
+
+`grow` participates in flexible-space distribution (`grow_width` and
+`grow_height` select one axis). `fill_width` and `fill_height` request 100% of
+the parent's available size without sharing flex space; percentages request a
+fraction from 0 through 1. Grow wins over fixed sizing, fixed sizing wins over
+percentage and fill, and percentage wins over fill. Min/max constrain grow or
+fixed sizing and select fit sizing when neither is present.
 
 ## Custom Shaders
 

--- a/src/examples/counter.zig
+++ b/src/examples/counter.zig
@@ -87,11 +87,8 @@ pub fn main(init: std.process.Init) !void {
 
 fn render(cx: *Cx) void {
     const s = cx.state(AppState);
-    const size = cx.windowSize();
 
-    cx.render(ui.box(.{
-        .width = size.width,
-        .height = size.height,
+    cx.render(ui.root(.{
         .padding = .{ .all = 32 },
         .gap = 20,
         .direction = .column,

--- a/src/examples/layout.zig
+++ b/src/examples/layout.zig
@@ -59,11 +59,7 @@ pub fn main(init: std.process.Init) !void {
 // =============================================================================
 
 fn render(cx: *Cx) void {
-    const size = cx.windowSize();
-
-    cx.render(ui.box(.{
-        .width = size.width,
-        .height = size.height,
+    cx.render(ui.root(.{
         .background = ui.Color.rgb(0.95, 0.95, 0.95),
         .direction = .column,
         .padding = .{ .all = 20 },

--- a/src/examples/todo.zig
+++ b/src/examples/todo.zig
@@ -182,11 +182,7 @@ pub fn main(init: std.process.Init) !void {
 // =============================================================================
 
 fn render(cx: *Cx) void {
-    const size = cx.windowSize();
-
-    cx.render(ui.box(.{
-        .width = size.width,
-        .height = size.height,
+    cx.render(ui.root(.{
         .direction = .column,
         .padding = .{ .all = 24 },
         .gap = 16,

--- a/src/layout/engine_tests.zig
+++ b/src/layout/engine_tests.zig
@@ -58,6 +58,43 @@ test "basic layout" {
     try std.testing.expect(commands.len > 0);
 }
 
+test "root fill follows viewport resize" {
+    // Goal: a fill-window root must use fresh viewport dimensions every frame.
+    // Methodology: lay out the same root before and after a viewport resize.
+    var engine = LayoutEngine.init(std.testing.allocator);
+    defer engine.deinit();
+
+    engine.beginFrame(320, 240);
+    try engine.openElement(.{
+        .id = LayoutId.init("resizing-root"),
+        .layout = .{ .sizing = .{
+            .width = SizingAxis.percent(1.0),
+            .height = SizingAxis.percent(1.0),
+        } },
+    });
+    engine.closeElement();
+    _ = try engine.endFrame();
+
+    const initial = engine.getBoundingBox(LayoutId.init("resizing-root").id).?;
+    try std.testing.expectEqual(@as(f32, 320), initial.width);
+    try std.testing.expectEqual(@as(f32, 240), initial.height);
+
+    engine.beginFrame(1024, 576);
+    try engine.openElement(.{
+        .id = LayoutId.init("resizing-root"),
+        .layout = .{ .sizing = .{
+            .width = SizingAxis.percent(1.0),
+            .height = SizingAxis.percent(1.0),
+        } },
+    });
+    engine.closeElement();
+    _ = try engine.endFrame();
+
+    const resized = engine.getBoundingBox(LayoutId.init("resizing-root").id).?;
+    try std.testing.expectEqual(@as(f32, 1024), resized.width);
+    try std.testing.expectEqual(@as(f32, 576), resized.height);
+}
+
 test "nested layout" {
     var engine = LayoutEngine.init(std.testing.allocator);
     defer engine.deinit();

--- a/src/ui/builder.zig
+++ b/src/ui/builder.zig
@@ -597,6 +597,8 @@ pub const Builder = struct {
 
     /// Internal: Box implementation with pre-resolved LayoutId
     fn boxWithLayoutIdImpl(self: *Self, layout_id: LayoutId, props: Box, children: anytype, source_loc: SourceLoc, is_canvas: bool) void {
+        // Reject bad inputs before they propagate through every layout pass.
+        std.debug.assert(props.sizingIsValid());
 
         // Push dispatch node at element open
         _ = self.dispatch.pushNode();

--- a/src/ui/mod.zig
+++ b/src/ui/mod.zig
@@ -62,6 +62,7 @@ pub const canvas = canvas_mod.canvas;
 pub const canvasWithData = canvas_mod.canvasWithData;
 
 // Container element functions: return element structs for use with cx.render().
+pub const root = primitives.root;
 pub const box = primitives.box;
 pub const rect = primitives.rect;
 pub const hstack = primitives.hstack;

--- a/src/ui/primitives.zig
+++ b/src/ui/primitives.zig
@@ -450,6 +450,48 @@ pub fn box(style: styles.Box, children: anytype) BoxElement(@TypeOf(children), f
     return .{ .style = style, .children = children, .source_loc = {} };
 }
 
+/// Create the application's root box, sized to the current window every frame.
+///
+/// `style` controls appearance and child layout. Explicit sizing is diagnosed
+/// in safety builds and ignored otherwise because it would make the fill-window
+/// contract ambiguous. Use `box` for a deliberately fixed-size root.
+pub fn root(style: styles.Box, children: anytype) BoxElement(@TypeOf(children), false) {
+    assertRootStyleHasNoSizing(style);
+
+    var root_style = style;
+    // Preserve the contract where diagnostic assertions are compiled out.
+    root_style.width = null;
+    root_style.height = null;
+    root_style.min_width = null;
+    root_style.min_height = null;
+    root_style.max_width = null;
+    root_style.max_height = null;
+    root_style.grow = false;
+    root_style.grow_width = false;
+    root_style.grow_height = false;
+    root_style.fill_width = true;
+    root_style.fill_height = true;
+    root_style.width_percent = null;
+    root_style.height_percent = null;
+    return .{ .style = root_style, .children = children, .source_loc = {} };
+}
+
+fn assertRootStyleHasNoSizing(style: styles.Box) void {
+    std.debug.assert(style.width == null);
+    std.debug.assert(style.height == null);
+    std.debug.assert(style.min_width == null);
+    std.debug.assert(style.min_height == null);
+    std.debug.assert(style.max_width == null);
+    std.debug.assert(style.max_height == null);
+    std.debug.assert(!style.grow);
+    std.debug.assert(!style.grow_width);
+    std.debug.assert(!style.grow_height);
+    std.debug.assert(!style.fill_width);
+    std.debug.assert(!style.fill_height);
+    std.debug.assert(style.width_percent == null);
+    std.debug.assert(style.height_percent == null);
+}
+
 /// Childless box — a visual-only rectangle (divider, spacer, colored block).
 ///
 /// Equivalent to `box(style, .{})` but without the empty children tuple:
@@ -592,6 +634,16 @@ test "box element primitive" {
     try std.testing.expectEqual(PrimitiveType.box_element, @TypeOf(b).primitive_type);
     try std.testing.expectEqual(@as(?f32, 100), b.style.width);
     try std.testing.expectEqual(@as(?f32, 50), b.style.height);
+}
+
+test "root primitive fills the window without explicit dimensions" {
+    // Goal: roots request both parent axes while retaining normal Box styling.
+    // Methodology: inspect the descriptor that the builder receives.
+    const r = root(.{ .padding = .{ .all = 16 }, .gap = 8 }, .{});
+    try std.testing.expectEqual(PrimitiveType.box_element, @TypeOf(r).primitive_type);
+    try std.testing.expect(r.style.fill_width);
+    try std.testing.expect(r.style.fill_height);
+    try std.testing.expectEqual(@as(f32, 8), r.style.gap);
 }
 
 test "hstack element primitive" {

--- a/src/ui/styles.zig
+++ b/src/ui/styles.zig
@@ -168,20 +168,29 @@ pub const TextStyle = struct {
 
 /// Box is the fundamental UI primitive. All interactive elements are built on Box.
 pub const Box = struct {
-    // Sizing
+    // Sizing. Grow wins over fixed sizing; fixed sizing wins over percentage
+    // and fill; percentage wins over fill. Min/max constrain grow or fixed
+    // sizing and select fit sizing when neither is present.
     width: ?f32 = null,
     height: ?f32 = null,
     min_width: ?f32 = null,
     min_height: ?f32 = null,
     max_width: ?f32 = null,
     max_height: ?f32 = null,
-    grow: bool = false, // Grow both axes
-    grow_width: bool = false, // Grow width only
-    grow_height: bool = false, // Grow height only
-    fill_width: bool = false, // 100% of parent width
-    fill_height: bool = false, // 100% of parent height
-    width_percent: ?f32 = null, // Percentage of parent width (0.0-1.0)
-    height_percent: ?f32 = null, // Percentage of parent height (0.0-1.0)
+    /// Participate in flexible space distribution on both axes.
+    grow: bool = false,
+    /// Participate in flexible horizontal space distribution.
+    grow_width: bool = false,
+    /// Participate in flexible vertical space distribution.
+    grow_height: bool = false,
+    /// Occupy 100% of the parent's available width without sharing flex space.
+    fill_width: bool = false,
+    /// Occupy 100% of the parent's available height without sharing flex space.
+    fill_height: bool = false,
+    /// Fraction of the parent's available width, in the inclusive range 0...1.
+    width_percent: ?f32 = null,
+    /// Fraction of the parent's available height, in the inclusive range 0...1.
+    height_percent: ?f32 = null,
 
     // Spacing
     padding: PaddingValue = .{ .all = 0 },
@@ -287,7 +296,32 @@ pub const Box = struct {
             .each => |e| e.top > 0 or e.right > 0 or e.bottom > 0 or e.left > 0,
         };
     }
+
+    /// Reports whether percentages can be resolved without invalid geometry.
+    /// The builder asserts this at the public layout boundary in safety builds.
+    pub fn sizingIsValid(self: Box) bool {
+        if (self.width_percent) |value| {
+            if (!std.math.isFinite(value)) return false;
+            if (value < 0 or value > 1) return false;
+        }
+        if (self.height_percent) |value| {
+            if (!std.math.isFinite(value)) return false;
+            if (value < 0 or value > 1) return false;
+        }
+        return true;
+    }
 };
+
+test "Box rejects percentages outside the parent range" {
+    // Goal: prevent invalid percentages from reaching layout arithmetic.
+    // Methodology: exercise both axes, infinities, NaN, and valid endpoints.
+    try std.testing.expect((Box{ .width_percent = 0 }).sizingIsValid());
+    try std.testing.expect((Box{ .height_percent = 1 }).sizingIsValid());
+    try std.testing.expect(!(Box{ .width_percent = -0.01 }).sizingIsValid());
+    try std.testing.expect(!(Box{ .height_percent = 1.01 }).sizingIsValid());
+    try std.testing.expect(!(Box{ .width_percent = std.math.inf(f32) }).sizingIsValid());
+    try std.testing.expect(!(Box{ .height_percent = std.math.nan(f32) }).sizingIsValid());
+}
 
 // =============================================================================
 // Input Styles


### PR DESCRIPTION
## Summary

- add `ui.root(style, children)`, a Box-compatible application root that fills the current viewport every frame
- migrate counter, todo, layout, and the README quick start away from manual `cx.windowSize()` plumbing
- document the compatibility-preserving semantics of `grow`, axis-specific grow, fill, percentage, fixed, and min/max sizing
- reject non-finite and out-of-range percentages at the Builder boundary in safety builds
- cover the root descriptor and percentage-fill behavior across viewport resize

## Why this scope

The sizing audit found 39 example calls to `cx.windowSize()`, commonly just to copy width and height into the root Box. A focused root primitive removes that routine application boilerplate without changing layout internals.

The field audit found substantial established usage (`fill_width` 113 times and `grow` 20 times in examples, plus intentional combinations such as grow with min/max or redundant lower-precedence fields). This PR therefore retains every existing field and the current resolution order rather than consolidating or renaming them:

- grow wins over fixed sizing
- fixed sizing wins over percentage and fill
- percentage wins over fill
- min/max constrain grow or fixed sizing, or select fit sizing when neither is present

`ui.root` diagnoses explicit sizing in safety builds and normalizes it away where assertions are compiled out, so its fill-window contract remains deterministic in every optimization mode. Layout continues to resolve its 100% percentages against the fresh viewport passed to `beginFrame`, preserving resize behavior.

## Validation

- `zig fmt src/ui/styles.zig src/ui/builder.zig src/ui/primitives.zig src/ui/mod.zig src/layout/engine_tests.zig src/examples/counter.zig src/examples/todo.zig src/examples/layout.zig src/examples/showcase.zig`
- `dbus-run-session -- zig build test` (exit 0; wrapper provides the session bus required by the existing Linux accessibility test)
- `zig build -Dskip-shader-compile=true` (all native examples, including counter, todo, layout, and showcase)
- launched counter, todo, layout, and showcase under the repository's supervised headless Weston/Vulkan preview path; all remained active with clean application logs
- inspected screenshots for all four apps; the known narrow-window clipping in counter, todo, and layout was reproduced unchanged from `origin/main`, so it is not introduced by this PR
- compared root fill at 320×240 and 1024×576 in the new regression test

## Intentionally deferred P2 items

- **Cx application/runtime API separation:** useful, but independent of root sizing and likely deserves a documentation/visibility audit of its own.
- **Async queue/group setup helper:** skipped because no clearly reusable abstraction emerged within this sizing-focused change; capacities and cancellation remain explicit.
- **Sizing field consolidation:** skipped to avoid breaking established application/component combinations. This PR documents and validates the current contract instead.
- **Wholesale example migration:** only representative ordinary apps and the quick start are migrated; examples that use `windowSize()` for canvas, change detection, or explicit behavior remain untouched.
