### PR TITLE
Restore WebGPU examples on Zig 0.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@
 #   - test-macos: Run unit tests on macOS
 #   - build-linux: Build all optimization levels on Linux
 #   - build-macos: Build all optimization levels on macOS
-#   - build-wasm: Build WebAssembly targets (disabled — pending Zig 0.16 support)
+#   - build-wasm: Build WebAssembly targets
 #   - valgrind: Memory leak detection (Linux only)
 #   - zig-fmt: Code formatting check
 # =============================================================================
@@ -51,6 +51,7 @@ jobs:
       - test-macos
       - build-linux
       - build-macos
+      - build-wasm
       - valgrind
       - zig-fmt
       - bench-macos
@@ -231,9 +232,37 @@ jobs:
   # ==========================================================================
   # WebAssembly Build
   # ==========================================================================
-  # NOTE: WASM builds are temporarily disabled. The WASM targets are not
-  # yet compatible with Zig 0.16 — re-enable once the WASM build path has
-  # been updated.
+  build-wasm:
+    name: Build (WebAssembly)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: ${{ env.ZIG_VERSION }}
+
+      - name: Cache Zig
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/zig
+            zig-cache
+          key: zig-cache-wasm-${{ hashFiles('build.zig', 'build.zig.zon') }}
+          restore-keys: |
+            zig-cache-wasm-
+
+      - name: Build browser examples
+        run: zig build wasm wasm-counter
+
+      - name: Upload browser examples
+        uses: actions/upload-artifact@v6
+        with:
+          name: gooey-wasm
+          path: zig-out/web/
+          retention-days: 14
 
   # ==========================================================================
   # Benchmarks (macOS)

--- a/build.zig
+++ b/build.zig
@@ -1016,27 +1016,7 @@ pub fn build(b: *std.Build) void {
         test_valgrind_step.dependOn(&valgrind_run.step);
     }
 
-    // =============================================================================
-    // WebAssembly Builds — deferred on Zig 0.16.0
-    // =============================================================================
-    //
-    // `std.Io.Threaded` does not compile for `wasm32-freestanding` on Zig 0.16.0:
-    // its comptime body eagerly references `posix.system.getrandom`
-    // (Threaded.zig:2064) and `posix.IOV_MAX` (posix.zig:90), both of which resolve
-    // to `void` / absent on wasm32-freestanding. This breaks the Phase-1 invariant
-    // ("WASM uses `init_single_threaded`") at the type-analysis level — so even
-    // reaching for `global_single_threaded` fails to compile.
-    //
-    // The WASM code paths (`src/platform/web/`, `WebApp` in `app.zig`, all
-    // `src/examples/*_wasm.zig` and web-specific examples) are deliberately left
-    // in place; they'll resume compiling once upstream gates these references
-    // behind `native_os == .linux` or the `@TypeOf(...) != void` idiom already
-    // used elsewhere in `Threaded.zig`. When that lands, restore the WASM build
-    // steps below (pulled from the git history prior to the 0.1.0 tag) and flip
-    // the deferred row in `docs/zig-0.16-io-migration.md` to complete.
-    //
-    // See `docs/zig-0.16-io-migration.md` → "Remediation Plan" → Step 3 for
-    // rationale, tracking, and exit criteria.
+    addWasmBuilds(b);
 }
 
 // =============================================================================
@@ -1153,9 +1133,106 @@ fn addChartsExample(
     run_cmd.step.dependOn(b.getInstallStep());
 }
 
