### PR TITLE
Cache text widths so long strings stop re-shaping every frame

### DIFF
--- a/src/layout/engine_tests.zig
+++ b/src/layout/engine_tests.zig
@@ -1026,3 +1026,154 @@ test "space_between with single child stays at start" {
     // Single child should be at start (x=0)
     try std.testing.expectEqual(@as(f32, 0.0), child.computed.bounding_box.x);
 }
+
+/// Records what the layout engine asks the text-measurement callback to
+/// measure, so tests can assert *how much* measuring a frame does rather than
+/// only what it computes.  Widths mirror the 10px-per-character mock used by
+/// the wrapping tests above.
+const MeasureRecorder = struct {
+    /// Byte length of the message under test.  `text()` measures the whole
+    /// string in a single call, while `wrapText` only ever measures individual
+    /// words, so a call of exactly this length is unambiguously the former.
+    whole_string_len: u32,
+    call_count: u32 = 0,
+    whole_string_calls: u32 = 0,
+    /// Longest call that was not the whole string — the longest word wrapping
+    /// measured.
+    longest_word_len: u32 = 0,
+
+    fn measure(
+        content: []const u8,
+        _: u16,
+        font_size: u16,
+        _: ?f32,
+        user_data: ?*anyopaque,
+    ) TextMeasurement {
+        const self: *MeasureRecorder = @ptrCast(@alignCast(user_data.?));
+        const content_len: u32 = @intCast(content.len);
+
+        self.call_count += 1;
+        if (content_len == self.whole_string_len) {
+            self.whole_string_calls += 1;
+        } else {
+            self.longest_word_len = @max(self.longest_word_len, content_len);
+        }
+
+        return .{
+            .width = @as(f32, @floatFromInt(content_len)) * 10.0,
+            .height = @floatFromInt(font_size),
+        };
+    }
+};
+
+/// Shape cache insert limit from `text.ShapedRunCache.MAX_GLYPHS_PER_ENTRY`,
+/// duplicated as a plain constant so the layout tests stay free of any
+/// dependency on the platform text backend.
+const SHAPE_CACHE_INSERT_LIMIT: u32 = 128;
+
+test "wrapped text re-measures the whole string on every frame" {
+    // Goal: pin the measurement pattern of `LayoutEngine.text()`.  It measures
+    // the entire string unconditionally, but for wrap-enabled text
+    // `computeTextWrapping` recomputes width and height from per-word
+    // measurements later in the same frame and overwrites both.
+    //
+    // That whole-string call is the only one long enough to exceed the shape
+    // cache's 128-glyph insert limit.  It used to re-shape through the platform
+    // shaper every frame because `ShapedRunCache.put` refuses over-limit runs;
+    // `TextSystem.MeasureCache` now absorbs it by caching width without glyphs,
+    // so the call remains but is a hash lookup rather than a full shape.
+    // The count below is therefore still expected to equal the frame count --
+    // the fix removed the cost, not the call.
+    //
+    // Methodology: lay out one long wrapped paragraph across several frames
+    // with a recording measure callback, then assert the whole-string call
+    // happens once per frame and that every other call is a short word.
+    const message = "The quick brown fox jumps over the lazy dog while the " ++
+        "cat watches from a sunny windowsill and the world turns slowly " ++
+        "onward through another long and uneventful afternoon";
+
+    // The message sits in the band that the shaped-run cache cannot store: past
+    // its insert limit but under the lookup gate.  This is exactly the range
+    // `MeasureCache` exists to cover.
+    try std.testing.expect(message.len > SHAPE_CACHE_INSERT_LIMIT);
+    try std.testing.expect(message.len < 512);
+
+    var recorder = MeasureRecorder{ .whole_string_len = @intCast(message.len) };
+
+    var engine = LayoutEngine.init(std.testing.allocator);
+    defer engine.deinit();
+
+    engine.setMeasureTextFn(MeasureRecorder.measure, &recorder);
+
+    const frame_count: u32 = 5;
+    var frame: u32 = 0;
+    while (frame < frame_count) : (frame += 1) {
+        engine.beginFrame(800, 600);
+        try engine.openElement(.{
+            .layout = .{
+                .sizing = Sizing.fixed(400, 600),
+                .layout_direction = .top_to_bottom,
+            },
+        });
+        {
+            try engine.text(message, .{ .wrap_mode = .words, .font_size = 14 });
+        }
+        engine.closeElement();
+        _ = try engine.endFrame();
+    }
+
+    // One whole-string measurement per frame, whose result is superseded by
+    // wrapping before the frame ends.  Deliberately NOT driven to 0: the value
+    // feeds Phase 1 min-sizing (`content_width = @max(content_width,
+    // td.measured_width)` in sizing_pass.zig), so skipping it would change the
+    // min content width of any fit-content ancestor -- a behaviour change, not
+    // an optimisation.  The cost is removed in the text layer instead.
+    try std.testing.expectEqual(frame_count, recorder.whole_string_calls);
+
+    // Wrapping itself was already cache-friendly: every other measurement is a
+    // single word, comfortably inside the shaped-run cache's insert limit.
+    try std.testing.expect(recorder.longest_word_len > 0);
+    try std.testing.expect(recorder.longest_word_len < SHAPE_CACHE_INSERT_LIMIT);
+}
+
+test "unwrapped text depends on the whole-string measurement" {
+    // Goal: guard the obvious over-correction.  With `wrap_mode == .none`,
+    // `computeTextWrapping` returns early and never overwrites the measurement,
+    // so `text()`'s whole-string call is the *only* source of the element's
+    // size.  Any fix that skips measuring must keep this path exact, which is
+    // why the redundancy cannot simply be deleted for all text.
+    //
+    // Methodology: lay out one unwrapped string and assert the sized width
+    // still matches what the measure callback reported.
+    const message = "Sized entirely by the whole-string measurement";
+
+    var recorder = MeasureRecorder{ .whole_string_len = @intCast(message.len) };
+
+    var engine = LayoutEngine.init(std.testing.allocator);
+    defer engine.deinit();
+
+    engine.setMeasureTextFn(MeasureRecorder.measure, &recorder);
+    engine.beginFrame(800, 600);
+
+    try engine.openElement(.{
+        .layout = .{
+            .sizing = Sizing.fixed(400, 600),
+            .layout_direction = .top_to_bottom,
+        },
+    });
+    {
+        try engine.text(message, .{ .wrap_mode = .none, .font_size = 14 });
+    }
+    engine.closeElement();
+
+    _ = try engine.endFrame();
+
+    try std.testing.expectEqual(@as(u32, 1), recorder.whole_string_calls);
+
+    // No wrapping ran, so the measured width survives to the computed size.
+    const text_elem = engine.elements.getConst(1);
+    const text_data = text_elem.text_data.?;
+    const expected_width = @as(f32, @floatFromInt(message.len)) * 10.0;
+    try std.testing.expectEqual(expected_width, text_data.measured_width);
+    try std.testing.expect(text_data.wrapped_lines == null);
+}

