### PR TITLE
Make stateful component bindings explicit and controlled

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,14 +198,10 @@ const AppState = struct {
         };
     }
 
-    // Command — needs framework access (the binding only flows widget -> state,
-    // so we reach the retained input widget to clear it after adding).
-    pub fn addTodo(self: *AppState, g: *gooey.Window) void {
+    // Controlled binding: resetting the model clears retained editor state.
+    pub fn addTodo(self: *AppState) void {
         self.pushTodo(self.draft);
         self.draft = "";
-        if (g.widgetState(gooey.widgets.TextInputState, draft_input_id)) |input| {
-            input.clear();
-        }
     }
 };
 
@@ -239,10 +235,10 @@ fn render(cx: *Cx) void {
     }, .{
         ui.text("Todos", .{ .size = 28 }),
 
-        // Input row: TextInput binds to state.draft; Add is a command.
+        // Input row: TextInput binds to state.draft; Add resets the model.
         ui.hstack(.{ .gap = 8, .alignment = .{ .cross = .center } }, .{
-            TextInput{ .id = draft_input_id, .placeholder = "What needs doing?", .bind = &s.draft, .fill_width = true },
-            Button{ .label = "Add", .on_click_handler = cx.command(AppState.addTodo) },
+            TextInput{ .id = draft_input_id, .placeholder = "What needs doing?", .bind = &s.draft, .width = 360 },
+            Button{ .label = "Add", .on_click_handler = cx.update(AppState.addTodo) },
         }),
 
         // Filters: each button packs its enum value into the handler arg.
@@ -731,6 +727,11 @@ TextArea{
 }
 ```
 
+Bindings are controlled and two-way: user edits update the bound slice, and
+assigning a new model value (including `""`) updates the retained editor on the
+next render. Active IME preedit is allowed to finish before an external value is
+applied, and valid cursor/selection offsets are preserved.
+
 ### Checkbox
 
 ```zig
@@ -788,7 +789,11 @@ Select{
 
 The widget manages open/close state internally — no toggle/close handlers or per-option handler arrays needed. Just provide `on_select` and a single handler that receives the selected index.
 
-> **Legacy API:** The explicit `is_open` / `on_toggle` / `on_close` / `handlers` fields are still supported for full manual control.
+> **Legacy API:** The explicit `is_open` / `on_toggle` / `on_close` / `handlers`
+> fields are still supported for full manual control. `on_select` may be paired
+> with manual toggle/close handlers, but it is mutually exclusive with the
+> per-option `handlers` array. Use `controlMode()` to inspect which open-state
+> contract a configuration selects.
 
 ### Modal
 

--- a/src/components/select.zig
+++ b/src/components/select.zig
@@ -168,7 +168,8 @@ pub const Select = struct {
     /// Placeholder text when nothing is selected
     placeholder: []const u8 = "Select...",
 
-    /// Whether the dropdown is currently open (legacy — ignored when using on_select)
+    /// Whether the dropdown is currently open. Legacy manual-control field;
+    /// ignored only when `controlMode()` resolves to `.internal`.
     is_open: bool = false,
 
     // === New API: on_select (recommended) ===
@@ -194,6 +195,8 @@ pub const Select = struct {
     on_close: ?HandlerRef = null,
 
     /// Array of handlers, one per option. Use cx.updateWith() to create these.
+    /// Mutually exclusive with `on_select`; mixing both selection APIs traps
+    /// during render instead of silently preferring this legacy field.
     handlers: ?[]const HandlerRef = null,
 
     // === Layout ===
@@ -262,9 +265,23 @@ pub const Select = struct {
         }
     };
 
+    /// Select either owns open/close state or delegates it to legacy manual
+    /// fields. Exposed so callers can reason about compatibility explicitly.
+    pub const ControlMode = enum {
+        internal,
+        manual,
+    };
+
+    pub const ControlError = error{
+        MixedSelectionHandlers,
+    };
+
     pub fn render(self: Select, cx: *ui.Cx) void {
         std.debug.assert(self.id.len > 0);
         std.debug.assert(self.options.len <= MAX_SELECT_OPTIONS);
+        self.validateControl() catch {
+            @panic("Select: on_select and legacy handlers are mutually exclusive");
+        };
 
         const layout_id = LayoutId.fromString(self.id);
         const t = cx.theme();
@@ -315,7 +332,7 @@ pub const Select = struct {
                 .selected = self.selected,
                 .handlers = self.handlers,
                 .on_select = self.on_select,
-                .id_hash = if (self.usesInternalState()) layout_id.id else 0,
+                .id_hash = if (self.controlMode() == .internal) layout_id.id else 0,
                 .on_close = resolved.close_handler,
                 .min_width = self.min_dropdown_width orelse self.width,
                 .background = colors.background,
@@ -331,19 +348,31 @@ pub const Select = struct {
         });
     }
 
-    /// Determine whether this Select uses internal (widget-managed) open/close state.
-    /// True when `on_select` is set and no legacy toggle/close/handlers are provided.
-    fn usesInternalState(self: Select) bool {
-        return self.on_select != null and
+    /// Determine whether this Select uses widget-managed or manual open state.
+    /// `on_select` with explicit toggle/close handlers remains supported as a
+    /// manual-control compatibility path.
+    pub fn controlMode(self: Select) ControlMode {
+        std.debug.assert(self.id.len > 0);
+        std.debug.assert(self.options.len <= MAX_SELECT_OPTIONS);
+        const uses_internal_state = self.on_select != null and
             self.on_toggle == null and
             self.on_close == null and
             self.handlers == null;
+        return if (uses_internal_state) .internal else .manual;
+    }
+
+    pub fn validateControl(self: Select) ControlError!void {
+        std.debug.assert(self.id.len > 0);
+        std.debug.assert(self.options.len <= MAX_SELECT_OPTIONS);
+        if (self.on_select != null and self.handlers != null) {
+            return error.MixedSelectionHandlers;
+        }
     }
 
     /// Resolve open/close state and handlers — internal vs external.
     fn resolveState(self: Select, cx: *ui.Cx, layout_id: LayoutId) ResolvedState {
         // Legacy path: caller manages open/close externally
-        if (!self.usesInternalState()) {
+        if (self.controlMode() == .manual) {
             std.debug.assert(self.on_select != null or self.handlers != null or
                 self.on_toggle == null);
             return .{
@@ -416,7 +445,6 @@ pub const Select = struct {
 
     fn getDisplayText(self: Select) []const u8 {
         if (self.selected) |idx| {
-            std.debug.assert(self.options.len > 0);
             if (idx < self.options.len) {
                 return self.options[idx];
             }
@@ -424,6 +452,41 @@ pub const Select = struct {
         return self.placeholder;
     }
 };
+
+test "Select control mode distinguishes internal and compatibility paths" {
+    // The canonical on_select-only shape owns open state. Supplying either
+    // manual open-state handler deliberately retains legacy external control.
+    const callback: OnSelectHandler = undefined;
+    const handler: HandlerRef = undefined;
+    const options = &.{"One"};
+
+    try std.testing.expectEqual(Select.ControlMode.internal, (Select{
+        .id = "internal",
+        .options = options,
+        .on_select = callback,
+    }).controlMode());
+    try std.testing.expectEqual(Select.ControlMode.manual, (Select{
+        .id = "manual",
+        .options = options,
+        .on_select = callback,
+        .on_toggle = handler,
+    }).controlMode());
+}
+
+test "Select rejects mixed canonical and legacy selection handlers" {
+    // Selection must have one source; this catches the formerly silent
+    // `handlers`-wins precedence before event wiring can become ambiguous.
+    const callback: OnSelectHandler = undefined;
+    const handler: HandlerRef = undefined;
+    const select = Select{
+        .id = "invalid",
+        .options = &.{"One"},
+        .on_select = callback,
+        .handlers = &.{handler},
+    };
+
+    try std.testing.expectError(error.MixedSelectionHandlers, select.validateControl());
+}
 
 // =============================================================================
 // Sub-components

--- a/src/components/tabs.zig
+++ b/src/components/tabs.zig
@@ -8,9 +8,9 @@
 //! Usage with Cx (recommended):
 //! ```zig
 //! cx.render(ui.box(.{ .direction = .row, .gap = 0 }, .{
-//!     Tab{ .label = "Home", .selected = s.page == 0, .on_click = cx.updateWith(@as(u8, 0), State.setPage) },
-//!     Tab{ .label = "Settings", .selected = s.page == 1, .on_click = cx.updateWith(@as(u8, 1), State.setPage) },
-//!     Tab{ .label = "About", .selected = s.page == 2, .on_click = cx.updateWith(@as(u8, 2), State.setPage) },
+//!     Tab{ .label = "Home", .selected = s.page == 0, .on_click_handler = cx.updateWith(@as(u8, 0), State.setPage) },
+//!     Tab{ .label = "Settings", .selected = s.page == 1, .on_click_handler = cx.updateWith(@as(u8, 1), State.setPage) },
+//!     Tab{ .label = "About", .selected = s.page == 2, .on_click_handler = cx.updateWith(@as(u8, 2), State.setPage) },
 //! }));
 //! ```
 //!
@@ -36,9 +36,11 @@ pub const Tab = struct {
     label: []const u8,
     selected: bool,
 
-    // Click handler - use with cx.updateWith() for index-based navigation.
-    // No `_handler` suffix: Tab has no stateless `on_click` variant, so the
-    // base name is free (unlike Button/Checkbox which keep both).
+    /// Canonical click handler name, matching Button and Checkbox.
+    on_click_handler: ?HandlerRef = null,
+
+    /// Compatibility alias for the original Tab API. Prefer
+    /// `on_click_handler`; setting both fields is invalid.
     on_click: ?HandlerRef = null,
 
     // Styling (null = use theme)
@@ -72,6 +74,8 @@ pub const Tab = struct {
 
     pub fn render(self: Tab, cx: *ui.Cx) void {
         const t = cx.theme();
+        if (self.on_click != null) std.debug.assert(self.on_click_handler == null);
+        if (self.on_click_handler != null) std.debug.assert(self.on_click == null);
 
         // Resolve font size: explicit override OR theme base
         const font_size = self.font_size orelse t.font_size_base;
@@ -134,7 +138,7 @@ pub const Tab = struct {
             .border_color = if (self.variant == .underline and self.selected) active_bg else Color.transparent,
             .alignment = .{ .main = .center, .cross = .center },
             .grow = self.grow,
-            .on_click_handler = self.on_click,
+            .on_click_handler = self.on_click_handler orelse self.on_click,
         }, .{
             ui.text(self.label, .{ .color = text_color, .size = font_size }),
         });
@@ -145,11 +149,24 @@ pub const Tab = struct {
         return .{
             .label = label,
             .selected = selected,
-            .on_click = handler,
+            .on_click_handler = handler,
             .variant = variant,
         };
     }
 };
+
+test "Tab canonical click handler and compatibility alias resolve identically" {
+    // Both field names remain source compatible, while the canonical path now
+    // matches Button/Checkbox and the primitive Box event field.
+    const handler: HandlerRef = undefined;
+    const canonical = Tab{ .label = "One", .selected = false, .on_click_handler = handler };
+    const legacy = Tab{ .label = "One", .selected = false, .on_click = handler };
+
+    try std.testing.expect(canonical.on_click_handler != null);
+    try std.testing.expect(canonical.on_click == null);
+    try std.testing.expect(legacy.on_click_handler == null);
+    try std.testing.expect(legacy.on_click != null);
+}
 
 /// A tab bar container that renders multiple tabs with simple fn callback.
 /// For more control (especially with Cx handlers), render Tab components directly.

--- a/src/components/text_area.zig
+++ b/src/components/text_area.zig
@@ -19,6 +19,9 @@ pub const TextArea = struct {
 
     // Content
     placeholder: []const u8 = "",
+    /// Controlled two-way binding. User edits update the model; changed model
+    /// values reconcile into retained editor state without resetting valid
+    /// cursor/selection offsets or interrupting active IME preedit.
     bind: ?*[]const u8 = null,
 
     // Layout

--- a/src/components/text_input.zig
+++ b/src/components/text_input.zig
@@ -20,6 +20,9 @@ pub const TextInput = struct {
     // Content
     placeholder: []const u8 = "",
     secure: bool = false,
+    /// Controlled two-way binding. User edits update the model; changed model
+    /// values reconcile into retained editor state without resetting valid
+    /// cursor/selection offsets or interrupting active IME preedit.
     bind: ?*[]const u8 = null,
 
     // State

--- a/src/examples/todo.zig
+++ b/src/examples/todo.zig
@@ -8,7 +8,6 @@
 //! - Pure state methods + `cx.update` (toggle-free mutations like clearCompleted)
 //! - `cx.updateWith` with a packed index argument (toggle / remove a row)
 //! - `cx.updateWith` with a packed enum argument (filter switch)
-//! - `cx.command` for framework access (clearing the input widget's buffer)
 //! - `TextInput` two-way binding via `.bind`
 //! - `Checkbox`, `Button` variants/sizes
 //! - Layout with `ui.box` (backgrounds, `{ .main, .cross }` alignment) vs
@@ -37,8 +36,6 @@ const TextInput = gooey.components.TextInput;
 const MAX_TODOS = 64;
 const TEXT_CAP = 128;
 
-/// Stable layout id for the draft input. Used both to render the field and to
-/// reach its retained widget buffer from `addTodo` so we can clear it.
 const draft_input_id = "new-todo";
 
 // =============================================================================
@@ -66,8 +63,7 @@ const Filter = enum { all, active, done };
 const AppState = struct {
     todos: [MAX_TODOS]Todo = [_]Todo{.{}} ** MAX_TODOS,
     count: usize = 0,
-    /// Bound to the TextInput; the widget writes the live text back here each
-    /// frame (widget -> state only — see `addTodo` for why clearing is manual).
+    /// Bound to the TextInput through a controlled two-way binding.
     draft: []const u8 = "",
     filter: Filter = .all,
 
@@ -139,19 +135,13 @@ const AppState = struct {
     }
 
     // -------------------------------------------------------------------------
-    // Command — needs Window access, so it goes through `cx.command`.
+    // Bound action.
     // -------------------------------------------------------------------------
 
-    /// Add the current draft, then clear the input. The binding only flows
-    /// widget -> state, so zeroing `self.draft` is not enough; we reach the
-    /// retained `TextInputState` by its string id and clear its buffer.
-    pub fn addTodo(self: *AppState, g: *gooey.Window) void {
+    /// Add the current draft, then reset the controlled input value.
+    pub fn addTodo(self: *AppState) void {
         self.pushTodo(self.draft);
         self.draft = "";
-
-        if (g.widgetState(gooey.widgets.TextInputState, draft_input_id)) |input| {
-            input.clear();
-        }
     }
 };
 
@@ -205,8 +195,7 @@ fn render(cx: *Cx) void {
 // Components
 // =============================================================================
 
-/// Text field + Add button. The field binds straight to `state.draft`; Add is
-/// a command because it has to clear the input widget after appending.
+/// Text field + Add button. Resetting the bound model clears the input.
 const InputRow = struct {
     pub fn render(_: @This(), cx: *Cx) void {
         const s = cx.state(AppState);
@@ -216,9 +205,9 @@ const InputRow = struct {
                 .id = draft_input_id,
                 .placeholder = "What needs doing?",
                 .bind = &s.draft,
-                .fill_width = true,
+                .width = 360,
             },
-            Button{ .label = "Add", .on_click_handler = cx.command(AppState.addTodo) },
+            Button{ .label = "Add", .on_click_handler = cx.update(AppState.addTodo) },
         }));
     }
 };
@@ -359,6 +348,17 @@ test "add trims, ignores blanks, and respects capacity" {
     var i: usize = 0;
     while (i < MAX_TODOS + 5) : (i += 1) s.pushTodo("x");
     try std.testing.expectEqual(@as(usize, MAX_TODOS), s.count);
+}
+
+test "addTodo appends the controlled draft and resets its model value" {
+    // The widget observes the empty model on the next render; no retained
+    // TextInputState lookup is required in the application handler.
+    var s = AppState{ .draft = "  buy milk  " };
+
+    s.addTodo();
+    try std.testing.expectEqual(@as(usize, 1), s.count);
+    try std.testing.expectEqualStrings("buy milk", s.todos[0].text());
+    try std.testing.expectEqualStrings("", s.draft);
 }
 
 test "toggle flips done and is bounds-checked" {

--- a/src/platform/web/composition_buffer.zig
+++ b/src/platform/web/composition_buffer.zig
@@ -14,7 +14,9 @@ pub const CompositionBuffer = extern struct {
     len: u32 align(4) = 0,
     /// Whether composition is active
     active: u8 = 0,
-    _pad: [3]u8 = .{ 0, 0, 0 },
+    /// One-shot event flag, including the empty event emitted on end/cancel.
+    pending: u8 = 0,
+    _pad: [2]u8 = .{ 0, 0 },
     /// The composing/preedit text
     data: [BUFFER_SIZE]u8 = undefined,
 
@@ -28,6 +30,10 @@ pub const CompositionBuffer = extern struct {
         return self.len > 0;
     }
 
+    pub fn hasPending(self: *const volatile Self) bool {
+        return self.pending != 0;
+    }
+
     pub fn getText(self: *volatile Self) []const u8 {
         const length = self.len;
         const non_volatile = @as(*Self, @volatileCast(self));
@@ -37,6 +43,7 @@ pub const CompositionBuffer = extern struct {
     pub fn clear(self: *volatile Self) void {
         self.len = 0;
         self.active = 0;
+        self.pending = 0;
     }
 };
 
@@ -61,11 +68,34 @@ const InputEvent = input.InputEvent;
 /// Process pending composition events
 pub fn processComposition(handler: *const fn (InputEvent) bool) bool {
     const buf = @as(*volatile CompositionBuffer, &g_composition_buffer);
-    if (!buf.isActive()) return false;
+    if (!buf.hasPending()) return false;
 
     const text = buf.getText();
     const event = InputEvent{ .composition = .{ .text = text } };
     _ = handler(event);
+    buf.pending = 0;
 
     return true;
+}
+
+test "composition end emits one empty event to clear retained preedit" {
+    // Browser cancellation/end is represented by pending + zero bytes. The
+    // event is consumed exactly once so model reconciliation can resume.
+    const Capture = struct {
+        var calls: u32 = 0;
+
+        fn handler(event: InputEvent) bool {
+            calls += 1;
+            return event.composition.text.len == 0;
+        }
+    };
+    const buf = @as(*volatile CompositionBuffer, &g_composition_buffer);
+    buf.clear();
+    defer buf.clear();
+    Capture.calls = 0;
+    buf.pending = 1;
+
+    try @import("std").testing.expect(processComposition(Capture.handler));
+    try @import("std").testing.expectEqual(@as(u32, 1), Capture.calls);
+    try @import("std").testing.expect(!processComposition(Capture.handler));
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -374,6 +374,9 @@ test {
         @import("widgets/edit_history.zig"),
         @import("widgets/text_common.zig"),
 
+        // Platform-independent web input buffer logic.
+        @import("platform/web/composition_buffer.zig"),
+
         // Scene leaves — path/polyline/svg test-heavy files.
         @import("scene/path.zig"),
         @import("scene/path_instance.zig"),

--- a/src/runtime/frame.zig
+++ b/src/runtime/frame.zig
@@ -335,6 +335,12 @@ fn renderTextWidgets(window: *Window, builder: *const Builder) !void {
 fn renderTextInput(window: *Window, pending: *const Builder.PendingInput) !void {
     const bounds = window.layout.getBoundingBox(pending.layout_id.id) orelse return;
     const input_widget = window.element_states.get(TextInputState, @as(u64, pending.layout_id.id)) orelse return;
+    std.debug.assert(pending.layout_id.id != 0);
+    std.debug.assert(input_widget.cursor_byte <= input_widget.getText().len);
+
+    if (pending.style.bind) |binding| {
+        _ = try input_widget.syncBoundText(binding.*);
+    }
 
     // If disabled and currently focused, blur it
     if (pending.style.disabled and input_widget.isFocused()) {
@@ -370,6 +376,12 @@ fn renderTextInput(window: *Window, pending: *const Builder.PendingInput) !void 
 fn renderTextArea(window: *Window, pending: *const Builder.PendingTextArea) !void {
     const bounds = window.layout.getBoundingBox(pending.layout_id.id) orelse return;
     const ta_widget = window.element_states.get(TextAreaState, @as(u64, pending.layout_id.id)) orelse return;
+    std.debug.assert(pending.layout_id.id != 0);
+    std.debug.assert(ta_widget.cursor_byte <= ta_widget.getText().len);
+
+    if (pending.style.bind) |binding| {
+        _ = try ta_widget.syncBoundText(binding.*);
+    }
 
     const inset = pending.style.padding + pending.style.border_width;
     // Compute inner_width from layout bounds when fill_width is true

--- a/src/runtime/input.zig
+++ b/src/runtime/input.zig
@@ -661,8 +661,9 @@ fn handleKeyDownEvent(cx: *Cx, window: *Window, k: input_mod.KeyEvent) bool {
     // Handle focused TextInput
     if (focusedTextInput(window, builder)) |input| {
         if (isControlKey(k.key, k.modifiers)) {
+            const binding_deferred = reconcileTextInputBinding(cx, input);
             input.handleKey(k) catch {};
-            syncBoundVariablesCx(cx);
+            if (!binding_deferred) writeTextInputBinding(cx, input);
             cx.notify();
             return true;
         }
@@ -671,8 +672,9 @@ fn handleKeyDownEvent(cx: *Cx, window: *Window, k: input_mod.KeyEvent) bool {
     // Handle focused TextArea
     if (focusedTextArea(window, builder)) |ta| {
         if (isControlKey(k.key, k.modifiers)) {
+            const binding_deferred = reconcileTextAreaBinding(cx, ta);
             ta.handleKey(k) catch {};
-            syncTextAreaBoundVariablesCx(cx);
+            if (!binding_deferred) writeTextAreaBinding(cx, ta);
             cx.notify();
             return true;
         }
@@ -730,14 +732,16 @@ fn handleFocusedKeyAction(cx: *Cx, window: *Window, k: input_mod.KeyEvent) bool 
 fn handleTextInputEvent(cx: *Cx, window: *Window, text: []const u8) bool {
     const builder = cx.builder();
     if (focusedTextInput(window, builder)) |input| {
+        const binding_deferred = reconcileTextInputBinding(cx, input);
         input.insertText(text) catch {};
-        syncBoundVariablesCx(cx);
+        if (!binding_deferred) writeTextInputBinding(cx, input);
         cx.notify();
         return true;
     }
     if (focusedTextArea(window, builder)) |ta| {
+        const binding_deferred = reconcileTextAreaBinding(cx, ta);
         ta.insertText(text) catch {};
-        syncTextAreaBoundVariablesCx(cx);
+        if (!binding_deferred) writeTextAreaBinding(cx, ta);
         cx.notify();
         return true;
     }
@@ -754,11 +758,13 @@ fn handleTextInputEvent(cx: *Cx, window: *Window, text: []const u8) bool {
 fn handleCompositionEvent(cx: *Cx, window: *Window, text: []const u8) bool {
     const builder = cx.builder();
     if (focusedTextInput(window, builder)) |input| {
+        _ = reconcileTextInputBinding(cx, input);
         input.setComposition(text) catch {};
         cx.notify();
         return true;
     }
     if (focusedTextArea(window, builder)) |ta| {
+        _ = reconcileTextAreaBinding(cx, ta);
         ta.setComposition(text) catch {};
         cx.notify();
         return true;
@@ -775,32 +781,62 @@ fn handleCompositionEvent(cx: *Cx, window: *Window, text: []const u8) bool {
 // Bound Variable Syncing
 // =============================================================================
 
+fn reconcileTextInputBinding(cx: *Cx, input: *TextInputState) bool {
+    std.debug.assert(input.cursor_byte <= input.getText().len);
+    std.debug.assert(input.preedit_cursor <= input.preedit_buffer.items.len);
+    for (cx.builder().pending_inputs.items) |pending| {
+        const candidate = cx.window().element_states.get(TextInputState, @as(u64, pending.layout_id.id)) orelse continue;
+        if (candidate != input) continue;
+        const binding = pending.style.bind orelse return false;
+        return (input.syncBoundText(binding.*) catch return true) == .deferred_ime;
+    }
+    return false;
+}
+
+fn reconcileTextAreaBinding(cx: *Cx, text_area: *TextAreaState) bool {
+    std.debug.assert(text_area.cursor_byte <= text_area.getText().len);
+    std.debug.assert(text_area.preedit_cursor <= text_area.preedit_buffer.items.len);
+    for (cx.builder().pending_text_areas.items) |pending| {
+        const candidate = cx.window().element_states.get(TextAreaState, @as(u64, pending.layout_id.id)) orelse continue;
+        if (candidate != text_area) continue;
+        const binding = pending.style.bind orelse return false;
+        return (text_area.syncBoundText(binding.*) catch return true) == .deferred_ime;
+    }
+    return false;
+}
+
+fn writeTextInputBinding(cx: *Cx, input: *TextInputState) void {
+    std.debug.assert(input.cursor_byte <= input.getText().len);
+    std.debug.assert(input.preedit_cursor <= input.preedit_buffer.items.len);
+    for (cx.builder().pending_inputs.items) |pending| {
+        const candidate = cx.window().element_states.get(TextInputState, @as(u64, pending.layout_id.id)) orelse continue;
+        if (candidate != input) continue;
+        if (pending.style.bind) |binding| binding.* = input.getText();
+        return;
+    }
+}
+
+fn writeTextAreaBinding(cx: *Cx, text_area: *TextAreaState) void {
+    std.debug.assert(text_area.cursor_byte <= text_area.getText().len);
+    std.debug.assert(text_area.preedit_cursor <= text_area.preedit_buffer.items.len);
+    for (cx.builder().pending_text_areas.items) |pending| {
+        const candidate = cx.window().element_states.get(TextAreaState, @as(u64, pending.layout_id.id)) orelse continue;
+        if (candidate != text_area) continue;
+        if (pending.style.bind) |binding| binding.* = text_area.getText();
+        return;
+    }
+}
+
 /// Sync TextInput content back to bound variables (Cx version).
 pub fn syncBoundVariablesCx(cx: *Cx) void {
-    const builder = cx.builder();
-    const window = cx.window();
-
-    for (builder.pending_inputs.items) |pending| {
-        if (pending.style.bind) |bind_ptr| {
-            if (window.element_states.get(TextInputState, @as(u64, pending.layout_id.id))) |input| {
-                bind_ptr.* = input.getText();
-            }
-        }
-    }
+    const input = focusedTextInput(cx.window(), cx.builder()) orelse return;
+    writeTextInputBinding(cx, input);
 }
 
 /// Sync TextArea content back to bound variables (Cx version).
 pub fn syncTextAreaBoundVariablesCx(cx: *Cx) void {
-    const builder = cx.builder();
-    const window = cx.window();
-
-    for (builder.pending_text_areas.items) |pending| {
-        if (pending.style.bind) |bind_ptr| {
-            if (window.element_states.get(TextAreaState, @as(u64, pending.layout_id.id))) |ta| {
-                bind_ptr.* = ta.getText();
-            }
-        }
-    }
+    const text_area = focusedTextArea(cx.window(), cx.builder()) orelse return;
+    writeTextAreaBinding(cx, text_area);
 }
 
 /// Sync CodeEditor content back to bound variables (Cx version).

--- a/src/widgets/text_area_state.zig
+++ b/src/widgets/text_area_state.zig
@@ -181,6 +181,12 @@ pub const TextAreaState = struct {
 
     const Self = @This();
 
+    pub const BindingSync = enum {
+        unchanged,
+        applied,
+        deferred_ime,
+    };
+
     const BLINK_INTERVAL_MS: i64 = 530;
 
     /// Initialize TextAreaState.
@@ -232,10 +238,11 @@ pub const TextAreaState = struct {
 
         if (aliases) {
             var temp: std.ArrayList(u8) = .empty;
+            defer temp.deinit(self.allocator);
+
             try temp.appendSlice(self.allocator, text);
             self.buffer.clearRetainingCapacity();
             try self.buffer.appendSlice(self.allocator, temp.items);
-            temp.deinit(self.allocator);
         } else {
             self.buffer.clearRetainingCapacity();
             try self.buffer.appendSlice(self.allocator, text);
@@ -245,6 +252,28 @@ pub const TextAreaState = struct {
         self.cursor_byte = @min(self.cursor_byte, self.buffer.items.len);
         self.updateCursorPosition();
         self.selection_anchor = null;
+    }
+
+    /// Reconcile a controlled binding while preserving valid editing offsets.
+    /// IME preedit is never discarded by a render-time model update.
+    pub fn syncBoundText(self: *Self, text: []const u8) !BindingSync {
+        std.debug.assert(self.cursor_byte <= self.buffer.items.len);
+        if (self.selection_anchor) |anchor| std.debug.assert(anchor <= self.buffer.items.len);
+        if (std.mem.eql(u8, self.buffer.items, text)) return .unchanged;
+        if (self.preedit_buffer.items.len > 0) return .deferred_ime;
+
+        const selection_anchor = self.selection_anchor;
+        try self.setText(text);
+        self.cursor_byte = common.snapToCharBoundary(text, @min(self.cursor_byte, text.len));
+        self.selection_anchor = if (selection_anchor) |anchor|
+            common.snapToCharBoundary(text, @min(anchor, text.len))
+        else
+            null;
+        if (self.selection_anchor == self.cursor_byte) self.selection_anchor = null;
+        self.updateCursorPosition();
+        self.preferred_column = null;
+        self.clearHistory();
+        return .applied;
     }
 
     pub fn clear(self: *Self) void {
@@ -1560,4 +1589,45 @@ test "TextAreaState cursor navigation" {
     // Move up
     ta.moveUp();
     try std.testing.expectEqual(@as(usize, 1), ta.cursor_row);
+}
+
+test "TextAreaState controlled binding resets and preserves active editing state" {
+    // External content replaces committed text, rebuilds line metadata, and
+    // preserves cursor/selection offsets only as far as the new value allows.
+    const allocator = std.testing.allocator;
+    var ta = TextAreaState.init(allocator, .{ .x = 0, .y = 0, .width = 300, .height = 200 });
+    defer ta.deinit();
+
+    try ta.setText("one\ntwo");
+    ta.cursor_byte = 5;
+    ta.selection_anchor = 2;
+    try std.testing.expectEqual(TextAreaState.BindingSync.applied, try ta.syncBoundText("alpha\nbeta"));
+    try std.testing.expectEqual(@as(usize, 5), ta.cursor_byte);
+    try std.testing.expectEqual(@as(?usize, 2), ta.selection_anchor);
+    try std.testing.expectEqual(@as(usize, 2), ta.lineCount());
+
+    try std.testing.expectEqual(TextAreaState.BindingSync.applied, try ta.syncBoundText(""));
+    try std.testing.expectEqualStrings("", ta.getText());
+    try std.testing.expectEqual(@as(usize, 0), ta.cursor_byte);
+    try std.testing.expectEqual(@as(?usize, null), ta.selection_anchor);
+
+    try ta.insertText("x");
+    try std.testing.expect(!ta.hasSelection());
+}
+
+test "TextAreaState controlled binding defers replacement during IME preedit" {
+    // The next render may carry a new model value, but composition owns the
+    // visible edit until the platform commits or cancels it.
+    const allocator = std.testing.allocator;
+    var ta = TextAreaState.init(allocator, .{ .x = 0, .y = 0, .width = 300, .height = 200 });
+    defer ta.deinit();
+
+    try ta.setText("before");
+    try ta.setComposition("候補");
+    try std.testing.expectEqual(TextAreaState.BindingSync.deferred_ime, try ta.syncBoundText("external"));
+    try std.testing.expectEqualStrings("before", ta.getText());
+
+    try ta.setComposition("");
+    try std.testing.expectEqual(TextAreaState.BindingSync.applied, try ta.syncBoundText("external"));
+    try std.testing.expectEqualStrings("external", ta.getText());
 }

--- a/src/widgets/text_input_state.zig
+++ b/src/widgets/text_input_state.zig
@@ -170,6 +170,12 @@ pub const TextInputState = struct {
 
     const Self = @This();
 
+    pub const BindingSync = enum {
+        unchanged,
+        applied,
+        deferred_ime,
+    };
+
     /// Cursor blink interval in milliseconds
     const BLINK_INTERVAL_MS: i64 = 530;
 
@@ -207,6 +213,37 @@ pub const TextInputState = struct {
     /// Set the text content
     /// Safety: Handles the case where `text` might alias with the internal buffer
     pub fn setText(self: *Self, text: []const u8) !void {
+        try self.replaceText(text);
+        self.cursor_byte = self.buffer.items.len;
+        self.selection_anchor = null;
+        self.notifyChange();
+    }
+
+    /// Reconcile a controlled binding without treating the model update as
+    /// user input. Cursor and selection offsets survive when they remain valid;
+    /// active IME preedit takes precedence until it is committed or cancelled.
+    pub fn syncBoundText(self: *Self, text: []const u8) !BindingSync {
+        std.debug.assert(self.cursor_byte <= self.buffer.items.len);
+        if (self.selection_anchor) |anchor| std.debug.assert(anchor <= self.buffer.items.len);
+        if (std.mem.eql(u8, self.buffer.items, text)) return .unchanged;
+        if (self.preedit_buffer.items.len > 0) return .deferred_ime;
+
+        const cursor_byte = self.cursor_byte;
+        const selection_anchor = self.selection_anchor;
+        try self.replaceText(text);
+        self.cursor_byte = common.snapToCharBoundary(text, @min(cursor_byte, text.len));
+        self.selection_anchor = if (selection_anchor) |anchor|
+            common.snapToCharBoundary(text, @min(anchor, text.len))
+        else
+            null;
+        if (self.selection_anchor == self.cursor_byte) self.selection_anchor = null;
+        self.clearHistory();
+        return .applied;
+    }
+
+    fn replaceText(self: *Self, text: []const u8) !void {
+        std.debug.assert(self.cursor_byte <= self.buffer.items.len);
+        std.debug.assert(self.preedit_cursor <= self.preedit_buffer.items.len);
         // Check if input slice aliases with our buffer (would cause @memcpy panic)
         const buf_start = @intFromPtr(self.buffer.items.ptr);
         const buf_end = buf_start + self.buffer.items.len;
@@ -226,10 +263,6 @@ pub const TextInputState = struct {
             self.buffer.clearRetainingCapacity();
             try self.buffer.appendSlice(self.allocator, text);
         }
-
-        self.cursor_byte = self.buffer.items.len;
-        self.selection_anchor = null;
-        self.notifyChange();
     }
 
     /// Clear all text
@@ -1118,4 +1151,44 @@ test "TextInputState selection" {
     try std.testing.expect(input.hasSelection());
     try std.testing.expectEqual(@as(usize, 0), input.selectionStart());
     try std.testing.expectEqual(@as(usize, 5), input.selectionEnd());
+}
+
+test "TextInputState controlled binding resets and preserves active editing state" {
+    // Model changes reconcile without resetting a valid cursor/selection, while
+    // an empty reset clamps both offsets and does not emit a user edit.
+    const allocator = std.testing.allocator;
+    var input = TextInputState.init(allocator, .{ .x = 0, .y = 0, .width = 200, .height = 32 });
+    defer input.deinit();
+
+    try input.setText("draft");
+    input.cursor_byte = 3;
+    input.selection_anchor = 1;
+    try std.testing.expectEqual(TextInputState.BindingSync.applied, try input.syncBoundText("draft updated"));
+    try std.testing.expectEqual(@as(usize, 3), input.cursor_byte);
+    try std.testing.expectEqual(@as(?usize, 1), input.selection_anchor);
+
+    try std.testing.expectEqual(TextInputState.BindingSync.applied, try input.syncBoundText(""));
+    try std.testing.expectEqualStrings("", input.getText());
+    try std.testing.expectEqual(@as(usize, 0), input.cursor_byte);
+    try std.testing.expectEqual(@as(?usize, null), input.selection_anchor);
+
+    try input.insertText("x");
+    try std.testing.expect(!input.hasSelection());
+}
+
+test "TextInputState controlled binding defers replacement during IME preedit" {
+    // Committed text remains stable until composition ends, avoiding loss of
+    // the platform-owned preedit sequence on an unrelated render.
+    const allocator = std.testing.allocator;
+    var input = TextInputState.init(allocator, .{ .x = 0, .y = 0, .width = 200, .height = 32 });
+    defer input.deinit();
+
+    try input.setText("before");
+    try input.setComposition("候補");
+    try std.testing.expectEqual(TextInputState.BindingSync.deferred_ime, try input.syncBoundText("external"));
+    try std.testing.expectEqualStrings("before", input.getText());
+
+    try input.setComposition("");
+    try std.testing.expectEqual(TextInputState.BindingSync.applied, try input.syncBoundText("external"));
+    try std.testing.expectEqualStrings("external", input.getText());
 }

--- a/web/index.html
+++ b/web/index.html
@@ -525,6 +525,8 @@
 
         // Text input via hidden input element
         hiddenInput.addEventListener("input", (e) => {
+          // Composition commits are queued by compositionend exactly once.
+          if (e.isComposing) return;
           if (hiddenInput.value) {
             appendText(hiddenInput.value);
             hiddenInput.value = ""; // Clear after capturing
@@ -533,19 +535,17 @@
 
         // Handle composition start
         hiddenInput.addEventListener("compositionstart", (e) => {
-          setCompositionActive(true);
+          startComposition();
         });
 
         // Handle composition updates (preedit text)
         hiddenInput.addEventListener("compositionupdate", (e) => {
-          if (e.data) {
-            updateCompositionText(e.data);
-          }
+          updateCompositionText(e.data || "");
         });
 
         // Handle composition end
         hiddenInput.addEventListener("compositionend", (e) => {
-          setCompositionActive(false);
+          finishComposition();
           if (e.data) {
             appendText(e.data);
             hiddenInput.value = "";
@@ -599,6 +599,7 @@
       }
 
       function handleKeyDown(e) {
+        if (isImeOwnedKey(e)) return;
         // Prevent browser defaults for keys we handle
         if (shouldPreventDefault(e)) {
           e.preventDefault();
@@ -608,7 +609,14 @@
       }
 
       function handleKeyUp(e) {
+        if (isImeOwnedKey(e)) return;
         pushKeyEvent(1, e); // 1 = key_up
+      }
+
+      function isImeOwnedKey(e) {
+        // Safari can report candidate confirmation as keyCode 229 after
+        // compositionend, when isComposing has already changed to false.
+        return e.isComposing || e.keyCode === 229;
       }
 
       function handleBeforeInput(e) {
@@ -627,6 +635,7 @@
       }
 
       function shouldPreventDefault(e) {
+        if (isImeOwnedKey(e)) return false;
         // Prevent defaults for navigation and common shortcuts
         const dominated = [
           "Tab",
@@ -731,10 +740,22 @@
         compositionBufferPtr = wasmInstance.exports.getCompositionBufferPtr();
       }
 
-      function setCompositionActive(active) {
+      function startComposition() {
         if (!compositionBufferPtr) return;
         const mem = new Uint8Array(wasmInstance.exports.memory.buffer);
-        mem[compositionBufferPtr + 4] = active ? 1 : 0; // active flag at offset 4
+        const view = new DataView(wasmInstance.exports.memory.buffer);
+        view.setUint32(compositionBufferPtr, 0, true);
+        mem[compositionBufferPtr + 4] = 1; // active
+        mem[compositionBufferPtr + 5] = 0; // wait for first preedit update
+      }
+
+      function finishComposition() {
+        if (!compositionBufferPtr) return;
+        const mem = new Uint8Array(wasmInstance.exports.memory.buffer);
+        const view = new DataView(wasmInstance.exports.memory.buffer);
+        view.setUint32(compositionBufferPtr, 0, true);
+        mem[compositionBufferPtr + 4] = 0; // inactive
+        mem[compositionBufferPtr + 5] = 1; // pending clear event
       }
 
       function updateCompositionText(text) {
@@ -755,6 +776,8 @@
         view.setUint32(compositionBufferPtr, writeLen, true);
         // Mark as active
         mem[compositionBufferPtr + 4] = 1;
+        // Queue this update exactly once.
+        mem[compositionBufferPtr + 5] = 1;
       }
 
       // Text rendering helper


### PR DESCRIPTION
## Summary

- make `TextInput` and `TextArea` bindings truly controlled and two-way: external model changes, including empty resets, reconcile into retained editor state
- preserve valid cursor/selection offsets, clear stale edit history, and defer authoritative model replacement while IME preedit is active
- narrow input write-back to the focused control and reconcile before dispatch so shared bindings and deferred IME updates cannot be overwritten by unrelated controls
- make Web composition updates one-shot, clear preedit on end/cancel, and keep IME-owned confirmation keys out of normal key dispatch
- expose `Select.ControlMode` and `Select.ControlError`, reject mixed `on_select` + legacy `handlers`, and retain manual toggle/close compatibility
- add canonical `Tab.on_click_handler` while preserving `on_click` as a compatibility alias
- simplify Todo's Add action to a pure `cx.update` handler that resets only the bound model value

## Behavior rationale

A binding is now synchronized only when the model and retained editor differ. This avoids overwriting active edits every frame. External updates remain authoritative, but active IME preedit is allowed to commit or cancel before replacement. Cursor and selection byte offsets are preserved when valid in the replacement text and snapped to UTF-8 boundaries otherwise; collapsed selections normalize to no selection.

Select keeps all existing fields. The canonical `on_select`-only configuration remains internally controlled, while supplying manual toggle/close handlers intentionally selects manual mode. The formerly ambiguous combination of `on_select` and per-option `handlers` now returns `MixedSelectionHandlers` from `validateControl()` and traps with a clear message during render.

## Compatibility

- no existing TextInput/TextArea call-site changes are required; `.bind` gains inbound synchronization
- Select legacy manual fields remain supported
- `Tab.on_click` remains supported; `on_click_handler` is the canonical alias
- no repository-wide callback rename

## Validation

- `zig fmt` on all touched Zig files
- `git diff --check`
- `dbus-run-session -- zig build test --summary all` — **24/24 steps, 1095/1095 tests passed**
- `zig build -Dskip-shader-compile=true` — all native examples built, including Todo and Select
- `zig build -Dtarget=wasm32-freestanding` — Web/WASM build passed
- launched Todo and Select under supervised headless Wayland/Sway services and inspected captured frames; both remained running and rendered without corruption
- focused tests cover empty external resets, focused cursor/selection preservation, post-reset typing, IME deferral/release, Web composition cancellation, Todo model reset, Select mode/validation, and the Tab event alias