### PR TITLE
Fix Metal custom shader uniform layout

### DIFF
--- a/src/platform/macos/metal/custom_shader.zig
+++ b/src/platform/macos/metal/custom_shader.zig
@@ -76,6 +76,21 @@ pub const Uniforms = extern struct {
     pub fn setMouse(self: *Uniforms, x: f32, y: f32, click_x: f32, click_y: f32) void {
         self.mouse = .{ x, y, click_x, click_y };
     }
+
+    comptime {
+        // Metal pads float3 to 16 bytes, after which the scalar timing fields
+        // exactly fill the next 16-byte block. Keep these offsets paired with
+        // ShaderUniforms below so extension uniforms cannot silently drift.
+        std.debug.assert(@offsetOf(Uniforms, "time") == 16);
+        std.debug.assert(@offsetOf(Uniforms, "frame") == 28);
+        std.debug.assert(@offsetOf(Uniforms, "mouse") == 32);
+        std.debug.assert(@offsetOf(Uniforms, "date") == 48);
+        std.debug.assert(@offsetOf(Uniforms, "focused_bounds") == 64);
+        std.debug.assert(@offsetOf(Uniforms, "hovered_bounds") == 80);
+        std.debug.assert(@offsetOf(Uniforms, "accent_color") == 96);
+        std.debug.assert(@offsetOf(Uniforms, "scroll_offset") == 112);
+        std.debug.assert(@sizeOf(Uniforms) == 128);
+    }
 };
 
 /// MSL prefix that provides Shadertoy-compatible interface
@@ -90,7 +105,6 @@ pub const msl_prefix =
     \\    float iTimeDelta;
     \\    float iFrameRate;
     \\    int iFrame;
-    \\    int _pad0;
     \\    float4 iMouse;
     \\    float4 iDate;
     \\    // Gooey extensions


### PR DESCRIPTION
## Summary

- Remove the extra MSL padding that shifted custom shader extension uniforms.
- Align ShaderUniforms with the CPU-side Uniforms ABI.
- Add compile-time offset and size assertions to prevent silent layout drift.

## Why

Metal already pads float3 to 16 bytes. The additional padding after iFrame shifted iMouse and every subsequent GPU field by 16 bytes relative to the CPU buffer. In particular, iAccentColor read the CPU-side scroll offset instead of the accent color, leaving alpha-gated effects disabled.

This surfaced in chat-zig as its assistant-thinking rim shader compiling successfully but producing no visible effect.

## Validation

- zig build in Gooey
- zig build in chat-zig against the adjacent Gooey checkout
- Launched chat-zig and confirmed the custom Metal shader loads successfully and the thinking effect appears.