--- a/src/text/benchmarks.zig
+++ b/src/text/benchmarks.zig
@@ -2082,6 +2082,22 @@ fn printMeasurementBenchmarks(text_sys: *TextSystem, reporter: *bench.Reporter) 
     collect(reporter, benchMeasureText(text_sys, "measure_long_104ch_x100", TEXT_LONG, 100));
     collect(reporter, benchMeasureTextWrapped(text_sys, "measure_wrapped_50ch_200px_x100", TEXT_MEDIUM, 200.0, 100));
     collect(reporter, benchMeasureTextWrapped(text_sys, "measure_wrapped_104ch_300px_x100", TEXT_LONG, 300.0, 100));
+
+    // Regression guard for the shape-cache insert boundary.  `ShapedRunCache.put`
+    // refuses runs longer than MAX_GLYPHS_PER_ENTRY, while the `measureText`
+    // lookup gate admits anything up to MAX_TEXT_LEN.  Text in between used to
+    // shape through CoreText on *every* call and never warm up -- a permanent
+    // miss that cost ~35us per measurement versus ~160ns for a hit (~220x).
+    // `MeasureCache` closes that gap by caching width without glyphs.
+    //
+    // These two cases straddle the boundary with otherwise-identical ASCII text
+    // (1 byte = 1 glyph), so they should now report the *same* cost.  If the
+    // 129ch row ever diverges sharply from the 128ch row again, the width cache
+    // has stopped covering the over-limit band.
+    std.debug.assert(ShapedRunCache.MAX_GLYPHS_PER_ENTRY == 128);
+    std.debug.assert(ShapedRunCache.MAX_TEXT_LEN >= 129);
+    collect(reporter, benchMeasureText(text_sys, "measure_at_shape_limit_128ch_x100", SCALING_TEXT_BASE[0..128], 100));
+    collect(reporter, benchMeasureText(text_sys, "measure_over_shape_limit_129ch_x100", SCALING_TEXT_BASE[0..129], 100));
     std.debug.print("=" ** TABLE_WIDTH ++ "\n", .{});
 }
 

--- a/src/text/text_system.zig
+++ b/src/text/text_system.zig
@@ -13,7 +13,8 @@ const types = @import("types.zig");
 const font_face_mod = @import("font_face.zig");
 const cache_mod = @import("cache.zig");
 const platform = @import("../platform/mod.zig");
-const RenderStats = @import("../debug/render_stats.zig").RenderStats;
+const render_stats = @import("../debug/render_stats.zig");
+const RenderStats = render_stats.RenderStats;
 
 const Atlas = @import("atlas.zig").Atlas;
 
@@ -453,6 +454,195 @@ pub const ShapedRunCache = struct {
 };
 
 // =============================================================================
