### PR TITLE
Compose nested floating z-index tiers

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -152,6 +152,7 @@ pub fn build(b: *std.Build) void {
         addNativeExample(b, mod, objc_mod, target, optimize, "todo", "src/examples/todo.zig", false);
         addNativeExample(b, mod, objc_mod, target, optimize, "layout", "src/examples/layout.zig", false);
         addNativeExample(b, mod, objc_mod, target, optimize, "select", "src/examples/select.zig", false);
+        addNativeExample(b, mod, objc_mod, target, optimize, "nested-overlay", "src/examples/nested_overlay.zig", false);
         addNativeExample(b, mod, objc_mod, target, optimize, "dynamic-counters", "src/examples/dynamic_counters.zig", false);
         addNativeExample(b, mod, objc_mod, target, optimize, "actions", "src/examples/actions.zig", false);
         addNativeExample(b, mod, objc_mod, target, optimize, "text-debug", "src/examples/text_debug_example.zig", false);
@@ -667,6 +668,7 @@ pub fn build(b: *std.Build) void {
         addLinuxExample(b, mod, target, optimize, compile_shaders_step, skip_shader_compile, "layout", "src/examples/layout.zig");
         addLinuxExample(b, mod, target, optimize, compile_shaders_step, skip_shader_compile, "actions", "src/examples/actions.zig");
         addLinuxExample(b, mod, target, optimize, compile_shaders_step, skip_shader_compile, "select", "src/examples/select.zig");
+        addLinuxExample(b, mod, target, optimize, compile_shaders_step, skip_shader_compile, "nested-overlay", "src/examples/nested_overlay.zig");
         addLinuxExample(b, mod, target, optimize, compile_shaders_step, skip_shader_compile, "tooltip", "src/examples/tooltip.zig");
         addLinuxExample(b, mod, target, optimize, compile_shaders_step, skip_shader_compile, "modal", "src/examples/modal.zig");
         addLinuxExample(b, mod, target, optimize, compile_shaders_step, skip_shader_compile, "context-menu", "src/examples/context_menu.zig");

--- a/src/examples/nested_overlay.zig
+++ b/src/examples/nested_overlay.zig
@@ -1,0 +1,119 @@
+//! Nested floating overlay regression example.
+//!
+//! The modal (z=1000) and its nested Select dropdown (z=100) start open.
+//! The dropdown should paint above the modal content. If floating z-indexes
+//! replace inherited values, the modal paints over the dropdown instead.
+
+const gooey = @import("gooey");
+const std = @import("std");
+
+pub const std_options = gooey.std_options;
+
+const platform = gooey.platform;
+const ui = gooey.ui;
+const Cx = gooey.Cx;
+const Modal = gooey.components.Modal;
+const Select = gooey.components.Select;
+
+const options = [_][]const u8{ "Alpha", "Bravo", "Charlie" };
+
+const AppState = struct {
+    selected: ?usize = null,
+    select_open: bool = true,
+
+    pub fn toggleSelect(self: *AppState) void {
+        std.debug.assert(options.len > 0);
+        std.debug.assert(options.len <= 4096);
+        self.select_open = !self.select_open;
+    }
+
+    pub fn selectOption(self: *AppState, index: usize) void {
+        std.debug.assert(index < options.len);
+        std.debug.assert(options.len == 3);
+        self.selected = index;
+    }
+};
+
+var state = AppState{};
+
+const App = gooey.App(AppState, &state, render, .{
+    .title = "Nested Overlay Z-Index Repro",
+    .width = 700,
+    .height = 500,
+});
+
+comptime {
+    _ = App;
+}
+
+pub fn main(init: std.process.Init) !void {
+    if (platform.is_wasm) unreachable;
+    return App.main(init);
+}
+
+fn render(cx: *Cx) void {
+    const size = cx.windowSize();
+    std.debug.assert(size.width > 0);
+    std.debug.assert(size.height > 0);
+
+    cx.render(ui.box(.{
+        .width = size.width,
+        .height = size.height,
+        .background = ui.Color.rgb(0.15, 0.24, 0.38),
+        .alignment = .{ .main = .center, .cross = .center },
+    }, .{
+        ui.text("Background content", .{ .size = 28, .color = ui.Color.white }),
+        Modal(ModalContent){
+            .id = "nested-overlay-modal",
+            .is_open = true,
+            .animate = false,
+            .close_on_backdrop = false,
+            .content_max_width = 360,
+            .child = ModalContent{},
+        },
+    }));
+}
+
+const ModalContent = struct {
+    pub fn render(_: @This(), cx: *Cx) void {
+        const app_state = cx.state(AppState);
+        std.debug.assert(options.len > 0);
+        if (app_state.selected) |index| std.debug.assert(index < options.len);
+
+        cx.render(ui.box(.{
+            .width = 312,
+            .direction = .column,
+            .gap = 16,
+        }, .{
+            ui.text("Modal with nested Select", .{ .size = 22 }),
+            ui.text("The open dropdown should be visible above this modal.", .{
+                .size = 14,
+                .color = ui.Color.rgb(0.35, 0.35, 0.4),
+                .wrap = .words,
+            }),
+            Select{
+                .id = "nested-select",
+                .options = &options,
+                .selected = app_state.selected,
+                .is_open = app_state.select_open,
+                .on_select = cx.onSelect(AppState.selectOption),
+                // Supplying a toggle handler selects the controlled mode so
+                // this repro can launch with the dropdown already open.
+                .on_toggle = cx.update(AppState.toggleSelect),
+                .width = 280,
+            },
+            ui.box(.{
+                .fill_width = true,
+                .height = 120,
+                .background = ui.Color.rgb(1.0, 0.93, 0.72),
+                .padding = .{ .all = 16 },
+                .corner_radius = 8,
+            }, .{
+                ui.text("Expected: Alpha / Bravo / Charlie overlay this yellow area.", .{
+                    .size = 14,
+                    .wrap = .words,
+                }),
+            }),
+        }));
+    }
+};

--- a/src/layout/benchmarks.zig
+++ b/src/layout/benchmarks.zig
@@ -772,6 +772,49 @@ test "validate: percentage_sizing" {
 }
 
 // =============================================================================
+// Benchmark: nested_floating_overlays (385 nodes, 256 floating)
+// =============================================================================
+// Models 128 open modals, each with a nested dropdown and later modal content.
+// This saturates MAX_FLOATING_ROOTS and exercises z-index composition on
+// two-thirds of all elements without overflowing the fixed floating pool.
+
+fn buildNestedFloatingOverlays(engine: *LayoutEngine) !u32 {
+    const group_count: u32 = 128;
+    comptime {
+        std.debug.assert(group_count > 0);
+        std.debug.assert(group_count * 2 == layout.engine.MAX_FLOATING_ROOTS);
+    }
+
+    try engine.openElement(.{
+        .layout = .{ .sizing = Sizing.fixed(1000, 1000) },
+    });
+
+    for (0..group_count) |_| {
+        try engine.openElement(.{
+            .layout = .{ .sizing = Sizing.fixed(400, 300) },
+            .floating = .{ .z_index = 1000, .attach_to_parent = false },
+        });
+        try engine.openElement(.{
+            .layout = .{ .sizing = Sizing.fixed(200, 100) },
+            .floating = .{ .z_index = 100 },
+        });
+        engine.closeElement();
+        try engine.openElement(.{
+            .layout = .{ .sizing = Sizing.fixed(200, 100) },
+        });
+        engine.closeElement();
+        engine.closeElement();
+    }
+
+    engine.closeElement();
+    return 1 + group_count * 3;
+}
+
+test "validate: nested_floating_overlays" {
+    try validateBenchmark(buildNestedFloatingOverlays, 385);
+}
+
+// =============================================================================
 // Main Entry Point (for benchmark executable)
 // =============================================================================
 
@@ -808,6 +851,7 @@ pub fn main(init: std.process.Init) !void {
     std.debug.print("-" ** 90 ++ "\n", .{});
 
     // Smallest first
+    collect(&reporter, runBenchmark(allocator, "nested_floating_overlays", buildNestedFloatingOverlays));
     collect(&reporter, runBenchmark(allocator, "wide_no_wrap_simple_few", buildWideNoWrapSimpleFew));
     collect(&reporter, runBenchmark(allocator, "deep_nesting", buildDeepNesting));
     collect(&reporter, runBenchmark(allocator, "space_distribution", buildSpaceDistribution));
@@ -837,6 +881,7 @@ pub fn main(init: std.process.Init) !void {
     });
     std.debug.print("-" ** 90 ++ "\n", .{});
 
+    collect(&reporter, runFullFrameBenchmark(allocator, "full_nested_floating_overlays", buildNestedFloatingOverlays));
     collect(&reporter, runFullFrameBenchmark(allocator, "full_wide_no_wrap_simple_few", buildWideNoWrapSimpleFew));
     collect(&reporter, runFullFrameBenchmark(allocator, "full_deep_nesting", buildDeepNesting));
     collect(&reporter, runFullFrameBenchmark(allocator, "full_space_distribution", buildSpaceDistribution));

--- a/src/layout/engine.zig
+++ b/src/layout/engine.zig
@@ -628,7 +628,7 @@ pub const LayoutEngine = struct {
     }
 
     /// Get z-index for an element by ID (O(1) lookup using cached value)
-    /// Returns the z_index from the nearest floating ancestor, or 0 for non-floating subtrees.
+    /// Returns the composed z-index from all floating ancestors, or 0 for non-floating subtrees.
     /// The z_index is cached during generateRenderCommands.
     pub fn getZIndex(self: *const Self, id: u32) i16 {
         const index = self.id_to_index.get(id) orelse return 0;

--- a/src/layout/engine_tests.zig
+++ b/src/layout/engine_tests.zig
@@ -571,6 +571,65 @@ test "z-index propagates to render commands" {
     try std.testing.expectEqual(@as(i16, 100), dropdown_item_z.?);
 }
 
+test "nested floating z-index composes with its host" {
+    // Goal: a dropdown inside a modal must sort above the modal's complete
+    // subtree. Methodology: place a normal sibling after the nested dropdown
+    // so equal-tier DFS ordering cannot accidentally make the test pass.
+    var engine = LayoutEngine.init(std.testing.allocator);
+    defer engine.deinit();
+
+    engine.beginFrame(800, 600);
+    try engine.openElement(.{
+        .id = LayoutId.init("modal"),
+        .layout = .{ .sizing = Sizing.fixed(400, 300) },
+        .floating = .{ .z_index = 1000 },
+        .background_color = Color.white,
+    });
+    try engine.openElement(.{
+        .id = LayoutId.init("dropdown"),
+        .layout = .{ .sizing = Sizing.fixed(200, 100) },
+        .floating = .{ .z_index = 100 },
+        .background_color = Color.blue,
+    });
+    engine.closeElement();
+    try engine.openElement(.{
+        .id = LayoutId.init("later-modal-content"),
+        .layout = .{ .sizing = Sizing.fixed(200, 100) },
+        .background_color = Color.red,
+    });
+    engine.closeElement();
+    engine.closeElement();
+
+    const commands = try engine.endFrame();
+    try std.testing.expectEqual(@as(i16, 1000), engine.getZIndex(LayoutId.init("modal").id));
+    try std.testing.expectEqual(@as(i16, 1100), engine.getZIndex(LayoutId.init("dropdown").id));
+    try std.testing.expectEqual(@as(i16, 1000), engine.getZIndex(LayoutId.init("later-modal-content").id));
+    try std.testing.expect(commands[commands.len - 1].id == LayoutId.init("dropdown").id);
+}
+
+test "nested floating z-index overflow fails the frame" {
+    // Goal: composition must not silently wrap a top overlay behind content.
+    // Methodology: exceed i16 by one with two nested floating elements.
+    var engine = LayoutEngine.init(std.testing.allocator);
+    defer engine.deinit();
+
+    engine.beginFrame(800, 600);
+    try engine.openElement(.{
+        .id = LayoutId.init("maximum-tier"),
+        .layout = .{ .sizing = Sizing.fixed(100, 100) },
+        .floating = .{ .z_index = std.math.maxInt(i16) },
+    });
+    try engine.openElement(.{
+        .id = LayoutId.init("overflowing-tier"),
+        .layout = .{ .sizing = Sizing.fixed(50, 50) },
+        .floating = .{ .z_index = 1 },
+    });
+    engine.closeElement();
+    engine.closeElement();
+
+    try std.testing.expectError(error.Overflow, engine.endFrame());
+}
+
 test "getZIndex returns inherited z-index" {
     var engine = LayoutEngine.init(std.testing.allocator);
     defer engine.deinit();

--- a/src/layout/layout.md
+++ b/src/layout/layout.md
@@ -353,7 +353,7 @@ Floating elements are positioned relative to a parent but don't affect sibling l
 ```zig
 .floating = .{
     .offset = Offset2D.init(10, 20),     // Position offset
-    .z_index = 100,                       // Render order (i16)
+    .z_index = 100,                       // Local render tier, added to floating ancestors (i16)
     .attach_to_parent = true,             // Use direct parent
     .parent_id = LayoutId.init("target").id,  // Or reference by ID
     .element_attach = .left_top,          // Anchor point on this element

--- a/src/layout/scroll_pass.zig
+++ b/src/layout/scroll_pass.zig
@@ -9,8 +9,8 @@
 //! into per-primitive `emit*Command` helpers.
 //!
 //! Inherited state threads through the recursion:
-//!   - `inherited_z_index` — floating elements override; descendants
-//!     inherit until another floating ancestor changes it.
+//!   - `inherited_z_index` — floating elements add their local tier;
+//!     descendants inherit the resulting composed value.
 //!   - `inherited_opacity` — multiplicative; alpha-folded into each
 //!     emitted command so the renderer doesn't need a stack.
 
@@ -47,8 +47,13 @@ pub fn generateRenderCommands(
     const elem = engine.elements.get(index);
     const bbox = elem.computed.bounding_box;
 
-    // Floating elements override z_index for themselves and their children.
-    const z_index: i16 = if (elem.config.floating) |f| f.z_index else inherited_z_index;
+    // A floating tier is local to its host. Adding it keeps nested overlays
+    // above the complete host subtree, including siblings visited later.
+    const z_index: i16 = if (elem.config.floating) |floating| blk: {
+        const sum = @addWithOverflow(inherited_z_index, floating.z_index);
+        if (sum[1] == 0) break :blk sum[0];
+        return error.Overflow;
+    } else inherited_z_index;
 
     // Combine element opacity with inherited opacity (multiplicative).
     const opacity = elem.config.opacity * inherited_opacity;


### PR DESCRIPTION
## Summary

- compose each floating element's local z-index with its inherited floating tier
- fail the frame on i16 composition overflow instead of wrapping render/input order
- add render-order regression tests and a runnable modal-with-select example
- add a floating-heavy layout and full-frame benchmark
- document floating z-index values as local tiers

## Why additive composition

The original absolute assignment resets a dropdown inside a modal from z=1000 to z=100. Using `max(local, inherited)` fixes the modal host itself, but still ties the dropdown with later modal siblings at z=1000; stable DFS order then paints and hit-tests those later siblings above the dropdown. Addition produces z=1100, keeping the nested overlay above the complete modal subtree while preserving all top-level tier values.

## Before

The Select reports itself open, but the Alpha / Bravo / Charlie dropdown is painted behind the modal subtree.

![Nested dropdown hidden behind modal](https://ampcode.com/user-content/artifacts/fa8d980022247632415b0d3d542dc44e0e78a3e1be2f6ffa24b785069bc0d60f-file.png)

## After

The composed z=1100 dropdown paints above the modal and its later yellow sibling.

![Nested dropdown above modal](https://ampcode.com/user-content/artifacts/d7bf863cd3b355a6e4e9d1933ed7b1a25aaf044bb7780530b381ac5e711087c1-file.png)

## Floating-element benchmark

The new `nested_floating_overlays` scenario builds 128 modal → dropdown → later-content groups: 385 total nodes and 256 floating nodes, saturating `MAX_FLOATING_ROOTS`.

| Measurement | Before | After | Delta |
|---|---:|---:|---:|
| Layout only, average | 51.29 ns/node | 50.96 ns/node | -0.6% |
| Layout only, minimum | 48.52 ns/node | 48.60 ns/node | +0.2% |
| Full frame, average | 102.55 ns/node | 102.36 ns/node | -0.2% |
| Full frame, minimum | 98.22 ns/node | 98.26 ns/node | +0.0% |

`bench-compare` result: **PASS**, 0 regressions at the configured 15% threshold. The checked addition has no measurable cost in this scenario.

## Verification

- `zig build test -Dskip-shader-compile=true`
- `zig build -Dskip-shader-compile=true`
- `zig build bench -Dskip-shader-compile=true`
- `zig build bench-compare -- <before.json> <after.json>`
- headless Wayland/Vulkan visual check of `gooey-nested-overlay`: Alpha, Bravo, and Charlie render above a later yellow modal sibling