-// `addWasmExample` helper removed alongside the WASM build steps — see the
-// deferral note in `pub fn build` above. Restore from git history (pre-0.1.0
-// tag) once upstream `Io.Threaded` compiles for `wasm32-freestanding`.
+fn addWasmBuilds(b: *std.Build) void {
+    const wasm_target = b.resolveTargetQuery(.{
+        .cpu_arch = .wasm32,
+        .os_tag = .freestanding,
+    });
+    const gooey_module = b.createModule(.{
+        .root_source_file = b.path("src/root.zig"),
+        .target = wasm_target,
+        .optimize = .ReleaseSmall,
+    });
+    addWasmShaderImports(b, gooey_module);
+
+    std.debug.assert(wasm_target.result.cpu.arch == .wasm32);
+    std.debug.assert(wasm_target.result.os.tag == .freestanding);
+
+    addWasmExample(b, gooey_module, wasm_target, .{
+        .step_name = "wasm",
+        .description = "Build showcase for web",
+        .source = "src/examples/showcase.zig",
+        .output_dir = "web",
+        .copy_showcase_assets = true,
+    });
+    addWasmExample(b, gooey_module, wasm_target, .{
+        .step_name = "wasm-counter",
+        .description = "Build counter example for web",
+        .source = "src/examples/counter.zig",
+        .output_dir = "web/counter",
+        .copy_showcase_assets = false,
+    });
+}
+
+fn addWasmShaderImports(b: *std.Build, module: *std.Build.Module) void {
+    const shaders = [_]struct { name: []const u8, path: []const u8 }{
+        .{ .name = "unified_wgsl", .path = "src/platform/wgpu/shaders/unified.wgsl" },
+        .{ .name = "text_wgsl", .path = "src/platform/wgpu/shaders/text.wgsl" },
+        .{ .name = "svg_wgsl", .path = "src/platform/wgpu/shaders/svg.wgsl" },
+        .{ .name = "image_wgsl", .path = "src/platform/wgpu/shaders/image.wgsl" },
+        .{ .name = "path_wgsl", .path = "src/platform/wgpu/shaders/path.wgsl" },
+        .{ .name = "solid_path_wgsl", .path = "src/platform/wgpu/shaders/path_solid.wgsl" },
+        .{ .name = "polyline_wgsl", .path = "src/platform/wgpu/shaders/polyline.wgsl" },
+        .{ .name = "point_cloud_wgsl", .path = "src/platform/wgpu/shaders/point_cloud.wgsl" },
+    };
+    std.debug.assert(shaders.len == 8);
+    std.debug.assert(shaders[0].name.len > 0);
+    for (shaders) |shader| {
+        module.addAnonymousImport(shader.name, .{
+            .root_source_file = b.path(shader.path),
+        });
+    }
+}
+
+fn addWasmExample(
+    b: *std.Build,
+    gooey_module: *std.Build.Module,
+    wasm_target: std.Build.ResolvedTarget,
+    options: struct {
+        step_name: []const u8,
+        description: []const u8,
+        source: []const u8,
+        output_dir: []const u8,
+        copy_showcase_assets: bool,
+    },
+) void {
+    std.debug.assert(options.step_name.len > 0);
+    std.debug.assert(options.output_dir.len > 0);
+
+    const application_module = b.createModule(.{
+        .root_source_file = b.path(options.source),
+        .target = wasm_target,
+        .optimize = .ReleaseSmall,
+        .imports = &.{.{ .name = "gooey", .module = gooey_module }},
+    });
+    const executable = b.addExecutable(.{
+        .name = "app",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/platform/web/entry.zig"),
+            .target = wasm_target,
+            .optimize = .ReleaseSmall,
+            .imports = &.{.{ .name = "application", .module = application_module }},
+        }),
+    });
+    executable.entry = .disabled;
+    executable.rdynamic = true;
+    executable.stack_size = 1024 * 1024;
+
+    const step = b.step(options.step_name, options.description);
+    step.dependOn(&b.addInstallArtifact(executable, .{
+        .dest_dir = .{ .override = .{ .custom = options.output_dir } },
+    }).step);
+    step.dependOn(&b.addInstallFile(
+        b.path("web/index.html"),
+        b.fmt("{s}/index.html", .{options.output_dir}),
+    ).step);
+    if (options.copy_showcase_assets) {
+        step.dependOn(&b.addInstallFile(
+            b.path("assets/gooey-logo-final.png"),
+            b.fmt("{s}/assets/gooey-logo-final.png", .{options.output_dir}),
+        ).step);
+    }
+}
 
 /// Helper to add a Linux native example with Vulkan + Wayland system libraries.
 fn addLinuxExample(

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ Example app built with Gooey — [**chat-zig**](https://github.com/duanebester/c
 
 ## Features
 
-- **GPU Rendering** - Metal (macOS), Vulkan (Linux) with MSAA anti-aliasing (WebGPU/WASM is blocked upstream on Zig 0.16 — see [WASM](#wasm))
+- **GPU Rendering** - Metal (macOS), Vulkan (Linux) with MSAA anti-aliasing, and WebGPU (WASM)
 - **Declarative UI** - Component-based layout with `ui.*` primitives and flexbox-style system
 - **Cx/UI Separation** - `Cx` for state, handlers, and focus; `ui.*` for layout primitives
 - **Pure State Pattern** - Testable state methods with automatic re-rendering
@@ -1738,35 +1738,17 @@ On native, `gooey.log` delegates to `std.log.scoped()`. On WASM, it writes direc
 
 ## WASM
 
-> **⚠️ Temporarily deferred on Zig 0.16.0 (upstream `Io.Threaded`).**
-> `std.Io.Threaded` does not compile for `wasm32-freestanding` on Zig 0.16.0 —
-> its comptime body eagerly references `posix.system.getrandom` and
-> `posix.IOV_MAX`, which resolve to `void`/absent on that target. This is an
-> upstream issue, not a Gooey one. The `zig build wasm*` steps have been removed
-> from `build.zig` (the commands no longer exist), while the web code paths
-> (`src/platform/web/`, `WebApp` in `app.zig`, and `src/examples/*_wasm.zig`) are
-> deliberately left in place to resume compiling once upstream gates those
-> references. Tracking: [`docs/zig-0.16-io-migration.md`](docs/zig-0.16-io-migration.md).
-
-Once the upstream fix lands, the WASM build steps will be restored. The commands
-below are the intended interface — **currently inactive**:
+Gooey avoids `std.Io.Threaded` on `wasm32-freestanding`, where the implementation
+does not compile in Zig 0.16. Browser services use the explicit JavaScript
+callback bridges in `src/platform/web/`; unsupported general-purpose `std.Io`
+operations use `std.Io.failing`.
 
 ```bash
-# (currently disabled — see the note above)
-# zig build wasm                 # showcase
-# zig build wasm-counter
-# zig build wasm-dynamic-counters
-# zig build wasm-pomodoro
-# zig build wasm-spaceship
-# zig build wasm-layout
-# zig build wasm-select
-# zig build wasm-tooltip
-# zig build wasm-modal
-# zig build wasm-images
-# zig build wasm-file-dialog
+zig build wasm                 # Showcase
+zig build wasm-counter         # Counter example
 
-# Run with a local server
-# python3 -m http.server 8080 -d zig-out/web
+# Run the showcase with a local server
+python3 -m http.server 8080 -d zig-out/web
 ```
 
 ## Hot Reloading (macOS)

--- a/src/app.zig
+++ b/src/app.zig
@@ -252,8 +252,11 @@ pub fn WebApp(
                 .font_name = if (@hasField(@TypeOf(config), "font")) config.font else null,
                 .font_size = if (@hasField(@TypeOf(config), "font_size")) config.font_size else 16.0,
             };
-            // WASM uses single-threaded IO — no fibers, sequential execution.
-            const io = std.Io.Threaded.global_single_threaded.io();
+            // Browser integrations provide asynchronous services through explicit
+            // JavaScript callbacks, so general std.Io operations are unsupported.
+            // Using the failing backend avoids analyzing std.Io.Threaded, which is
+            // not portable to wasm32-freestanding in Zig 0.16 or current 0.17-dev.
+            const io = std.Io.failing;
 
             // PR 7b.3 — allocate the shared `App` before the
             // `Window` so it can be wired in immediately after

--- a/src/app.zig
+++ b/src/app.zig
@@ -253,10 +253,10 @@ pub fn WebApp(
                 .font_size = if (@hasField(@TypeOf(config), "font_size")) config.font_size else 16.0,
             };
             // Browser integrations provide asynchronous services through explicit
-            // JavaScript callbacks, so general std.Io operations are unsupported.
-            // Using the failing backend avoids analyzing std.Io.Threaded, which is
-            // not portable to wasm32-freestanding in Zig 0.16 or current 0.17-dev.
-            const io = std.Io.failing;
+            // JavaScript callbacks, so unsupported operations retain failing-I/O
+            // semantics. The browser backend overrides clocks because animation
+            // and interaction timing require a monotonic source.
+            const io = platform.backend.io.browser;
 
             // PR 7b.3 — allocate the shared `App` before the
             // `Window` so it can be wired in immediately after

--- a/src/examples/counter.zig
+++ b/src/examples/counter.zig
@@ -69,6 +69,7 @@ const App = gooey.App(AppState, &state, render, .{
     .width = 500,
     .height = 350,
 });
+pub const wasm_app = App;
 
 // Force type analysis - triggers @export on WASM
 comptime {

--- a/src/examples/showcase.zig
+++ b/src/examples/showcase.zig
@@ -234,6 +234,7 @@ const App = gooey.App(AppState, &state, render, .{
     .height = 800,
     .on_event = onEvent,
 });
+pub const wasm_app = App;
 
 pub fn main(init: std.process.Init) !void {
     try App.main(init);

--- a/src/platform/web/custom_shader.zig
+++ b/src/platform/web/custom_shader.zig
@@ -310,7 +310,7 @@ pub const PostProcessState = struct {
 
     /// Update timing uniforms
     pub fn updateTiming(self: *Self) void {
-        const now = imports.getTimestampMillis();
+        const now = imports.getFrameTime();
 
         if (self.start_time == null) {
             self.start_time = now;

--- a/src/platform/web/entry.zig
+++ b/src/platform/web/entry.zig
@@ -1,0 +1,12 @@
+//! Root module for freestanding browser builds.
+//!
+//! Examples are imported as child modules so their native `main` declaration
+//! does not make Zig synthesize `std.start` for a freestanding executable.
+
+const application = @import("application");
+
+pub const std_options = application.std_options;
+
+comptime {
+    _ = application.wasm_app;
+}

--- a/src/platform/web/io.zig
+++ b/src/platform/web/io.zig
@@ -1,0 +1,57 @@
+//! Browser-backed `std.Io` clock support.
+//!
+//! Browser applications use explicit JavaScript callbacks for asynchronous
+//! services, so unsupported operations retain `std.Io.failing` semantics.
+//! Clocks are the exception: animation and interaction timing require a
+//! monotonically advancing source even though no general-purpose WASM I/O
+//! backend exists.
+
+const std = @import("std");
+const imports = @import("imports.zig");
+
+const nanoseconds_per_millisecond: f64 = @floatFromInt(std.time.ns_per_ms);
+
+pub const browser: std.Io = .{
+    .userdata = null,
+    .vtable = &browser_vtable,
+};
+
+const browser_vtable: std.Io.VTable = blk: {
+    var vtable = std.Io.failing.vtable.*;
+    vtable.now = now;
+    vtable.clockResolution = clockResolution;
+    break :blk vtable;
+};
+
+comptime {
+    std.debug.assert(browser_vtable.now != std.Io.failing.vtable.now);
+    std.debug.assert(browser_vtable.clockResolution != std.Io.failing.vtable.clockResolution);
+}
+
+fn now(userdata: ?*anyopaque, clock: std.Io.Clock) std.Io.Timestamp {
+    std.debug.assert(userdata == null);
+
+    const milliseconds = switch (clock) {
+        .real => imports.getTimestampMillis(),
+        .awake, .boot => imports.getFrameTime(),
+        .cpu_process, .cpu_thread => return .zero,
+    };
+    std.debug.assert(std.math.isFinite(milliseconds));
+    std.debug.assert(milliseconds >= 0);
+
+    const nanoseconds: i96 = @intFromFloat(milliseconds * nanoseconds_per_millisecond);
+    return std.Io.Timestamp.fromNanoseconds(nanoseconds);
+}
+
+fn clockResolution(
+    userdata: ?*anyopaque,
+    clock: std.Io.Clock,
+) std.Io.Clock.ResolutionError!std.Io.Duration {
+    std.debug.assert(userdata == null);
+    std.debug.assert(std.time.ns_per_ms > 0);
+
+    return switch (clock) {
+        .real, .awake, .boot => .{ .nanoseconds = std.time.ns_per_ms },
+        .cpu_process, .cpu_thread => error.ClockUnavailable,
+    };
+}

--- a/src/platform/web/mod.zig
+++ b/src/platform/web/mod.zig
@@ -3,6 +3,7 @@
 //! Exports for WebAssembly/browser target.
 
 pub const imports = @import("imports.zig");
+pub const io = @import("io.zig");
 pub const window = @import("window.zig");
 pub const renderer = @import("renderer.zig");
 pub const platform = @import("platform.zig");

--- a/src/widgets/text_area_state.zig
+++ b/src/widgets/text_area_state.zig
@@ -1516,7 +1516,7 @@ pub const TextAreaState = struct {
 /// keep blink deltas independent of wall-clock adjustments.
 fn getTimestamp() i64 {
     const timestamp_ms = if (comptime builtin.os.tag == .freestanding and builtin.cpu.arch == .wasm32)
-        @as(i64, @intFromFloat(@import("../platform/web/imports.zig").getTimestampMillis()))
+        @as(i64, @intFromFloat(@import("../platform/web/imports.zig").getFrameTime()))
     else blk: {
         const io = std.Io.Threaded.global_single_threaded.io();
         break :blk std.Io.Timestamp.now(io, .awake).toMilliseconds();

--- a/src/widgets/text_area_state.zig
+++ b/src/widgets/text_area_state.zig
@@ -1510,15 +1510,20 @@ pub const TextAreaState = struct {
 };
 
 /// Monotonic millisecond timestamp for edit-history entries and the cursor
-/// blink timer. See the matching comment in `text_input_state.zig` — we
-/// reach for the process-lifetime single-threaded `Io` here because every
-/// keystroke path would otherwise need to thread `io` through
-/// `handleKey`/`insertText` and friends. `.awake` is the correct clock:
-/// edit history wants a stable monotonic ordering, and blink deltas must
-/// not jump if the wall clock is adjusted.
+/// blink timer. Native targets use the process-lifetime `Io`; browsers use
+/// their JavaScript monotonic clock because `Io.Threaded` cannot be analyzed
+/// for `wasm32-freestanding`. Both clocks provide stable edit ordering and
+/// keep blink deltas independent of wall-clock adjustments.
 fn getTimestamp() i64 {
-    const io = std.Io.Threaded.global_single_threaded.io();
-    return std.Io.Timestamp.now(io, .awake).toMilliseconds();
+    const timestamp_ms = if (comptime builtin.os.tag == .freestanding and builtin.cpu.arch == .wasm32)
+        @as(i64, @intFromFloat(@import("../platform/web/imports.zig").getTimestampMillis()))
+    else blk: {
+        const io = std.Io.Threaded.global_single_threaded.io();
+        break :blk std.Io.Timestamp.now(io, .awake).toMilliseconds();
+    };
+    std.debug.assert(timestamp_ms >= 0);
+    std.debug.assert(timestamp_ms <= std.math.maxInt(i64));
+    return timestamp_ms;
 }
 
 // =============================================================================

--- a/src/widgets/text_input_state.zig
+++ b/src/widgets/text_input_state.zig
@@ -1097,7 +1097,7 @@ pub const TextInputState = struct {
 /// analyzed for `wasm32-freestanding`.
 fn getTimestamp() i64 {
     const timestamp_ms = if (comptime builtin.os.tag == .freestanding and builtin.cpu.arch == .wasm32)
-        @as(i64, @intFromFloat(@import("../platform/web/imports.zig").getTimestampMillis()))
+        @as(i64, @intFromFloat(@import("../platform/web/imports.zig").getFrameTime()))
     else blk: {
         const io = std.Io.Threaded.global_single_threaded.io();
         break :blk std.Io.Timestamp.now(io, .awake).toMilliseconds();

--- a/src/widgets/text_input_state.zig
+++ b/src/widgets/text_input_state.zig
@@ -1091,16 +1091,20 @@ pub const TextInputState = struct {
 /// interval — both are immune to wall-clock adjustments, so `.awake` is
 /// the right clock.
 ///
-/// This runs on every keystroke, deep inside widget code that does not
-/// carry a `*Cx`/`Gooey`. Threading `io` through `handleKey`/`insertText`
-/// and all their callers purely to read a timestamp would balloon this
-/// patch; instead we reach for the process-lifetime single-threaded `Io`
-/// (a pair of pointers into a static vtable — the read is essentially
-/// free). Same escape hatch used by the render mutex; see phase-5
-/// option 3 in `docs/zig-0.16-io-migration.md`.
+/// This runs on every keystroke, deep inside widget code that does not carry
+/// a `*Cx`/`Window`. Native targets use the process-lifetime `Io`; browsers
+/// use their JavaScript monotonic clock because `Io.Threaded` cannot be
+/// analyzed for `wasm32-freestanding`.
 fn getTimestamp() i64 {
-    const io = std.Io.Threaded.global_single_threaded.io();
-    return std.Io.Timestamp.now(io, .awake).toMilliseconds();
+    const timestamp_ms = if (comptime builtin.os.tag == .freestanding and builtin.cpu.arch == .wasm32)
+        @as(i64, @intFromFloat(@import("../platform/web/imports.zig").getTimestampMillis()))
+    else blk: {
+        const io = std.Io.Threaded.global_single_threaded.io();
+        break :blk std.Io.Timestamp.now(io, .awake).toMilliseconds();
+    };
+    std.debug.assert(timestamp_ms >= 0);
+    std.debug.assert(timestamp_ms <= std.math.maxInt(i64));
+    return timestamp_ms;
 }
 
 test "TextInputState basic operations" {

--- a/web/index.html
+++ b/web/index.html
@@ -2493,6 +2493,12 @@
 
         // Load WASM
         const response = await fetch("app.wasm");
+        if (!response.ok) {
+          throw new Error(
+            `Failed to load ${response.url}: HTTP ${response.status} ${response.statusText}. ` +
+              "Serve the generated zig-out/web directory, not the source web directory.",
+          );
+        }
         const wasmBytes = await response.arrayBuffer();
         const { instance } = await WebAssembly.instantiate(wasmBytes, {
           env,


### PR DESCRIPTION
## Summary

- restore the `wasm` showcase and `wasm-counter` build steps on Zig 0.16
- avoid `std.Io.Threaded` analysis on `wasm32-freestanding` by using the explicit unsupported `std.Io.failing` backend for browser integrations
- compile examples as child modules beneath a startup-free WASM root so Zig does not synthesize `std.start`
- use the JavaScript monotonic clock for text input and text area timestamps on WASM
- copy showcase assets into the browser bundle and report missing WASM responses with actionable HTTP diagnostics
- re-enable WASM as a required CI build and upload the generated browser bundle

## Why

Zig 0.16 and current 0.17-dev eagerly analyze unsupported `std.Io.Threaded` POSIX declarations for `wasm32-freestanding`. A root-level `pub fn main(std.process.Init)` also causes Zig to synthesize `std.start`, reaching the same broken path even for a no-entry executable.

Gooey's browser services already use explicit JavaScript callback bridges, so the browser build can avoid the threaded backend entirely while preserving native behavior.

## Verification

- `zig fmt --check build.zig src/app.zig src/platform/web/entry.zig src/examples/showcase.zig src/examples/counter.zig src/widgets/text_input_state.zig src/widgets/text_area_state.zig`
- `zig build wasm wasm-counter`
- `zig build test`
- clean bundle validation for both WASM magic headers and required assets
- headless Chrome WebGPU smoke test: WASM instantiated, `init()` completed, keyboard/scroll/mouse bridges initialized, and the showcase rendered without Gooey or asset-loading errors
- manual verification in Chrome at `http://localhost:8080`