+// Measure Cache - Width-Only, Fixed Capacity, Zero Runtime Allocation
+// =============================================================================
+
+/// A single width-only measurement slot.
+const MeasureEntry = struct {
+    key: ShapedRunKey,
+    width: f32,
+    /// LRU tracking - higher = more recently used
+    last_access: u32,
+    /// Is this slot in use?
+    valid: bool,
+
+    const Self = @This();
+
+    fn clear(self: *Self) void {
+        self.valid = false;
+        self.last_access = 0;
+        self.width = 0;
+    }
+};
+
+/// Cache of text *widths*, independent of the shaped-run cache.
+///
+/// Why this exists as a separate cache: `ShapedRunCache` refuses any run longer
+/// than `MAX_GLYPHS_PER_ENTRY` (128), because every entry embeds its glyph array
+/// inline -- 128 glyphs x 44 bytes is ~5.6KB per entry, and 256 of those already
+/// sit just under the 2MB comptime budget asserted above.  Raising that limit to
+/// cover `MAX_TEXT_LEN` (512) would multiply the cache by 4x and blow it.
+///
+/// But `measureText` never looks at the glyphs -- it reads the scalar `width` and
+/// throws the rest away.  Storing only the width costs ~56 bytes per entry
+/// instead of ~5.6KB, which is ~100x cheaper and comfortably covers the whole
+/// `MAX_TEXT_LEN` range.  Without this, every string between 129 and 512 bytes is
+/// a *permanent* miss: it passes the lookup gate, shapes through CoreText, then
+/// gets refused on insert, so the next frame repeats the entire cycle.
+///
+/// Layout is set-associative rather than the index-plus-hash-table scheme used by
+/// `ShapedRunCache`.  Entries are small enough to live directly in the probe
+/// window, so a bounded linear probe with LRU eviction inside that window needs no
+/// separate hash table, no tombstones, and no rehash-on-removal.
+pub const MeasureCache = struct {
+    /// Pre-allocated slots, indexed directly by hash
+    slots: [SLOT_COUNT]MeasureEntry,
+    /// Global access counter for LRU
+    access_counter: u32,
+    /// Track font pointer to invalidate on font change
+    current_font_ptr: usize,
+
+    const Self = @This();
+
+    // Capacity limits. 1024 x ~56 bytes is ~57KB -- two orders of magnitude below
+    // the shaped-run cache, so this is affordable at a much higher entry count.
+    pub const SLOT_COUNT: usize = 1024;
+    /// Associativity: how far a key may probe from its natural slot before the
+    /// least-recently-used slot in that window is evicted. Bounds worst-case
+    /// lookup to a fixed number of comparisons.
+    pub const MAX_PROBE_LENGTH: usize = 8;
+
+    comptime {
+        // Power of two keeps the modulo a mask.
+        std.debug.assert(std.math.isPowerOfTwo(SLOT_COUNT));
+        std.debug.assert(MAX_PROBE_LENGTH < SLOT_COUNT);
+        // Stay far below the shaped-run cache budget; this is the whole point.
+        std.debug.assert(@sizeOf(MeasureEntry) * SLOT_COUNT < 128 * 1024);
+    }
+
+    /// Initialize in-place using the out-pointer pattern, matching
+    /// `ShapedRunCache`. Marked noinline to keep the ~57KB off the WASM stack.
+    pub noinline fn initInPlace(self: *Self) void {
+        self.access_counter = 0;
+        self.current_font_ptr = 0;
+
+        for (&self.slots) |*slot| {
+            slot.clear();
+        }
+
+        std.debug.assert(self.access_counter == 0);
+        std.debug.assert(self.current_font_ptr == 0);
+    }
+
+    pub fn init() Self {
+        var self: Self = undefined;
+        self.initInPlace();
+        return self;
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.access_counter = 0;
+        self.current_font_ptr = 0;
+        self.* = undefined;
+    }
+
+    /// Check if the font changed and invalidate the whole cache if so.
+    /// Widths are only meaningful for the font that produced them.
+    pub fn checkFont(self: *Self, font_ptr: usize) void {
+        std.debug.assert(font_ptr != 0);
+
+        if (self.current_font_ptr != font_ptr) {
+            self.clearAll();
+            self.current_font_ptr = font_ptr;
+        }
+
+        std.debug.assert(self.current_font_ptr == font_ptr);
+    }
+
+    /// Look up a cached width. Returns null on miss. Updates LRU on hit.
+    pub fn get(self: *Self, key: ShapedRunKey) ?f32 {
+        std.debug.assert(key.text_len > 0);
+        std.debug.assert(key.text_len <= ShapedRunCache.MAX_TEXT_LEN);
+
+        const start_slot = @as(usize, @truncate(key.text_hash)) % SLOT_COUNT;
+
+        for (0..MAX_PROBE_LENGTH) |offset| {
+            const slot = &self.slots[(start_slot + offset) % SLOT_COUNT];
+
+            if (slot.valid) {
+                if (ShapedRunKey.eql(slot.key, key)) {
+                    self.access_counter += 1;
+                    slot.last_access = self.access_counter;
+
+                    std.debug.assert(slot.width >= 0);
+                    return slot.width;
+                }
+            } else {
+                // An empty slot inside the probe window means the key was never
+                // inserted: `put` always fills the first empty slot it finds.
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    /// Store a width, evicting the least-recently-used slot in the probe window
+    /// if every slot there is already taken.
+    pub fn put(self: *Self, key: ShapedRunKey, width: f32) void {
+        std.debug.assert(key.text_len > 0);
+        std.debug.assert(key.text_len <= ShapedRunCache.MAX_TEXT_LEN);
+        std.debug.assert(width >= 0);
+
+        const start_slot = @as(usize, @truncate(key.text_hash)) % SLOT_COUNT;
+
+        var victim_index: usize = start_slot;
+        var oldest_access: u32 = std.math.maxInt(u32);
+
+        for (0..MAX_PROBE_LENGTH) |offset| {
+            const index = (start_slot + offset) % SLOT_COUNT;
+            const slot = &self.slots[index];
+
+            if (slot.valid) {
+                // Refresh in place when the key is already present.
+                if (ShapedRunKey.eql(slot.key, key)) {
+                    victim_index = index;
+                    break;
+                }
+                if (slot.last_access < oldest_access) {
+                    oldest_access = slot.last_access;
+                    victim_index = index;
+                }
+            } else {
+                victim_index = index;
+                break;
+            }
+        }
+
+        const victim = &self.slots[victim_index];
+        victim.key = key;
+        victim.width = width;
+        victim.valid = true;
+        self.access_counter += 1;
+        victim.last_access = self.access_counter;
+
+        std.debug.assert(victim.valid);
+        std.debug.assert(victim.width == width);
+    }
+
+    /// Clear all slots (e.g. on font change).
+    fn clearAll(self: *Self) void {
+        for (&self.slots) |*slot| {
+            slot.clear();
+        }
+        // Don't reset access_counter, to preserve LRU ordering after clear.
+
+        std.debug.assert(!self.slots[0].valid);
+        std.debug.assert(!self.slots[SLOT_COUNT - 1].valid);
+    }
+};
+
+// =============================================================================
 // Platform Selection (compile-time)
 // =============================================================================
 
@@ -507,6 +697,9 @@ pub const TextSystem = struct {
     scale_factor: f32,
     /// Cache for shaped text runs (fixed capacity, pre-allocated)
     shape_cache: ShapedRunCache,
+    /// Cache for text widths (fixed capacity, pre-allocated). Covers the full
+    /// MAX_TEXT_LEN range that `shape_cache` cannot -- see `MeasureCache`.
+    measure_cache: MeasureCache,
     /// IO instance for mutex operations. Stored on the struct because lock
     /// sites run on CVDisplayLink threads that have no access to `*Cx` and
     /// therefore cannot reach `cx.io()`. Io is a pair of pointers into the
@@ -540,6 +733,7 @@ pub const TextSystem = struct {
             .shaper = null,
             .scale_factor = scale,
             .shape_cache = ShapedRunCache.init(),
+            .measure_cache = MeasureCache.init(),
             .io = io,
             .shape_cache_mutex = .init,
             .glyph_cache_mutex = .init,
@@ -563,6 +757,7 @@ pub const TextSystem = struct {
         // Initialize caches in-place to avoid large stack temporaries
         try self.cache.initInPlace(allocator, scale);
         self.shape_cache.initInPlace();
+        self.measure_cache.initInPlace();
         self.shape_cache_mutex = .init;
         self.glyph_cache_mutex = .init;
     }
@@ -580,6 +775,7 @@ pub const TextSystem = struct {
         if (self.shaper) |*s| s.deinit();
         self.cache.deinit();
         self.shape_cache.deinit();
+        self.measure_cache.deinit();
         self.* = undefined;
     }
 
@@ -591,8 +787,11 @@ pub const TextSystem = struct {
         if (self.current_face) |*f| f.deinit();
         self.current_face = try PlatformFace.init(name, size);
         self.cache.clear();
-        // Force shape cache invalidation by setting invalid font ptr
+        // Force cache invalidation by setting invalid font ptr. Needed because
+        // the keyed font_ptr is the address of `current_face`, which is stable
+        // across font loads and so cannot itself signal the change.
         self.shape_cache.current_font_ptr = 0;
+        self.measure_cache.current_font_ptr = 0;
     }
 
     /// Load a system font
@@ -602,8 +801,9 @@ pub const TextSystem = struct {
         if (self.current_face) |*f| f.deinit();
         self.current_face = try PlatformFace.initSystem(style, size);
         self.cache.clear();
-        // Force shape cache invalidation
+        // Force cache invalidation (see `loadFont`).
         self.shape_cache.current_font_ptr = 0;
+        self.measure_cache.current_font_ptr = 0;
     }
 
     /// Get current font metrics
@@ -790,28 +990,62 @@ pub const TextSystem = struct {
             const face = self.current_face orelse return error.NoFontLoaded;
             std.debug.assert(face.metrics.point_size > 0);
 
-            // Fast path: look up width directly from shape cache (no allocation).
-            // The cache entry is valid while the mutex is held, and we only read
-            // the scalar `width` field — no slice escapes the lock scope.
-            if (text.len <= ShapedRunCache.MAX_TEXT_LEN) {
-                const font_ptr = @intFromPtr(&self.current_face);
-                const cache_key = ShapedRunKey.init(text, font_ptr, face.metrics.point_size);
+            // Text past MAX_TEXT_LEN cannot even be keyed -- `hashText` asserts
+            // that bound -- so it shapes uncached on every call.  Accepted: it is
+            // far rarer than the 129..512 band this function used to mishandle.
+            if (text.len > ShapedRunCache.MAX_TEXT_LEN) {
+                var shaped_long = try self.shapeText(text, &render_stats.frame_stats);
+                defer shaped_long.deinit(self.allocator);
+                return shaped_long.width;
+            }
 
+            const font_ptr = @intFromPtr(&self.current_face);
+            const cache_key = ShapedRunKey.init(text, font_ptr, face.metrics.point_size);
+
+            // Fast path: both caches are read under the same mutex, and only the
+            // scalar `width` is copied out — no slice escapes the lock scope.
+            {
                 self.shape_cache_mutex.lockUncancelable(self.io);
                 defer self.shape_cache_mutex.unlock(self.io);
 
+                self.measure_cache.checkFont(font_ptr);
                 self.shape_cache.checkFont(font_ptr);
 
+                if (self.measure_cache.get(cache_key)) |cached_width| {
+                    std.debug.assert(cached_width >= 0);
+                    render_stats.frame_stats.recordShapeCacheHit();
+                    return cached_width;
+                }
+
+                // The shaped-run cache may already hold this text from a render
+                // pass. Promote the width so later measurements skip it entirely.
                 if (self.shape_cache.get(cache_key)) |cached_run| {
                     std.debug.assert(cached_run.width >= 0);
+                    self.measure_cache.put(cache_key, cached_run.width);
+                    render_stats.frame_stats.recordShapeCacheHit();
                     return cached_run.width;
                 }
             }
 
-            // Cache miss: full shape via CoreText/HarfBuzz, read width, free.
-            // The shapeText call also populates the cache for next time.
-            var shaped = try self.shapeText(text, null);
+            // Miss: shape once via CoreText/HarfBuzz, then record the width so
+            // this text never shapes again.  `shapeText` populates the shaped-run
+            // cache only when the run fits MAX_GLYPHS_PER_ENTRY; the width cache
+            // has no such limit, which is what makes the miss non-recurring.
+            //
+            // Stats are reported so the cost is visible in the profiler rather
+            // than silent. Measurement runs on the main thread during frame
+            // building -- the same thread that resets `frame_stats` in
+            // `beginFrame` -- so the unsynchronised increment is safe here.
+            var shaped = try self.shapeText(text, &render_stats.frame_stats);
             defer shaped.deinit(self.allocator);
+            std.debug.assert(shaped.width >= 0);
+
+            {
+                self.shape_cache_mutex.lockUncancelable(self.io);
+                defer self.shape_cache_mutex.unlock(self.io);
+                self.measure_cache.put(cache_key, shaped.width);
+            }
+
             return shaped.width;
         }
     }
@@ -1275,4 +1509,283 @@ test "shapeTextInto warm path copies into caller buffer with owned=false" {
     cache.checkFont(0x2000);
     try testing.expectEqual(@as(u16, 42), result.glyphs[0].glyph_id);
     try testing.expectEqual(@as(f32, 24.5), result.width);
+}
+
+/// Fill `glyphs` and `text_buf` with a uniform run so cache tests can hit an
+/// exact glyph count without needing a loaded font.
+fn fillTestRun(glyphs: []ShapedGlyph, text_buf: []u8) ShapedRun {
+    std.debug.assert(glyphs.len == text_buf.len);
+    std.debug.assert(glyphs.len > 0);
+
+    for (glyphs, 0..) |*glyph, index| {
+        glyph.* = .{
+            .glyph_id = @intCast(index),
+            .x_offset = 0,
+            .y_offset = 0,
+            .x_advance = 10,
+            .y_advance = 0,
+            .cluster = @intCast(index),
+        };
+    }
+    @memset(text_buf, 'a');
+
+    return .{
+        .glyphs = glyphs,
+        .width = @as(f32, @floatFromInt(glyphs.len)) * 10,
+        .owned = false,
+    };
+}
+
+test "shape cache insert limit is MAX_GLYPHS_PER_ENTRY, not MAX_TEXT_LEN" {
+    // Goal: pin the two different limits that govern the shape cache, because
+    // they disagree.  `MAX_TEXT_LEN` (512) gates the *lookup* in
+    // `TextSystem.measureText`, but `put` refuses any run over
+    // `MAX_GLYPHS_PER_ENTRY` (128).  Text between the two never gets stored, so
+    // it probes, misses, shapes, and is refused again — every frame, forever.
+    // The miss is permanent rather than merely cold.
+    //
+    // This asymmetry is intentional and still holds: an entry embeds its glyph
+    // array inline, so raising the insert limit to MAX_TEXT_LEN would blow the
+    // 2MB comptime budget.  `MeasureCache` is what compensates -- it stores width
+    // without glyphs, so `measureText` no longer pays for this refusal.  The test
+    // pins the refusal itself so that compensation stays necessary and visible.
+    //
+    // Methodology: drive the cache at exactly the limit and one past it, using
+    // text short enough that the lookup gate would happily admit both.
+    const testing = std.testing;
+
+    var cache = ShapedRunCache.init();
+    defer cache.deinit();
+
+    const at_limit = ShapedRunCache.MAX_GLYPHS_PER_ENTRY;
+    const over_limit = ShapedRunCache.MAX_GLYPHS_PER_ENTRY + 1;
+
+    // Both lengths sit under the lookup gate, so any difference in behaviour
+    // below comes from the insert limit alone.
+    try testing.expect(over_limit <= ShapedRunCache.MAX_TEXT_LEN);
+
+    // Control: a run exactly at the limit round-trips.
+    var glyphs_at: [at_limit]ShapedGlyph = undefined;
+    var text_at: [at_limit]u8 = undefined;
+    const run_at = fillTestRun(&glyphs_at, &text_at);
+    const key_at = ShapedRunKey.init(&text_at, 0x1000, 16.0);
+
+    cache.put(key_at, run_at);
+    try testing.expect(cache.get(key_at) != null);
+    try testing.expectEqual(@as(u32, 1), cache.entry_count);
+
+    // One glyph more, and the insert is silently dropped.
+    var glyphs_over: [over_limit]ShapedGlyph = undefined;
+    var text_over: [over_limit]u8 = undefined;
+    const run_over = fillTestRun(&glyphs_over, &text_over);
+    const key_over = ShapedRunKey.init(&text_over, 0x1000, 16.0);
+
+    cache.put(key_over, run_over);
+    try testing.expect(cache.get(key_over) == null);
+    try testing.expectEqual(@as(u32, 1), cache.entry_count); // unchanged
+
+    // Repeating the shape-then-store cycle never converges.  Each iteration
+    // stands in for one frame re-shaping the same unchanged string.
+    var frame: u32 = 0;
+    while (frame < 8) : (frame += 1) {
+        cache.put(key_over, run_over);
+        try testing.expect(cache.get(key_over) == null);
+    }
+    try testing.expectEqual(@as(u32, 1), cache.entry_count);
+}
+
+// =============================================================================
+// MeasureCache Tests
+// =============================================================================
+
+/// Fill `buf` with deterministic ASCII derived from `seed`, so each seed yields
+/// a distinct string. Keeps the cache tests free of any font or platform state.
+///
+/// The seed is written as little-endian base-26 with 'a' as the zero digit, which
+/// makes the mapping injective. A tempting `'a' + (seed + index) % 26` is not: it
+/// is periodic in 26, so seeds 26 apart produce byte-identical text and therefore
+/// identical cache keys, which silently turns a correctness test into a tautology.
+fn fillTestText(buf: []u8, seed: u32) void {
+    std.debug.assert(buf.len > 0);
+    std.debug.assert(buf.len <= ShapedRunCache.MAX_TEXT_LEN);
+
+    @memset(buf, 'a');
+
+    var remaining = seed;
+    var index: usize = 0;
+    while (index < buf.len) : (index += 1) {
+        buf[index] = 'a' + @as(u8, @intCast(remaining % 26));
+        remaining /= 26;
+        if (remaining == 0) break;
+    }
+
+    // The seed must fit, or distinct seeds could alias.
+    std.debug.assert(remaining == 0);
+}
+
+test "MeasureCache stores widths the shape cache refuses" {
+    // Goal: the entire purpose of MeasureCache is covering the band between
+    // MAX_GLYPHS_PER_ENTRY and MAX_TEXT_LEN, where `ShapedRunCache.put` bails
+    // out. Verify a round-trip at the first refused length and across the band.
+    const testing = std.testing;
+
+    var cache = MeasureCache.init();
+    defer cache.deinit();
+
+    const font_ptr: usize = 0x2000;
+    cache.checkFont(font_ptr);
+
+    const lengths = [_]usize{
+        ShapedRunCache.MAX_GLYPHS_PER_ENTRY + 1, // 129: first refused length
+        300,
+        ShapedRunCache.MAX_TEXT_LEN - 1, // 511
+        ShapedRunCache.MAX_TEXT_LEN, // 512: the lookup gate itself
+    };
+
+    var buf: [ShapedRunCache.MAX_TEXT_LEN]u8 = undefined;
+
+    for (lengths, 0..) |len, index| {
+        const text = buf[0..len];
+        fillTestText(text, @intCast(index));
+
+        // Precisely the lengths the shaped-run cache turns away.
+        try testing.expect(len > ShapedRunCache.MAX_GLYPHS_PER_ENTRY);
+        try testing.expect(len <= ShapedRunCache.MAX_TEXT_LEN);
+
+        const key = ShapedRunKey.init(text, font_ptr, 16.0);
+        const width: f32 = @floatFromInt(len);
+
+        try testing.expect(cache.get(key) == null); // Cold.
+        cache.put(key, width);
+        try testing.expectEqual(width, cache.get(key).?);
+    }
+}
+
+test "MeasureCache converges after a single miss for over-limit text" {
+    // Goal: this is the fix, stated as a test.  The shape-cache test above runs
+    // the same put-then-get cycle and never converges; here the second frame
+    // onward must hit.  Methodology: replay 8 frames of an unchanged string and
+    // count how many of them would have had to shape.
+    const testing = std.testing;
+
+    var cache = MeasureCache.init();
+    defer cache.deinit();
+
+    const font_ptr: usize = 0x3000;
+    cache.checkFont(font_ptr);
+
+    var buf: [ShapedRunCache.MAX_GLYPHS_PER_ENTRY + 1]u8 = undefined;
+    fillTestText(&buf, 7);
+
+    const key = ShapedRunKey.init(&buf, font_ptr, 16.0);
+    const width: f32 = 1234.5;
+
+    var shape_count: u32 = 0;
+    var frame: u32 = 0;
+    while (frame < 8) : (frame += 1) {
+        if (cache.get(key)) |cached_width| {
+            try testing.expectEqual(width, cached_width);
+        } else {
+            // Stands in for a full CoreText shape.
+            shape_count += 1;
+            cache.put(key, width);
+        }
+    }
+
+    try testing.expectEqual(@as(u32, 1), shape_count);
+}
+
+test "MeasureCache invalidates on font change" {
+    // Goal: widths are only meaningful for the font that produced them. A font
+    // swap that reuses the same key must not surface the previous font's width.
+    const testing = std.testing;
+
+    var cache = MeasureCache.init();
+    defer cache.deinit();
+
+    var buf: [200]u8 = undefined;
+    fillTestText(&buf, 1);
+
+    const first_font: usize = 0x1111;
+    cache.checkFont(first_font);
+
+    const key = ShapedRunKey.init(&buf, first_font, 16.0);
+    cache.put(key, 500.0);
+    try testing.expectEqual(@as(f32, 500.0), cache.get(key).?);
+
+    // Swapping fonts drops everything.
+    const second_font: usize = 0x2222;
+    cache.checkFont(second_font);
+    try testing.expect(cache.get(key) == null);
+}
+
+test "MeasureCache keys distinguish font size" {
+    // Goal: the same string at two sizes has two different widths. Guard against
+    // a key that hashes text but forgets the size.
+    const testing = std.testing;
+
+    var cache = MeasureCache.init();
+    defer cache.deinit();
+
+    const font_ptr: usize = 0x5555;
+    cache.checkFont(font_ptr);
+
+    var buf: [200]u8 = undefined;
+    fillTestText(&buf, 3);
+
+    const key_16 = ShapedRunKey.init(&buf, font_ptr, 16.0);
+    const key_24 = ShapedRunKey.init(&buf, font_ptr, 24.0);
+
+    cache.put(key_16, 160.0);
+    cache.put(key_24, 240.0);
+
+    try testing.expectEqual(@as(f32, 160.0), cache.get(key_16).?);
+    try testing.expectEqual(@as(f32, 240.0), cache.get(key_24).?);
+}
+
+test "MeasureCache never returns a stale width under eviction pressure" {
+    // Goal: eviction is the riskiest part of a set-associative cache -- a slot
+    // whose key and payload fall out of sync silently returns a wrong width,
+    // which would corrupt layout rather than merely slow it down.  Methodology:
+    // overflow the cache several times over, then verify that every key which
+    // still hits carries exactly the width it was stored with.
+    const testing = std.testing;
+
+    var cache = MeasureCache.init();
+    defer cache.deinit();
+
+    const font_ptr: usize = 0x4000;
+    cache.checkFont(font_ptr);
+
+    const insert_count: u32 = @intCast(MeasureCache.SLOT_COUNT * 4);
+    var buf: [200]u8 = undefined;
+
+    var seed: u32 = 0;
+    while (seed < insert_count) : (seed += 1) {
+        fillTestText(&buf, seed);
+        const key = ShapedRunKey.init(&buf, font_ptr, 16.0);
+        cache.put(key, @floatFromInt(seed));
+    }
+
+    var hits: u32 = 0;
+    seed = 0;
+    while (seed < insert_count) : (seed += 1) {
+        fillTestText(&buf, seed);
+        const key = ShapedRunKey.init(&buf, font_ptr, 16.0);
+
+        if (cache.get(key)) |cached_width| {
+            try testing.expectEqual(@as(f32, @floatFromInt(seed)), cached_width);
+            hits += 1;
+        }
+    }
+
+    // Some entries must survive, and the cache cannot hold more than it has
+    // slots -- the latter guards against the probe window silently growing.
+    try testing.expect(hits > 0);
+    try testing.expect(hits <= MeasureCache.SLOT_COUNT);
+
+    // The most recent insert is always resident.
+    fillTestText(&buf, insert_count - 1);
+    const newest = ShapedRunKey.init(&buf, font_ptr, 16.0);
+    try testing.expectEqual(@as(f32, @floatFromInt(insert_count - 1)), cache.get(newest).?);
 }


### PR DESCRIPTION
## The bug

The shape cache has two thresholds that don't line up:

| Constant | Value | Governs |
|---|---|---|
| `MAX_TEXT_LEN` | 512 | the **lookup** in `measureText` |
| `MAX_GLYPHS_PER_ENTRY` | 128 | the **insert** in `put()` |

```zig
// ShapedRunCache.put
if (run.glyphs.len > MAX_GLYPHS_PER_ENTRY) {
    return;   // silently refused
}
```

Text between 129 and 512 bytes passed the lookup gate, probed the hash table, missed, shaped through CoreText, and was then refused on insert. Nothing was ever stored, so the next frame repeated the entire cycle.

**This was a permanent miss, not a cold one** -- it never warmed up. Every message longer than ~128 characters cost a full `CFAttributedString` + `CTLine` construction on every single frame.

## Why not just raise the limit

`CacheEntry` embeds its glyph array inline (~5.6KB each), and 256 of them already sit just under the 2MB `comptime` budget. Covering `MAX_TEXT_LEN` that way would multiply the cache by 4x and blow the assert.

But `measureText` only ever reads the scalar `width` and throws the glyphs away -- it doesn't need that storage at all.

## The fix

`MeasureCache`: width-only, ~56 bytes per entry, 1024 slots (~57KB), covering the full `MAX_TEXT_LEN` range.

It's set-associative -- a bounded probe window with LRU eviction inside it -- rather than copying the index-plus-hash-table scheme from `ShapedRunCache`. Entries are small enough to live in the probe window directly, which removes the separate hash table, tombstones, and rehash-on-removal entirely.

`measureText` now checks the width cache, promotes any shaped-run hit into it, then shapes and records on true miss.

### What is deliberately *not* changed

`LayoutEngine.text()` still measures the whole string unconditionally, every frame. That's intentional. The value feeds Phase 1 min-sizing:

```zig
// sizing_pass.zig
content_width = @max(content_width, td.measured_width);
```

Skipping or estimating it would change the min content width of every fit-content ancestor -- a behaviour change, not an optimisation. **The call remains; the cost is removed in the text layer instead.**

`wrapText` was already cache-friendly (`findWordBoundaries` measures per word, and words sit far below the 128-glyph limit), so it needed no change.

## Results

`zig build bench-text`, identical ASCII either side of the boundary:

| case | before | after |
|---|---|---|
| `measure_at_shape_limit_128ch` | 160.8 ns/op | 165.1 ns/op |
| `measure_over_shape_limit_129ch` | **35,361.9 ns/op** | **167.1 ns/op** |

**212x reduction**, and the one-character cliff is gone.

## Observability

`measureText` previously passed `null` for stats, so this path never reached `RenderStats.shape_misses` -- **the profiler panel was under-reporting this cost entirely.** Stats are now threaded through, so the shape count is visible in `debugger.zig` and assertable in tests.

## Tests

- `MeasureCache` round-trips at exactly the lengths the shape cache refuses (129, 300, 511, 512).
- Convergence: 8 frames of unchanged over-limit text => **exactly 1 shape**. This is the fix stated as a test; the sibling shape-cache test runs the same loop and never converges.
- Font-change invalidation, font-size key differentiation.
- Eviction safety: overflow the cache 4x over, then assert every key that still hits carries exactly the width it was stored with -- a key/payload desync would corrupt layout, not merely slow it.

The existing `ShapedRunCache` characterization test is unchanged and still passes; its comment now explains that the 128/512 asymmetry is intentional and that `MeasureCache` is what compensates.

> One note: the eviction test initially failed, and the bug was in the *test*. The helper used `'a' + (seed + index) % 26`, which is periodic in 26 -- seeds 0 and 4082 produced byte-identical text and therefore identical keys. The cache was correct. Replaced with an injective base-26 encoding and documented, since it's an easy trap to reintroduce.

## Validation

- `zig build test` -- all pass. The two `failed command` lines are pre-existing (charts/select); stash-verified identical against baseline.
- `zig build bench-text` -- numbers above.

## Known remaining gap

`measureTextEx` still consults only `shape_cache`, so text over 128 glyphs remains a permanent miss there. Left out of scope deliberately: wrapping needs per-glyph advances, so a width-only cache can't serve it -- it needs a different fix.

## Caveat on the original report

This was chased as the cause of a frame-budget overrun (34 -> 74 -> 125 ms). What's *proven* here is 35.2 us per long text element per frame, and a 212x reduction. Whether that was the dominant cost is arithmetic on element count: ~100 long messages is 3.5 ms/frame, ~1000 is 35 ms, ~3500 is 125 ms. Consistent with the reported scaling, but not confirmed as dominant. The stats threading in this PR makes it directly readable off the profiler rather than inferred.
